### PR TITLE
feat(portal-framework-ui, portal-framework-auth): add form grouping functionality

### DIFF
--- a/libs/portal-framework-auth/src/ui/forms/register.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/register.tsx
@@ -1,6 +1,7 @@
 import {
   type FormConfig,
   FormFieldType,
+  GroupOrder,
   InlineAuthLinkBanner,
 } from "@lumeweb/portal-framework-ui";
 
@@ -11,15 +12,19 @@ export const getRegisterForm = (
 ): FormConfig => ({
   fields: [
     {
-      className: "flex-1",
+      className: "space-y-2",
+      group: "name",
       inputClassName: "h-14",
+      itemClassName: "flex-1",
       label: "First Name",
       name: "firstName",
       type: FormFieldType.TEXT,
     },
     {
-      className: "flex-1",
+      className: "space-y-2",
+      group: "name",
       inputClassName: "h-14",
+      itemClassName: "flex-1",
       label: "Last Name",
       name: "lastName",
       type: FormFieldType.TEXT,
@@ -62,6 +67,13 @@ export const getRegisterForm = (
     },
   ],
   formClassName: "w-full p-2 max-w-md space-y-4 mt-14 sm:bg-background",
+  groupOrder: GroupOrder.GROUPS_FIRST,
+  groups: [
+    {
+      className: "flex gap-4",
+      id: "name",
+    },
+  ],
   header: (
     <>
       <InlineAuthLinkBanner label="Already have an account?" to="/login" />

--- a/libs/portal-framework-ui/src/components/form/FormGroup.tsx
+++ b/libs/portal-framework-ui/src/components/form/FormGroup.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@lumeweb/portal-framework-ui-core";
+import React from "react";
+
+interface FormGroupProps {
+  children: React.ReactNode;
+  className?: string;
+  description?: string;
+  title?: string;
+}
+
+export const FormGroup = ({
+  children,
+  className,
+  description,
+  title,
+}: FormGroupProps) => {
+  return (
+    <div className={cn(className)}>
+      {title || description ? (
+        <>
+          {title && <h3 className="text-lg font-medium">{title}</h3>}
+          {description && (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          )}
+          <div className="space-y-4">{children}</div>
+        </>
+      ) : (
+        children
+      )}
+    </div>
+  );
+};

--- a/libs/portal-framework-ui/src/components/form/FormRenderer.tsx
+++ b/libs/portal-framework-ui/src/components/form/FormRenderer.tsx
@@ -19,7 +19,8 @@ import {
 import { adapters } from "./adapters";
 import { useFormContext } from "./context";
 import { FormFieldType, getFormComponent } from "./fields";
-import { type FormFieldConfig } from "./types";
+import { FormGroup as FormGroupComponent } from "./FormGroup";
+import type { FormGroupType, FormFieldConfig, GroupOrder } from "./types";
 
 interface FieldRendererProps<TFieldValues extends FieldValues> {
   field: FormFieldConfig<TFieldValues>;
@@ -27,21 +28,83 @@ interface FieldRendererProps<TFieldValues extends FieldValues> {
 
 export function FormRenderer<TRequest extends FieldValues = FieldValues>({
   fields = [],
+  groups = [],
 }: {
   fields?: FormFieldConfig<TRequest>[];
+  groups?: FormGroupType[];
 }) {
-  const { adapter: adapterName } = useFormContext();
+  // Group fields by their group ID
+  const { groupedFields, ungroupedFields } = React.useMemo(() => {
+    const grouped: Record<string, FormFieldConfig<TRequest>[]> = {};
+    const ungrouped: FormFieldConfig<TRequest>[] = [];
+
+    // Initialize groups
+    groups?.forEach((group) => {
+      grouped[group.id] = [];
+    });
+
+    // Distribute fields
+    fields.forEach((field) => {
+      if (field.group && grouped[field.group]) {
+        grouped[field.group].push(field);
+      } else {
+        ungrouped.push(field);
+      }
+    });
+
+    return { groupedFields: grouped, ungroupedFields: ungrouped };
+  }, [fields, groups]);
+  const { adapter: adapterName, config } = useFormContext();
   const adapter = adapters[adapterName];
 
   if (!adapter) {
     throw new Error(`Form adapter "${String(adapterName)}" is not registered`);
   }
 
-  return (
+  const groupOrder = config.groupOrder ?? GroupOrder.UNGROUPED_FIRST;
+
+  const renderGroups = () => (
     <>
-      {fields.map((field) => (
+      {groups?.map((group) => {
+        const groupFields = groupedFields[group.id];
+        if (!groupFields?.length) return null;
+
+        return (
+          <FormGroup
+            className={group.className}
+            description={group.description}
+            key={group.id}
+            title={group.title}>
+            {groupFields.map((field) => (
+              <FieldRenderer field={field} key={field.name as string} />
+            ))}
+          </FormGroup>
+        );
+      })}
+    </>
+  );
+
+  const renderUngrouped = () => (
+    <>
+      {ungroupedFields.map((field) => (
         <FieldRenderer field={field} key={field.name as string} />
       ))}
+    </>
+  );
+
+  return (
+    <>
+      {groupOrder === GroupOrder.GROUPS_FIRST ? (
+        <>
+          {renderGroups()}
+          {renderUngrouped()}
+        </>
+      ) : (
+        <>
+          {renderUngrouped()}
+          {renderGroups()}
+        </>
+      )}
     </>
   );
 }

--- a/libs/portal-framework-ui/src/components/form/SchemaForm.tsx
+++ b/libs/portal-framework-ui/src/components/form/SchemaForm.tsx
@@ -154,7 +154,7 @@ export function SchemaForm<T extends FieldValues = FieldValues>({
                 : cConfig.header}
             </div>
           )}
-          <FormRenderer fields={cConfig.fields} />
+          <FormRenderer fields={cConfig.fields} groups={cConfig.groups} />
           {cConfig.footer !== false && (
             <FormFooter
               className={cConfig.footerClassName}

--- a/libs/portal-framework-ui/src/components/form/index.ts
+++ b/libs/portal-framework-ui/src/components/form/index.ts
@@ -263,6 +263,7 @@
  * - Individual component registrars (registerInput(), registerSelect(), etc)
  */
 export * from "./adapters";
+export * from "./FormGroup";
 export * from "./context";
 export * from "./fields";
 export * from "./FormRenderer";

--- a/libs/portal-framework-ui/src/components/form/types.ts
+++ b/libs/portal-framework-ui/src/components/form/types.ts
@@ -18,6 +18,11 @@ import type { DialogConfig } from "../dialog/Dialog.types";
 import { ActionItemConfig, ActionListLayout } from "../actions";
 import { FormFieldType } from "./fields/types";
 
+export enum GroupOrder {
+  GROUPS_FIRST = "groups-first",
+  UNGROUPED_FIRST = "ungrouped-first",
+}
+
 export type FormAutosaveConfig<T> = AutoSaveProps<T>["autoSave"];
 
 export interface FormConfig<
@@ -65,6 +70,19 @@ export interface FormConfig<
    */
   footerClassName?: false | string;
   formClassName?: string;
+  /**
+   * Controls whether grouped or ungrouped fields are rendered first
+   * @default GroupOrder.UNGROUPED_FIRST
+   */
+  groupOrder?: GroupOrder;
+  /**
+   * Groups configuration for organizing fields
+   */
+  groups?: FormGroupType[];
+  /**
+   * Custom header content to render at the top of the form
+   */
+  header?: ((methods: any) => ReactNode) | ReactNode;
   id?: BaseKey;
   layout?: "grid" | "horizontal" | "vertical";
   onError?: (error: Error) => void;
@@ -82,15 +100,11 @@ export interface FormConfig<
     successNotification?: (data: any, values: any) => OpenNotificationParams;
   };
   resource?: string;
-  submitLabel?: string;
 
+  submitLabel?: string;
   /** Alias for refineCoreProps.successNotification */
   successNotification?: (data: any, values: any) => OpenNotificationParams;
   validationSchema?: z.ZodSchema<TRequest>;
-  /**
-   * Custom header content to render at the top of the form
-   */
-  header?: React.ReactNode | ((methods: any) => React.ReactNode);
 }
 
 export interface FormFieldConfig<TRequest extends BaseRecord = any> {
@@ -103,6 +117,10 @@ export interface FormFieldConfig<TRequest extends BaseRecord = any> {
    */
   dependencies?: string[];
   description?: string;
+  /**
+   * Group ID this field belongs to
+   */
+  group?: string;
   inputClassName?: string;
   /**
    * Additional props to pass to the underlying input element
@@ -141,6 +159,13 @@ export interface FormFieldConfig<TRequest extends BaseRecord = any> {
 }
 
 export type FormFieldOption = string | { label: string; value: string };
+
+export interface FormGroupType {
+  className?: string;
+  description?: string;
+  id: string;
+  title?: string;
+}
 
 /**
  * Defines the structure for a single step in a multi-step form.


### PR DESCRIPTION
- Introduced FormGroup component for organizing form fields
- Added group support in FormRenderer with configurable rendering order
- Extended form types to include group configuration (GroupOrder enum, FormGroup interface)
- Updated register form to use field grouping for name fields
- Exported FormGroup from form components index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forms now support field grouping with optional titles/descriptions and a configurable display order (groups first or ungrouped first).
  * Presentational group blocks added to visually bundle related inputs.
  * Form renderer and schema-driven forms accept grouping configuration to control layout.
  * Added customizable form header content.
  * Registration form layout improved: First Name and Last Name now appear side-by-side with equal widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->