### PR TITLE
fix(repo): update task pipelines

### DIFF
--- a/libs/libs5/project.json
+++ b/libs/libs5/project.json
@@ -6,10 +6,6 @@
   "tags": [],
   "targets": {
     "build": {
-      "command": "echo",
-      "dependsOn": ["base-build"]
-    },
-    "base-build": {
       "executor": "@nx/js:tsc",
       "options": {
         "outputPath": "dist/libs/libs5",

--- a/libs/portal-sdk/project.json
+++ b/libs/portal-sdk/project.json
@@ -6,10 +6,6 @@
   "tags": [],
   "targets": {
     "build": {
-      "command": "tsc-alias -p libs/portal-sdk/tsconfig.lib.json",
-      "dependsOn": ["base-build"]
-    },
-    "base-build": {
       "executor": "@nx/js:tsc",
       "options": {
         "outputPath": "dist/libs/portal-sdk",
@@ -19,10 +15,10 @@
           "libs/portal-sdk/*.md"
         ]
       },
-      "dependsOn": ["orval"]
+      "dependsOn": ["^build", "orval"]
     },
     "orval": {
-      "command": "orval; orval",
+      "command": "orval",
       "options": {
         "cwd": "libs/portal-sdk"
       }

--- a/libs/s5-js/project.json
+++ b/libs/s5-js/project.json
@@ -4,13 +4,8 @@
   "sourceRoot": "libs/s5-js/src",
   "projectType": "library",
   "tags": [],
-
   "targets": {
     "build": {
-      "command": "echo Building",
-      "dependsOn": ["base-build"]
-    },
-    "base-build": {
       "executor": "@nx/js:tsc",
       "options": {
         "outputPath": "dist/libs/s5-js",
@@ -20,10 +15,10 @@
           "libs/libs5/*.md"
         ]
       },
-      "dependsOn": ["orval"]
+      "dependsOn": ["^build", "orval"]
     },
     "orval": {
-      "command": "orval; orval",
+      "command": "orval",
       "options": {
         "cwd": "libs/s5-js"
       }

--- a/nx.json
+++ b/nx.json
@@ -44,10 +44,8 @@
   "targetDefaults": {
     "build": {
       "inputs": ["production", "^production"],
-      "outputs": ["{workspaceRoot}/dist/{projectRoot}"]
-    },
-    "base-build": {
-      "outputs": ["{workspaceRoot}/dist/{projectRoot}"]
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "dependsOn": ["^build"]
     },
     "@nx/remix:build": {
       "cache": true,


### PR DESCRIPTION
Adjusts some config to make building in parallel work as expected.

Key changes:

* `project.json` level `dependsOn` will overwrite the defaults defined in `nx.json`
* removed `tsc-alias` step from library
* removed `build-base` target from all libraries

The new task graph can be viewed with `nx run-many -t build --graph`, or invoked with `nx run-many -t build`.

Remix app doesn't build properly due to some Node built-ins that don't seem to be getting properly polyfilled, but everything in the `libs` folder builds in order correctly.