### PR TITLE
feat(account): implement account deletion functionality

### DIFF
--- a/apps/portal-dashboard/app/dataProviders/accountProvider.ts
+++ b/apps/portal-dashboard/app/dataProviders/accountProvider.ts
@@ -4,6 +4,7 @@ import type {
   CustomParams,
   CustomResponse,
   DataProvider,
+  DeleteOneParams,
   HttpError,
   UpdateParams,
   UpdateResponse,
@@ -72,9 +73,9 @@ export const createAccountProvider = (
 ): DataProvider => {
   return {
     ...restProvider,
-    update: async <TVariables extends AccountParams = AccountParams>(
+    async update<TVariables extends AccountParams = AccountParams>(
       params: UpdateParams<TVariables>,
-    ): Promise<UpdateResponse<AccountData>> => {
+    ): Promise<UpdateResponse<AccountData>> {
       if (params.resource === "default") {
         if (params.variables.email && params.variables.password) {
           const ret = await sdk
@@ -98,6 +99,24 @@ export const createAccountProvider = (
       }
 
       return restProvider.update(params);
+    },
+
+    async deleteOne(
+      params: DeleteOneParams<TVariables>,
+    ): Promise<DeleteOneResponse<any>> {
+      if (params.resource === "account") {
+        const ret = await sdk?.account().requestAccountDeletion();
+
+        if (ret instanceof Error) {
+          return Promise.reject(ret as HttpError);
+        }
+
+        return {
+          data: {},
+        };
+      }
+
+      return restProvider.deleteOne(params);
     },
     getApiUrl: () => sdk.account().apiUrl,
 

--- a/apps/portal-dashboard/app/dataProviders/authProvider.ts
+++ b/apps/portal-dashboard/app/dataProviders/authProvider.ts
@@ -140,6 +140,12 @@ export const createPortalAuthProvider = (sdk: Sdk): AuthProvider => {
           const response = await sdk.account().login(params);
           const loginResponse = response as unknown as LoginResponse;
 
+          if (response instanceof AccountError) {
+            return handleResponse({
+              ret: loginResponse as unknown as Error,
+            });
+          }
+
           if (loginResponse.otp) {
             return handleResponse({
               ret: true,

--- a/apps/portal-dashboard/app/root.tsx
+++ b/apps/portal-dashboard/app/root.tsx
@@ -106,6 +106,9 @@ export function Root() {
         },
       },
     },
+    {
+      name: "account",
+    },
   ];
 
   return (

--- a/apps/portal-dashboard/app/routes/account/account.tsx
+++ b/apps/portal-dashboard/app/routes/account/account.tsx
@@ -27,6 +27,7 @@ import ChangeEmailForm from "./components/ChangeEmailForm";
 import ChangePasswordForm from "./components/ChangePasswordForm";
 import SetupTwoFactorDialog from "./components/SetupTwoFactorDialog";
 import DisableTwoFactorDialog from "./components/DisableTwoFactorDialog";
+import DeleteAccountDialog from "@/routes/account/components/DeleteAccountDialog.js";
 
 interface ModalState {
   changeEmail: boolean;
@@ -34,6 +35,7 @@ interface ModalState {
   setupTwoFactor: boolean;
   disableTwoFactor: boolean;
   changeAvatar: boolean;
+  deleteAccount: boolean;
 }
 
 export default function MyAccount() {
@@ -45,6 +47,7 @@ export default function MyAccount() {
     setupTwoFactor: false,
     disableTwoFactor: false,
     changeAvatar: false,
+    deleteAccount: false,
   });
 
   const closeModal = () => {
@@ -54,6 +57,7 @@ export default function MyAccount() {
       setupTwoFactor: false,
       disableTwoFactor: false,
       changeAvatar: false,
+      deleteAccount: false,
     });
   };
   const isModalOpen = Object.values(openModal).some((isOpen) => isOpen);
@@ -222,7 +226,10 @@ export default function MyAccount() {
               Once initiated, this action cannot be undone.
             </ManagementCardContent>
             <ManagementCardFooter>
-              <Button className="h-12 gap-x-2" variant="destructive">
+              <Button
+                className="h-12 gap-x-2"
+                variant="destructive"
+                onClick={() => setModal({ ...openModal, deleteAccount: true })}>
                 <AddIcon />
                 Delete my Account
               </Button>
@@ -245,6 +252,9 @@ export default function MyAccount() {
           )}
           {openModal.disableTwoFactor && (
             <DisableTwoFactorDialog close={closeModal} />
+          )}
+          {openModal.deleteAccount && (
+            <DeleteAccountDialog close={closeModal} />
           )}
         </DialogContent>
       </Dialog>

--- a/apps/portal-dashboard/app/routes/account/components/DeleteAccountDialog.tsx
+++ b/apps/portal-dashboard/app/routes/account/components/DeleteAccountDialog.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import { useForm } from "@refinedev/react-hook-form";
+import { useDelete, useLogout, useNavigation } from "@refinedev/core";
+import {
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const stepOneSchema = z.object({
+  confirmText: z.literal("DELETE", {
+    errorMap: () => ({ message: "Please type DELETE to confirm" }),
+  }),
+});
+
+const stepTwoSchema = z.object({
+  confirmText: z.literal("I UNDERSTAND", {
+    errorMap: () => ({ message: "Please type I UNDERSTAND to confirm" }),
+  }),
+});
+
+type StepOneValues = z.infer<typeof stepOneSchema>;
+type StepTwoValues = z.infer<typeof stepTwoSchema>;
+
+type DeleteAccountDialogProps = {
+  close: () => void;
+};
+
+export default function DeleteAccountDialog({
+  close,
+}: DeleteAccountDialogProps) {
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const { mutate: logout } = useLogout();
+  const { push } = useNavigation();
+  const deleteMutator = useDelete();
+
+  const stepOneForm = useForm<StepOneValues>({
+    resolver: zodResolver(stepOneSchema),
+    defaultValues: {
+      confirmText: "",
+    },
+  });
+
+  const stepTwoForm = useForm<StepTwoValues>({
+    resolver: zodResolver(stepTwoSchema),
+    defaultValues: {
+      confirmText: "",
+    },
+  });
+
+  const onStepOneSubmit = (data: StepOneValues) => {
+    setStep(2);
+  };
+
+  const onStepTwoSubmit = (data: StepTwoValues) => {
+    deleteMutator.mutate(
+      {
+        resource: "account",
+        id: "",
+        successNotification: false, // Disable default success notification
+      },
+      {
+        onSuccess: () => {
+          setStep(3);
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    setStep(1);
+    stepOneForm.reset();
+    stepTwoForm.reset();
+    close();
+  };
+
+  const handleLogout = () => {
+    logout();
+    push("/");
+  };
+
+  const renderStepOne = () => (
+    <form onSubmit={stepOneForm.handleSubmit(onStepOneSubmit)}>
+      <Alert variant="destructive">
+        <AlertDescription>
+          Are you sure you want to delete your account? This action cannot be
+          undone.
+        </AlertDescription>
+      </Alert>
+      <p className="mt-4">Type "DELETE" to confirm:</p>
+      <Input {...stepOneForm.register("confirmText")} className="mt-2" />
+      {stepOneForm.formState.errors.confirmText && (
+        <p className="text-sm text-red-500 mt-1">
+          {stepOneForm.formState.errors.confirmText.message}
+        </p>
+      )}
+      <DialogFooter className="mt-6">
+        <Button type="button" variant="outline" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="destructive">
+          Proceed
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+
+  const renderStepTwo = () => (
+    <form onSubmit={stepTwoForm.handleSubmit(onStepTwoSubmit)}>
+      <Alert variant="destructive">
+        <AlertDescription>
+          This is your final chance to reconsider. Your account will be
+          permanently deleted.
+        </AlertDescription>
+      </Alert>
+      <Label htmlFor="finalConfirm" className="mt-4 block">
+        Type "I UNDERSTAND" to proceed with account deletion:
+      </Label>
+      <Input
+        id="finalConfirm"
+        {...stepTwoForm.register("confirmText")}
+        className="mt-2"
+      />
+      {stepTwoForm.formState.errors.confirmText && (
+        <p className="text-sm text-red-500 mt-1">
+          {stepTwoForm.formState.errors.confirmText.message}
+        </p>
+      )}
+      <DialogFooter className="mt-6">
+        <Button type="button" variant="outline" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="destructive">
+          Delete Account
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+
+  const renderSuccessScreen = () => (
+    <>
+      <Alert>
+        <AlertDescription>
+          Your account will be deleted within 48 hours. If this is an error,
+          please contact support as soon as possible.
+        </AlertDescription>
+      </Alert>
+      <DialogFooter className="mt-6">
+        <Button onClick={handleLogout}>OK</Button>
+      </DialogFooter>
+    </>
+  );
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {step === 1 && "Delete Account"}
+          {step === 2 && "Final Confirmation"}
+          {step === 3 && "Account Deletion Scheduled"}
+        </DialogTitle>
+      </DialogHeader>
+      {step === 1 && renderStepOne()}
+      {step === 2 && renderStepTwo()}
+      {step === 3 && renderSuccessScreen()}
+    </>
+  );
+}

--- a/libs/portal-sdk/src/account.ts
+++ b/libs/portal-sdk/src/account.ts
@@ -1,36 +1,34 @@
 import {
   AccountInfoResponse,
+  deleteApiAccountDelete,
   getApiAccount,
+  getApiAuthOtpGenerate,
+  getApiUploadLimit,
   LoginRequest,
   LoginResponse,
   OTPDisableRequest,
   OTPGenerateResponse,
   OTPValidateRequest,
   OTPVerifyRequest,
+  PasswordResetRequest,
   PasswordResetVerifyRequest,
   PingResponse,
+  postApiAccountPasswordResetConfirm,
   postApiAccountPasswordResetRequest,
+  postApiAccountUpdateEmail,
+  postApiAccountUpdatePassword,
+  postApiAccountVerifyEmail,
   postApiAccountVerifyEmailResend,
+  postApiAuthLogin,
+  postApiAuthLogout,
+  postApiAuthOtpDisable,
+  postApiAuthOtpValidate,
+  postApiAuthOtpVerify,
   postApiAuthPing,
+  postApiAuthRegister,
   RegisterRequest,
   UploadLimitResponse,
   VerifyEmailRequest,
-} from "./account/generated/index.js";
-
-import {
-  postApiAuthLogin,
-  postApiAuthRegister,
-  postApiAccountVerifyEmail,
-  getApiAuthOtpGenerate,
-  postApiAuthOtpVerify,
-  postApiAuthOtpValidate,
-  postApiAuthOtpDisable,
-  PasswordResetRequest,
-  postApiAccountPasswordResetConfirm,
-  postApiAuthLogout,
-  getApiUploadLimit,
-  postApiAccountUpdateEmail,
-  postApiAccountUpdatePassword,
 } from "./account/generated/index.js";
 import { AxiosError, AxiosResponse } from "axios";
 
@@ -327,6 +325,20 @@ export class AccountApi {
         { current_password: currentPassword, new_password: newPassword },
         this.buildOptions(),
       );
+    } catch (e) {
+      return new AccountError(
+        (e as AxiosError).response?.data as string,
+        (e as AxiosError).response?.status as number,
+      );
+    }
+
+    return this.checkSuccessBool(ret);
+  }
+
+  public async requestAccountDeletion(): Promise<boolean | AccountError> {
+    let ret: AxiosResponse<void>;
+    try {
+      ret = await deleteApiAccountDelete(this.buildOptions());
     } catch (e) {
       return new AccountError(
         (e as AxiosError).response?.data as string,

--- a/libs/portal-sdk/src/account/swagger.yaml
+++ b/libs/portal-sdk/src/account/swagger.yaml
@@ -60,6 +60,12 @@ paths:
       responses:
         "200":
           description: Email verification resent successfully
+  /api/account/delete:
+    delete:
+      summary: Request account deletion
+      responses:
+        "200":
+          description: Account deletion requested successfully
   /api/auth/otp/generate:
     get:
       summary: Generate OTP for two-factor authentication


### PR DESCRIPTION
- Add deleteOne method to accountProvider
- Create DeleteAccountDialog component with multi-step confirmation process
- Update Account page to include delete account button and dialog
- Add requestAccountDeletion method to AccountSDK
- Update swagger.yaml to include new account deletion endpoint