### PR TITLE
refactor(portal-dashboard): extract free plan logic into useOnFreePlan hook

### DIFF
--- a/apps/portal-dashboard/app/hooks/useOnFreePlan.ts
+++ b/apps/portal-dashboard/app/hooks/useOnFreePlan.ts
@@ -1,0 +1,17 @@
+import usePluginMeta from "@/hooks/usePluginMeta";
+import useIsPaidBillingEnabled from "@/hooks/useIsPaidBillingEnabled";
+import useSubscription from "@/hooks/useSubscription";
+
+export default function useOnFreePlan() {
+  const { subscriptionData } = useSubscription();
+
+  const freePlanName = usePluginMeta("billing", "free_plan_name");
+
+  const paidBillingEnabled = useIsPaidBillingEnabled();
+
+  return (
+    paidBillingEnabled &&
+    freePlanName &&
+    subscriptionData?.plan.name === freePlanName
+  );
+}

--- a/apps/portal-dashboard/app/routes/account/components/PricingPlans.tsx
+++ b/apps/portal-dashboard/app/routes/account/components/PricingPlans.tsx
@@ -26,6 +26,7 @@ import HyperPayment from "./HyperPayment";
 import { SubscriptionPlan } from "@/dataProviders/accountProvider";
 import useSubmitSubscriptionConnect from "../hooks/useSubmitSubscriptionConnect";
 import { useSubscriptionContext } from "@/routes/account/contexts/SubscriptionContext.js";
+import useOnFreePlan from "@/hooks/useOnFreePlan";
 
 export default function PricingPlans() {
   const {
@@ -59,6 +60,8 @@ export default function PricingPlans() {
     subscription?.billing_info?.zip &&
     subscription?.billing_info?.country;
 
+  const onFreePlan = useOnFreePlan();
+
   const formatStorage = (storage: number) => filesize(storage, 0).toUpperCase();
   const formatBandwidth = (bandwidth: number) =>
     filesize(bandwidth, 0).toUpperCase();
@@ -89,6 +92,10 @@ export default function PricingPlans() {
     currentPlan: SubscriptionPlan,
     newPlan: SubscriptionPlan,
   ) => {
+    if (onFreePlan) {
+      return "Subscribe";
+    }
+
     const currentIndex = plans.findIndex(
       (p: { identifier: string }) => p.identifier === currentPlan.identifier,
     );

--- a/apps/portal-dashboard/app/routes/account/subscription.tsx
+++ b/apps/portal-dashboard/app/routes/account/subscription.tsx
@@ -10,7 +10,7 @@ import {
   useSubscriptionContext,
 } from "./contexts/SubscriptionContext";
 import useIsPaidBillingEnabled from "@/hooks/useIsPaidBillingEnabled";
-import usePluginMeta from "@/hooks/usePluginMeta";
+import useOnFreePlan from "@/hooks/useOnFreePlan";
 
 export default function Subscription() {
   return (
@@ -21,16 +21,11 @@ export default function Subscription() {
 }
 
 function SubscriptionContent() {
-  const { isLoading, subscription } = useSubscriptionContext();
-
-  const freePlanName = usePluginMeta("billing", "free_plan_name");
+  const { isLoading } = useSubscriptionContext();
 
   const paidBillingEnabled = useIsPaidBillingEnabled();
 
-  const onFreePlan =
-    paidBillingEnabled &&
-    freePlanName &&
-    subscription?.plan.name === freePlanName;
+  const onFreePlan = useOnFreePlan();
 
   if (isLoading) return <SkeletonSubscription />;
 


### PR DESCRIPTION
- Create new hook `useOnFreePlan` to centralize free plan detection logic
- Update PricingPlans component to use `useOnFreePlan` for button text
- Refactor subscription.tsx to use `useOnFreePlan` instead of inline logic
- Adjust "Subscribe" button text logic in PricingPlans component