### PR TITLE
fix(libs5): use default export for EventEmitter

### DIFF
--- a/.changeset/grumpy-lemons-beam.md
+++ b/.changeset/grumpy-lemons-beam.md
@@ -1,0 +1,5 @@
+---
+"@lumeweb/libs5": patch
+---
+
+Use default export for EventEmitter

--- a/libs/libs5/src/service/registry.ts
+++ b/libs/libs5/src/service/registry.ts
@@ -12,7 +12,7 @@ import { decodeEndian, encodeEndian } from "../util.js";
 import { ed25519 } from "@noble/curves/ed25519";
 import Packer from "../serialization/pack.js";
 import { Buffer } from "buffer";
-import { EventEmitter } from "events";
+import EventEmitter from "events";
 import KeyPairEd25519 from "../ed25519.js";
 import { S5Node, stringifyBytes } from "../node.js";
 


### PR DESCRIPTION
- Need to use the default export for EventEmitter when importing