### PR TITLE
refactor(portal-framework-auth): simplify API URL handling and add localhost JWT storage

### DIFF
--- a/libs/portal-framework-auth/src/capabilities/sdk.ts
+++ b/libs/portal-framework-auth/src/capabilities/sdk.ts
@@ -26,8 +26,6 @@ export class Capability implements SdkCapability {
     try {
       const apiUrl = getApiBaseUrl({
         currentUrl: framework.portalUrl,
-        allowLocalhost: process.env.NODE_ENV === "development",
-        preserveSubdomain: env.VITE_PORTAL_DOMAIN_IS_ROOT,
       });
 
       if (apiUrl === false) {

--- a/libs/portal-framework-auth/src/dataProviders/auth.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.ts
@@ -10,6 +10,8 @@ import type {
   AuthProvider,
   CheckResponse,
 } from "@refinedev/core";
+import { getApiBaseUrl } from "@lumeweb/portal-framework-core";
+
 export interface AuthFormRequest extends LoginRequest {
   redirectTo?: string;
 }
@@ -177,6 +179,16 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
 
           if (response.data.token) {
             sdk.setAuthToken(response.data.token);
+            const baseUrl = getApiBaseUrl();
+            if (baseUrl) {
+              try {
+                if (new URL(baseUrl).hostname === "localhost") {
+                  localStorage.setItem("jwt", response.data.token);
+                }
+              } catch {
+                // Silently ignore URL parse errors
+              }
+            }
             return createAuthResponse({
               redirectTo: params.redirectTo ?? "/dashboard",
               success: true,
@@ -215,6 +227,16 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
 
         if (response.data.token) {
           sdk.setAuthToken(response.data.token);
+          const baseUrl = getApiBaseUrl();
+          if (baseUrl) {
+            try {
+              if (new URL(baseUrl).hostname === "localhost") {
+                localStorage.setItem("jwt", response.data.token);
+              }
+            } catch {
+              // Silently ignore URL parse errors
+            }
+          }
           return createAuthResponse({
             redirectTo: params.redirectTo ?? "/dashboard",
             success: true,
@@ -241,9 +263,17 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
     async logout(): Promise<AuthActionResponse> {
       const response = await sdk.account().logout();
 
-      // @ts-ignore
-      if (response.success && import.meta.env.DEV) {
-        localStorage.removeItem("jwt");
+      if (response.success) {
+        const baseUrl = getApiBaseUrl();
+        if (baseUrl) {
+          try {
+            if (new URL(baseUrl).hostname === "localhost") {
+              localStorage.removeItem("jwt");
+            }
+          } catch {
+            // Silently ignore URL parse errors
+          }
+        }
       }
 
       return createAuthResponse({


### PR DESCRIPTION
- Remove redundant API URL configuration options in Capability class
- Add local JWT storage for localhost development in auth provider
- Ensure consistent API base URL usage across auth flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - After login on localhost, your session token is saved in the browser so you stay signed in across page reloads; signing out clears that stored token.

- **Bug Fixes**
  - The app now resolves the API address using its default resolution rules, improving connectivity and behavior across development and subdomain setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->