### PR TITLE
fix(portal-plugin-abuse): use apiUrl for blocklist endpoints

### DIFF
--- a/libs/portal-plugin-abuse/src/ui/components/case-management/actions/BlockManagementCard.tsx
+++ b/libs/portal-plugin-abuse/src/ui/components/case-management/actions/BlockManagementCard.tsx
@@ -25,7 +25,7 @@ import {
   RadioGroupItem,
   Textarea,
 } from "@lumeweb/portal-framework-ui-core";
-import { useCustomMutation, useNotification } from "@refinedev/core";
+import { useCustomMutation, useNotification, useApiUrl } from "@refinedev/core";
 import { Shield, ShieldAlert, ShieldCheck, ShieldX } from "lucide-react";
 import React, { useState } from "react";
 import { SubjectResponse } from "@/types/subject";
@@ -65,6 +65,7 @@ export function BlockManagementCard({
 
   // Block subject mutation
   const { isLoading: isBlocking, mutate: blockSubject } = useCustomMutation();
+  const apiUrl = useApiUrl();
 
   // Unblock subject mutation
   const { isLoading: isUnblocking, mutate: unblockSubject } =
@@ -74,7 +75,7 @@ export function BlockManagementCard({
     blockSubject(
       {
         method: "post",
-        url: RefineResource.Blocklist,
+        url: `${apiUrl}/abuse/${RefineResource.Blocklist}`,
         values: {
           action: BlockAction.reject,
           caseId,
@@ -124,7 +125,7 @@ export function BlockManagementCard({
     unblockSubject(
       {
         method: "delete",
-        url: `/abuse/blocklist/${subjectData?.data?.identifier || `subject-${subjectId}`}`,
+        url: `${apiUrl}/abuse/${RefineResource.Blocklist}/${subjectData?.data?.identifier}`,
         values: {},
       },
       {


### PR DESCRIPTION
- Added useApiUrl hook to get base API URL
- Updated block and unblock endpoints to use full API path
- Fixed subject identifier usage in unblock endpoint