### PR TITLE
refactor(portal-plugin-abuse): add CaseEvidence resource and update API endpoints

### DIFF
--- a/libs/portal-plugin-abuse-common/src/index.ts
+++ b/libs/portal-plugin-abuse-common/src/index.ts
@@ -75,6 +75,7 @@ export enum RefineResource {
   Case = "cases",
   Communication = "communication",
   CaseCommunication = "case.communication",
+  CaseEvidence = "case.evidence",
   Evidence = "evidence",
   Reporter = "reporter",
   ReporterCase = "reporter-case",

--- a/libs/portal-plugin-abuse/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-abuse/src/capabilities/refineConfig.ts
@@ -50,6 +50,12 @@ export class Capability implements RefineConfigCapability {
             template: "/abuse/cases/:caseId/communications",
           },
         },
+        {
+          name: RefineResource.CaseEvidence,
+          meta: {
+            template: "/abuse/cases/:caseId/communications",
+          },
+        },
       ],
       ...existing,
     };

--- a/libs/portal-plugin-abuse/src/ui/components/case-management/evidence/EvidenceList.tsx
+++ b/libs/portal-plugin-abuse/src/ui/components/case-management/evidence/EvidenceList.tsx
@@ -42,7 +42,7 @@ export function EvidenceList({ caseId }: EvidenceListProps) {
     pagination: {
       pageSize: 10,
     },
-    resource: RefineResource.Evidence,
+    resource: RefineResource.CaseEvidence,
   });
 
   const handleViewDetails = (evidence: EvidenceResponse) => {
@@ -52,18 +52,18 @@ export function EvidenceList({ caseId }: EvidenceListProps) {
 
   const handleDownload = (evidenceId: number) => {
     // In a real app, this would download the file
-    window.open(`/api/evidence/${evidenceId}/content`, "_blank");
+    window.open(`/api/abuse/evidence/${evidenceId}/content`, "_blank");
   };
 
   const getSourceLabel = (source: EvidenceSource) => {
     switch (source) {
-      case EvidenceSource.API:
+      case EvidenceSource.api:
         return "API";
-      case EvidenceSource.Email:
+      case EvidenceSource.email:
         return "Email";
-      case EvidenceSource.System:
+      case EvidenceSource.system:
         return "System";
-      case EvidenceSource.WebUpload:
+      case EvidenceSource.web_upload:
         return "Web Upload";
       default:
         return source;
@@ -128,16 +128,16 @@ export function EvidenceList({ caseId }: EvidenceListProps) {
                 {evidenceFiles.map((evidence) => (
                   <TableRow key={evidence.id}>
                     <TableCell className="flex items-center gap-2">
-                      {getFileTypeIcon(evidence.contentType)}
+                      {getFileTypeIcon(evidence.content_type)}
                       <span className="truncate max-w-[200px]">
-                        {evidence.fileName}
+                        {evidence.file_name}
                       </span>
                     </TableCell>
-                    <TableCell>{evidence.contentType}</TableCell>
-                    <TableCell>{formatFileSize(evidence.fileSize)}</TableCell>
+                    <TableCell>{evidence.content_type}</TableCell>
+                    <TableCell>{formatFileSize(evidence.file_size)}</TableCell>
                     <TableCell>{getSourceLabel(evidence.source)}</TableCell>
                     <TableCell>
-                      {format(new Date(evidence.createdAt), "MMM d, yyyy")}
+                      {format(new Date(evidence.created_at), "MMM d, yyyy")}
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">

--- a/libs/portal-plugin-abuse/src/ui/components/case-management/scanning/SubjectScanPanel.tsx
+++ b/libs/portal-plugin-abuse/src/ui/components/case-management/scanning/SubjectScanPanel.tsx
@@ -151,7 +151,7 @@ export function SubjectScanPanel({ caseId, subjectId }: SubjectScanPanelProps) {
             Clean
           </Badge>
         );
-      case ScanStatus.error:
+      case ScanStatus.failed:
         return (
           <Badge
             className="bg-orange-100 text-orange-800 hover:bg-orange-100 dark:bg-orange-900/30 dark:text-orange-400"
@@ -169,7 +169,7 @@ export function SubjectScanPanel({ caseId, subjectId }: SubjectScanPanelProps) {
             Flagged
           </Badge>
         );
-      case ScanStatus.pending:
+      case ScanStatus.in_progress:
       default:
         return (
           <Badge
@@ -229,20 +229,20 @@ export function SubjectScanPanel({ caseId, subjectId }: SubjectScanPanelProps) {
               {getSubjectTypeIcon()}
               <h3 className="font-medium">Subject Details</h3>
             </div>
-            <Badge variant="outline">{subject.type.toUpperCase()}</Badge>
+            <Badge variant="outline">{subject.type?.toUpperCase()}</Badge>
           </div>
 
           <div className="mb-4">
             <p className="text-sm font-mono break-all">{subject.identifier}</p>
-            {subject.source_url && (
+            {subject?.source_url && (
               <p className="text-xs text-muted-foreground mt-1">
                 Source:{" "}
                 <a
                   className="hover:underline"
-                  href={subject.source_url}
+                  href={subject?.source_url}
                   rel="noopener noreferrer"
                   target="_blank">
-                  {subject.source_url}
+                  {subject?.source_url}
                 </a>
               </p>
             )}

--- a/libs/portal-plugin-abuse/src/ui/routes/case/view.tsx
+++ b/libs/portal-plugin-abuse/src/ui/routes/case/view.tsx
@@ -621,9 +621,9 @@ function CaseViewContent({ id }: { id: BaseKey }) {
               <UserInfoCard
                 isReporter={true}
                 title="Reporter"
-                user={record.reporter_id}
+                id={record.reporter_id}
               />
-              <UserInfoCard title="Subject" user={record.subject_id} />
+              <UserInfoCard title="Subject" id={record.subject_id} />
               {/* @ts-ignore */}
               <RiskFactorsCard riskFactors={record?.riskFactors} />
               <CaseActions


### PR DESCRIPTION
- Added CaseEvidence to RefineResource enum
- Updated evidence API endpoints to use `/api/abuse/` prefix
- Changed evidence source enum values to lowercase
- Updated evidence field names to match API (snake_case)
- Modified UserInfoCard to accept id prop instead of user