### PR TITLE
fix(portal-abuse-plugin): correct case priority and status enum casing

### DIFF
--- a/libs/portal-plugin-abuse/src/ui/components/case-management/PrioritySwitch.tsx
+++ b/libs/portal-plugin-abuse/src/ui/components/case-management/PrioritySwitch.tsx
@@ -24,25 +24,25 @@ export function PrioritySwitch({
       className: "text-green-700 dark:text-green-400",
       icon: <CircleCheck className="h-4 w-4 text-green-500" />,
       label: "Low",
-      value: CasePriority.Low,
+      value: CasePriority.low,
     },
     {
       className: "text-blue-700 dark:text-blue-400",
       icon: <AlertCircle className="h-4 w-4 text-blue-500" />,
       label: "Medium",
-      value: CasePriority.Medium,
+      value: CasePriority.medium,
     },
     {
       className: "text-orange-700 dark:text-orange-400",
       icon: <AlertTriangle className="h-4 w-4 text-orange-500" />,
       label: "High",
-      value: CasePriority.High,
+      value: CasePriority.high,
     },
     {
       className: "text-red-700 dark:text-red-400",
       icon: <CircleAlert className="h-4 w-4 text-red-500" />,
       label: "Critical",
-      value: CasePriority.Critical,
+      value: CasePriority.critical,
     },
   ];
 

--- a/libs/portal-plugin-abuse/src/ui/components/case-management/StatusSwitch.tsx
+++ b/libs/portal-plugin-abuse/src/ui/components/case-management/StatusSwitch.tsx
@@ -20,25 +20,25 @@ export function StatusSwitch({
       className: "text-blue-700 dark:text-blue-400",
       icon: <CircleDot className="h-4 w-4 text-blue-500" />,
       label: "New",
-      value: CaseStatus.New,
+      value: CaseStatus.new,
     },
     {
       className: "text-yellow-700 dark:text-yellow-400",
       icon: <Clock className="h-4 w-4 text-yellow-500" />,
       label: "In Progress",
-      value: CaseStatus.InProgress,
+      value: CaseStatus.in_progress,
     },
     {
       className: "text-green-700 dark:text-green-400",
       icon: <CheckCircle2 className="h-4 w-4 text-green-500" />,
       label: "Resolved",
-      value: CaseStatus.Resolved,
+      value: CaseStatus.resolved,
     },
     {
       className: "text-gray-700 dark:text-gray-400",
       icon: <XCircle className="h-4 w-4 text-gray-500" />,
       label: "Closed",
-      value: CaseStatus.Closed,
+      value: CaseStatus.closed,
     },
   ];
 


### PR DESCRIPTION
- Fixed enum values in PrioritySwitch to use correct lowercase:
  - CasePriority.Low → CasePriority.low
  - CasePriority.Medium → CasePriority.medium
  - CasePriority.High → CasePriority.high
  - CasePriority.Critical → CasePriority.critical

- Fixed enum values in StatusSwitch to use correct lowercase/snake_case:
  - CaseStatus.New → CaseStatus.new
  - CaseStatus.InProgress → CaseStatus.in_progress
  - CaseStatus.Resolved → CaseStatus.resolved
  - CaseStatus.Closed → CaseStatus.closed