### PR TITLE
fix(portal-dashboard): adjust condition for payment skeleton display

### DIFF
--- a/apps/portal-dashboard/app/routes/account/components/HyperPayment.tsx
+++ b/apps/portal-dashboard/app/routes/account/components/HyperPayment.tsx
@@ -55,8 +55,8 @@ export default function HyperPayment({
 
   if (
     !hyperState.isHyperLoaded ||
-    (mode === "change_payment" &&
-      (isRequestingPaymentMethodChange || !clientSecret))
+    !clientSecret ||
+    (mode === "change_payment" && isRequestingPaymentMethodChange)
   ) {
     return <StyledPaymentSkeleton />;
   }


### PR DESCRIPTION
The condition for displaying the payment skeleton in HyperPayment.tsx has been modified. The clientSecret check is now performed independently of the mode, ensuring the skeleton is shown when clientSecret is not available regardless of the payment mode.