### PR TITLE
refactor(portal-framework-ui, portal-plugin-dashboard): add account deletion widget with confirmation flow, extract submission logic to dedicated handlers

### DIFF
--- a/libs/advanced-rest/src/utils/generateUrl.ts
+++ b/libs/advanced-rest/src/utils/generateUrl.ts
@@ -59,7 +59,7 @@ export function generateNestedUrl({
   } catch (error) {
     // Detect missing parameter errors and rethrow with correct type
     if (error instanceof Error && error.message.startsWith("Missing a value")) {
-      const paramMatch = error.message.match(/placeholder: (\w+)/);
+      const paramMatch = /placeholder: (\w+)/.exec(error.message);
       if (paramMatch) throw new NestedParamError(paramMatch[1]);
     }
     throw new TemplateResolutionError(template, error as Error);
@@ -81,8 +81,6 @@ export function generateNestedUrl({
     resolvedPath = `${resolvedPath}/${operation}`.replace(/\/\/+/g, "/");
   }
 
-  const finalPath = `${resolvedPath.replace(/^\/+/, "")}`;
-
   // Return relative path without leading slash for ky's prefixUrl
-  return finalPath;
+  return `${resolvedPath.replace(/^\/+/, "")}`;
 }

--- a/libs/portal-framework-ui/src/components/actions/items/CancelActionItem.tsx
+++ b/libs/portal-framework-ui/src/components/actions/items/CancelActionItem.tsx
@@ -12,10 +12,11 @@ export const CancelActionItem: React.FC<
   ActionItemProps<CancelActionItemConfig>
 > = ({ closeDialog, config, isSubmitting }) => {
   const handleClick = () => {
+    if (closeDialog) {
+      closeDialog();
+    }
     if (config.onClick) {
       config.onClick?.();
-    } else if (closeDialog) {
-      closeDialog();
     }
   };
 

--- a/libs/portal-framework-ui/src/components/dialog/utils/dialogActions.ts
+++ b/libs/portal-framework-ui/src/components/dialog/utils/dialogActions.ts
@@ -82,6 +82,7 @@ function createCancelAction(
     // For alerts, we use confirmText but treat it as CANCEL type
     return {
       label: dialog.confirmText ?? "OK",
+      onClick: dialog.onConfirm,
       type: ActionItemType.CANCEL,
     };
   }
@@ -90,6 +91,7 @@ function createCancelAction(
   if (dialog.type === "confirm") {
     return {
       label: dialog.cancelText ?? "Cancel",
+      onClick: dialog.onConfirm,
       type: ActionItemType.CANCEL,
     };
   }
@@ -168,8 +170,8 @@ function getSubmitType(
     | FormDialogConfig<BaseRecord>,
 ): ActionItemType.BUTTON | ActionItemType.SUBMIT {
   switch (dialog.type) {
-    case "form":
     case "confirm":
+    case "form":
       return ActionItemType.SUBMIT;
     default:
       return ActionItemType.BUTTON;

--- a/libs/portal-framework-ui/src/components/form/SchemaForm.tsx
+++ b/libs/portal-framework-ui/src/components/form/SchemaForm.tsx
@@ -17,6 +17,7 @@ import { adapters, FormAdapter, UnifiedFormReturnType } from "./adapters";
 import { FormProvider } from "./context";
 import { FormFooter } from "./FormFooter";
 import { FormRenderer } from "./FormRenderer";
+import { handleFormSubmission } from "./handlers/core";
 import { type FormConfig, isStepFormConfig } from "./types";
 import { computeAutoSaveConfig } from "./utils/autoSave";
 
@@ -26,14 +27,19 @@ export interface SchemaFormProps<
   TRequest extends FieldValues = FieldValues,
   TResponse extends BaseRecord = any,
 > {
+  active?: boolean;
   closeDialog?: () => void;
   config: FormConfig<TRequest, TResponse>;
 }
 
 export function SchemaForm<T extends FieldValues = FieldValues>({
+  active = true,
   closeDialog = () => void 0,
   config,
 }: SchemaFormProps<T>) {
+  if (!active) {
+    return null;
+  }
   const { currentDialog, setFormMethods: setFormInstance } = useDialog();
   const { open: openNotification } = useNotification();
   if (!config) throw new Error("SchemaForm requires a form config");
@@ -108,44 +114,24 @@ export function SchemaForm<T extends FieldValues = FieldValues>({
             "space-y-4": cConfig.layout !== "grid",
           })}
           onSubmit={formInstance.handleSubmit(async () => {
-            try {
-              const response = await adapter.submitHandler(
-                cConfig,
-                formInstance,
-              );
-              // Unwrap nested response data if present
-              const responseData =
-                typeof response === "object" &&
-                response !== null &&
-                "data" in response
-                  ? (response as Record<string, unknown>).data
-                  : response;
-
-              if (cConfig.closeOnSubmit ?? true) {
-                await closeDialog?.();
-              }
-
-              if (!isStepFormConfig(cConfig) && cConfig.onSuccess) {
-                cConfig.onSuccess(responseData, formInstance.getValues());
-              } else if (
-                currentDialog?.type === "form" &&
-                currentDialog.onSuccess
-              ) {
-                currentDialog.onSuccess(responseData, formInstance.getValues());
-              }
-
-              await new Promise((resolve) => setTimeout(resolve, 100));
-            } catch (error) {
-              cConfig.onError?.(error as Error);
-
-              if (adapterName !== "refine" && cConfig.errorNotification) {
-                const notification =
-                  typeof cConfig.errorNotification === "function"
-                    ? cConfig.errorNotification(error)
-                    : cConfig.errorNotification;
-                openNotification?.(notification);
-              }
-            }
+            await handleFormSubmission({
+              closeDialog,
+              config: cConfig,
+              currentDialog,
+              formMethods: formInstance,
+              isStep: isStepFormConfig(cConfig),
+              onError: async (error) => {
+                if (adapterName !== "refine" && cConfig.errorNotification) {
+                  const notification =
+                    typeof cConfig.errorNotification === "function"
+                      ? cConfig.errorNotification(error)
+                      : cConfig.errorNotification;
+                  openNotification?.(notification);
+                }
+              },
+              onSubmit: async (data) =>
+                adapter.submitHandler(cConfig, formInstance),
+            });
           })}>
           {cConfig.header && (
             <div className="form-header">

--- a/libs/portal-framework-ui/src/components/form/StepSchemaForm.tsx
+++ b/libs/portal-framework-ui/src/components/form/StepSchemaForm.tsx
@@ -1,14 +1,15 @@
 import type { FieldValues } from "react-hook-form";
 
 import { BaseRecord } from "@refinedev/core";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { FormConfig, StepFormFooterRenderer } from "./types";
-import { type StepFormConfig } from "./types";
 
 import { useDialog } from "../dialog/Dialog.context";
+import { getStepOnSuccessHandler, handleStepSubmission } from "./handlers/step";
 import { SchemaForm } from "./SchemaForm";
 import { StepFormFooter } from "./StepFormFooter";
+import { type StepFormConfig } from "./types";
 
 const defaultStepFormFooter: StepFormFooterRenderer = (
   stepMethods,
@@ -53,17 +54,40 @@ export function StepSchemaForm<
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === totalSteps - 1;
 
-  const currentStepFields = useMemo(
-    () => config.steps[currentStep]?.fields || [],
-    [config.steps, currentStep],
-  );
+  const formInstances = useRef<Record<number, any>>({});
 
-  const getFieldsForStep = useCallback(
-    (stepIndex: number): string[] => {
-      return config.steps[stepIndex]?.fields.map((f) => f.name as string) || [];
+  // Clean up form instances when steps change or component unmounts
+  useEffect(() => {
+    const currentSteps = config.steps;
+    return () => {
+      // On unmount or steps change, clear any instances that are no longer valid
+      const validStepIndices = new Set(currentSteps.map((_, index) => index));
+      Object.keys(formInstances.current).forEach((key) => {
+        const index = Number(key);
+        if (!validStepIndices.has(index)) {
+          delete formInstances.current[index];
+        }
+      });
+    };
+  }, [config.steps]);
+
+  const getFormInstance = useCallback(
+    (stepIndex: number) => {
+      if (!formInstances.current[stepIndex]) {
+        formInstances.current[stepIndex] = {
+          fields: config.steps[stepIndex]?.fields || [],
+          getFields: () =>
+            config.steps[stepIndex]?.fields.map((f) => f.name as string) || [],
+        };
+      }
+      return formInstances.current[stepIndex];
     },
     [config.steps],
   );
+
+  const currentStepConfig = useMemo(() => {
+    return getFormInstance(currentStep);
+  }, [currentStep, getFormInstance]);
 
   const go = (step: number) => {
     const targetStep = Math.max(0, Math.min(step, totalSteps - 1));
@@ -71,59 +95,41 @@ export function StepSchemaForm<
   };
 
   const handleNext = useCallback(async () => {
-    if (isLastStep || !formMethods?.handleSubmit) return;
+    if (!formMethods?.handleSubmit) return;
 
-    const currentStepConfig = config.steps[currentStep];
-
-    await formMethods.handleSubmit(
-      async (data: Partial<TRequest>) => {
-        try {
-          let submitResult: any;
-          if (currentStepConfig.onStepSubmit) {
-            submitResult = await currentStepConfig.onStepSubmit(data);
-          }
-
-          // Call step success handler with both data and submit result
-          if (currentStepConfig.onStepSuccess) {
-            await currentStepConfig.onStepSuccess(submitResult, data);
-          }
-
-          // Only proceed to next step if submission succeeds
-          go(currentStep + 1);
-        } catch (error) {
-          if (currentStepConfig.onStepError) {
-            await currentStepConfig.onStepError(error as Error);
-          }
-          throw error;
-        }
+    await handleStepSubmission({
+      closeDialog,
+      config: {
+        ...config,
+        onSuccess: getStepOnSuccessHandler(
+          config,
+          formMethods,
+          isLastStep,
+          closeDialog,
+        ),
       },
-      (errors: any) => {
-        console.error("Validation errors:", errors);
-      },
-    )();
-  }, [
-    formMethods,
-    currentStep,
-    isLastStep,
-    go,
-    getFieldsForStep,
-    config.steps,
-  ]);
+      currentStep,
+      formMethods,
+      goToNextStep: isLastStep ? undefined : () => go(currentStep + 1),
+      isLastStep,
+      stepConfig: config.steps[currentStep],
+    });
+  }, [formMethods, currentStep, isLastStep, go, closeDialog, config]);
 
   const handlePrevious = useCallback(async () => {
     if (isFirstStep) return;
 
     if (isBackValidate && formMethods?.trigger) {
-      const fieldsToValidate = getFieldsForStep(currentStep);
-      const isValid = await formMethods.trigger(fieldsToValidate);
+      const currentForm = getFormInstance(currentStep);
+      const isValid = await formMethods.trigger(currentForm.getFields());
       if (!isValid) return;
     }
 
     // Call onStepSubmit for previous step if going back
     const prevStepConfig = config.steps[currentStep - 1];
     if (prevStepConfig.onStepSubmit) {
-      const prevFields = getFieldsForStep(currentStep - 1);
-      const prevStepValues = prevFields.reduce((acc, field) => {
+      const prevForm = getFormInstance(currentStep - 1);
+      const prevStepValues = prevForm.getFields().reduce((acc, field) => {
         acc[field] = formMethods?.getValues(field);
         return acc;
       }, {} as Partial<TRequest>);
@@ -137,44 +143,29 @@ export function StepSchemaForm<
     isFirstStep,
     isBackValidate,
     go,
-    getFieldsForStep,
+    getFormInstance,
     config.steps,
   ]);
 
   const triggerSubmit = useCallback(() => {
     if (!formMethods?.handleSubmit) return;
 
-    const currentStepConfig = config.steps[currentStep];
-
-    formMethods.handleSubmit(
-      async (data: Partial<TRequest>) => {
-        try {
-          if (currentStepConfig.onStepSubmit) {
-            await currentStepConfig.onStepSubmit(data);
-          }
-
-          if (isLastStep) {
-            const allValues = formMethods.getValues() as TRequest;
-            if (config.onFinish) {
-              await config.onFinish(allValues);
-            }
-            if (config.onSuccess) {
-              await config.onSuccess(allValues, allValues);
-            }
-            // Close dialog after successful final step submission if available
-            closeDialog?.();
-          }
-        } catch (error) {
-          if (currentStepConfig.onStepError) {
-            await currentStepConfig.onStepError(error as Error);
-          }
-          throw error;
-        }
+    handleStepSubmission({
+      closeDialog,
+      config: {
+        ...config,
+        onSuccess: getStepOnSuccessHandler(
+          config,
+          formMethods,
+          isLastStep,
+          closeDialog,
+        ),
       },
-      (errors: any) => {
-        console.error("Validation errors:", errors);
-      },
-    )();
+      currentStep,
+      formMethods,
+      isLastStep,
+      stepConfig: config.steps[currentStep],
+    });
   }, [formMethods, config, currentStep, isLastStep, closeDialog]);
 
   const getStepFooter = useCallback(
@@ -210,23 +201,24 @@ export function StepSchemaForm<
     ],
   );
 
-  const schemaFormConfigForCurrentStep: FormConfig<TRequest, TResponse> =
-    useMemo(
-      () => ({
+  const schemaForms = useMemo(() => {
+    return config.steps.map((step, index) => {
+      const formConfig: FormConfig<TRequest, TResponse> = {
         ...config,
-        fields: currentStepFields,
+        fields: getFormInstance(index).fields,
         footer: config.footer === false ? false : getStepFooter,
-        validationSchema: config.steps[currentStep]?.validationSchema,
-      }),
-      [config, currentStepFields, currentStep, getStepFooter],
-    );
+        validationSchema: step.validationSchema,
+      };
+      return (
+        <SchemaForm<TRequest>
+          active={currentStep === index}
+          closeDialog={closeDialog}
+          config={formConfig}
+          key={`step-${index}`}
+        />
+      );
+    });
+  }, [config, currentStep, getFormInstance, getStepFooter, closeDialog]);
 
-  return (
-    <>
-      <SchemaForm<TRequest>
-        closeDialog={closeDialog}
-        config={schemaFormConfigForCurrentStep}
-      />
-    </>
-  );
+  return <>{schemaForms}</>;
 }

--- a/libs/portal-framework-ui/src/components/form/adapters.tsx
+++ b/libs/portal-framework-ui/src/components/form/adapters.tsx
@@ -1,17 +1,17 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { BaseRecord, HttpError } from "@refinedev/core"; // Add FormAction import
 import {
-  useForm as useRefineForm,
   type UseFormProps as RefineUseFormProps,
   UseFormReturnType,
+  useForm as useRefineForm,
 } from "@refinedev/react-hook-form";
 import {
-  Controller as RHFController,
   FieldValues,
+  Controller as RHFController,
   FormProvider as RHFFormProvider,
-  useForm as useRHFForm,
   type UseFormProps as RHFUseFormProps,
   type UseFormReturn,
+  useForm as useRHFForm,
 } from "react-hook-form";
 import * as z from "zod";
 

--- a/libs/portal-framework-ui/src/components/form/fields/Input.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Input.tsx
@@ -1,4 +1,4 @@
-import { cn, Input as BaseInput } from "@lumeweb/portal-framework-ui-core";
+import { Input as BaseInput, cn } from "@lumeweb/portal-framework-ui-core";
 import React from "react";
 
 import { registerFormComponent } from ".";

--- a/libs/portal-framework-ui/src/components/form/fields/Select.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Select.tsx
@@ -1,6 +1,6 @@
 import {
-  cn,
   Select as BaseSelect,
+  cn,
   SelectContent,
   SelectItem,
   SelectTrigger,
@@ -9,9 +9,9 @@ import {
 import React from "react";
 
 import type { FormFieldOption } from "../";
-import { FormFieldType } from "../";
 
 import { registerFormComponent } from ".";
+import { FormFieldType } from "../";
 
 export const Select = React.forwardRef<
   HTMLButtonElement,

--- a/libs/portal-framework-ui/src/components/form/fields/Switch.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Switch.tsx
@@ -1,4 +1,8 @@
-import { Label, Switch as BaseSwitch, cn } from "@lumeweb/portal-framework-ui-core";
+import {
+  Switch as BaseSwitch,
+  cn,
+  Label,
+} from "@lumeweb/portal-framework-ui-core";
 import React from "react";
 
 import { registerFormComponent } from ".";
@@ -28,7 +32,9 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
           ref={ref}
         />
         {label && (
-          <Label className={cn("text-foreground", props.labelClassName)} htmlFor={props.name}>
+          <Label
+            className={cn("text-foreground", props.labelClassName)}
+            htmlFor={props.name}>
             {label}
           </Label>
         )}

--- a/libs/portal-framework-ui/src/components/form/fields/index.ts
+++ b/libs/portal-framework-ui/src/components/form/fields/index.ts
@@ -1,6 +1,6 @@
 export * from "./Checkbox";
-export * from "./EmailInput";
 export * from "./DatePicker";
+export * from "./EmailInput";
 export * from "./FileInput";
 export * from "./Input";
 export * from "./RadioGroup";

--- a/libs/portal-framework-ui/src/components/form/handlers/core.ts
+++ b/libs/portal-framework-ui/src/components/form/handlers/core.ts
@@ -1,0 +1,79 @@
+import type { BaseRecord } from "@refinedev/core";
+import type { UseFormReturn } from "react-hook-form";
+
+import type { FormConfig } from "../types";
+
+export interface SubmissionHandlerOptions<TRequest, TResponse> {
+  closeDialog?: () => void;
+  config: FormConfig<TRequest, TResponse>;
+  currentDialog?: any;
+  formMethods: UseFormReturn<TRequest>;
+  isStep?: boolean;
+  onError?: (error: Error) => Promise<void> | void;
+  onSubmit?: (data: TRequest) => Promise<TResponse>;
+  onSuccess?: (response: TResponse, values: TRequest) => Promise<void> | void;
+}
+
+export async function handleFormSubmission<
+  TRequest extends BaseRecord,
+  TResponse extends BaseRecord,
+>(options: SubmissionHandlerOptions<TRequest, TResponse>): Promise<void> {
+  const {
+    closeDialog,
+    config,
+    currentDialog,
+    formMethods,
+    isStep,
+    onError,
+    onSubmit,
+    onSuccess,
+  } = options;
+
+  try {
+    return await formMethods.handleSubmit(async (data: TRequest) => {
+      const submitResponse = onSubmit
+        ? await onSubmit(data)
+        : await config.onSubmit?.(data);
+
+      // Unwrap nested response data if present
+      const responseData =
+        typeof submitResponse === "object" &&
+        submitResponse !== null &&
+        "data" in submitResponse
+          ? (submitResponse as Record<string, unknown>).data
+          : submitResponse;
+
+      if (!isStep) {
+        if (config.closeOnSubmit ?? true) {
+          await closeDialog?.();
+        }
+        if (config.onSuccess) {
+          await config.onSuccess(responseData as TResponse, data);
+        } else if (currentDialog?.type === "form" && currentDialog.onSuccess) {
+          await currentDialog.onSuccess(responseData, data);
+        }
+      }
+
+      if (onSuccess) {
+        await onSuccess(responseData as TResponse, data);
+      }
+
+      return responseData;
+    })();
+  } catch (error) {
+    const err = error as Error;
+    try {
+      if (onError) {
+        await onError(err);
+      } else if (config.onError) {
+        await config.onError(err);
+      } else if (currentDialog?.type === "form" && currentDialog.onError) {
+        await currentDialog.onError(err);
+      }
+    } catch (innerError) {
+      // If error handler itself throws, preserve original error
+      console.error("Error in form error handler:", innerError);
+    }
+    throw err;
+  }
+}

--- a/libs/portal-framework-ui/src/components/form/handlers/step.ts
+++ b/libs/portal-framework-ui/src/components/form/handlers/step.ts
@@ -1,0 +1,91 @@
+import type { BaseRecord } from "@refinedev/core";
+import type { UseFormReturn } from "react-hook-form";
+
+import type { FormConfig, StepDefinition, StepFormConfig } from "../types";
+
+import { handleFormSubmission } from "./core";
+
+export interface StepSubmissionHandlerOptions<TRequest, TResponse> {
+  closeDialog?: () => void;
+  config: FormConfig<TRequest, TResponse>;
+  currentStep: number;
+  formMethods: UseFormReturn<TRequest>;
+  goToNextStep?: () => void;
+  isLastStep?: boolean;
+  stepConfig: StepDefinition<TRequest>;
+}
+
+export function getStepOnSuccessHandler<
+  TRequest extends BaseRecord,
+  TResponse extends BaseRecord,
+>(
+  config: StepFormConfig<TRequest, TResponse>,
+  formMethods: UseFormReturn<TRequest>,
+  isLastStep: boolean,
+  closeDialog: () => void,
+) {
+  return async (response: TResponse, data: TRequest) => {
+    if (isLastStep) {
+      const allValues = formMethods.getValues();
+      if (config.closeOnSubmit ?? true) {
+        await closeDialog();
+      }
+      if (config.onFinish) {
+        await config.onFinish(allValues);
+      }
+      if (config.onSuccess) {
+        await config.onSuccess(response, allValues);
+      }
+    }
+  };
+}
+
+export async function handleStepSubmission<
+  TRequest extends BaseRecord,
+  TResponse extends BaseRecord,
+>(options: StepSubmissionHandlerOptions<TRequest, TResponse>): Promise<void> {
+  const { currentStep, goToNextStep, stepConfig, ...baseOptions } = options;
+
+  return handleFormSubmission({
+    ...baseOptions,
+    closeOnSubmit: false, // Never close dialog during step transitions
+    isStep: true,
+    onError: async (error) => {
+      if (stepConfig.onStepError) {
+        await stepConfig.onStepError(error);
+      }
+    },
+    onSubmit: async (data) => {
+      const { isLastStep } = options;
+
+      if (stepConfig.onStepSubmit) {
+        return await stepConfig.onStepSubmit(data);
+      }
+
+      if (isLastStep && options.config.onSubmit) {
+        return await options.config.onSubmit(data);
+      }
+
+      // Default return when no submit handlers are defined
+      return Promise.resolve(data);
+    },
+    onSuccess: async (response, data) => {
+      const { isLastStep } = options;
+
+      // First call step-specific success handler if defined
+      if (stepConfig.onStepSuccess) {
+        await stepConfig.onStepSuccess(response, data);
+      }
+
+      // Then call any parent success handler (for final form submission)
+      if (options.config.onSuccess) {
+        await options.config.onSuccess(response, data);
+      }
+
+      // Finally proceed to next step if not last step
+      if (!isLastStep && options.goToNextStep) {
+        await options.goToNextStep();
+      }
+    },
+  });
+}

--- a/libs/portal-framework-ui/src/components/form/index.ts
+++ b/libs/portal-framework-ui/src/components/form/index.ts
@@ -263,9 +263,9 @@
  * - Individual component registrars (registerInput(), registerSelect(), etc)
  */
 export * from "./adapters";
-export * from "./FormGroup";
 export * from "./context";
 export * from "./fields";
+export * from "./FormGroup";
 export * from "./FormRenderer";
 export * from "./register";
 export * from "./SchemaForm";

--- a/libs/portal-plugin-dashboard/plugin.config.ts
+++ b/libs/portal-plugin-dashboard/plugin.config.ts
@@ -24,6 +24,7 @@ export default {
     "./resetPassword/reset": "./src/ui/routes/resetPassword.reset",
     "./widgets/account/2fa": "./src/ui/widgets/account/2fa",
     "./widgets/account/bio": "./src/ui/widgets/account/bio",
+    "./widgets/account/delete": "./src/ui/widgets/account/delete",
     "./widgets/account/emailVerificationBanner":
       "./src/ui/widgets/account/emailVerificationBanner",
     "./widgets/account/password": "./src/ui/widgets/account/password",

--- a/libs/portal-plugin-dashboard/src/ui/dialogs/deleteAccount.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/dialogs/deleteAccount.tsx
@@ -1,0 +1,41 @@
+import type { DialogConfig } from "@lumeweb/portal-framework-ui";
+import type { HttpError, DeleteOneParams } from "@refinedev/core";
+import type { UseMutationResult } from "@tanstack/react-query";
+
+import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
+
+import deleteAccountForm from "@/ui/forms/deleteAccount";
+
+export function deleteAccountDialogConfig(
+  deleteMutation: UseMutationResult<void, HttpError, DeleteOneParams, unknown>,
+  logout: () => Promise<void>,
+  openDialog: (config: DialogConfig) => void,
+): DialogConfig {
+  return {
+    formConfig: deleteAccountForm(),
+    onSubmit: async () => {
+      try {
+        return await deleteMutation.mutateAsync({
+          resource: DATA_PROVIDER_NAME,
+          successNotification: false,
+        });
+      } catch (error) {
+        console.error('Failed to delete account:', error);
+        throw new Error('Failed to delete account. Please try again or contact support.');
+      }
+    },
+    onSuccess: () => {
+      openDialog({
+        description:
+          "Your account will be deleted within 48 hours. If this is an error, please contact support immediately.",
+        onConfirm: () => logout(),
+        title: "Account Deletion Scheduled",
+        type: "alert",
+        variant: "success",
+      });
+      return true;
+    },
+    title: "Delete Account",
+    type: "form",
+  };
+}

--- a/libs/portal-plugin-dashboard/src/ui/forms/deleteAccount.schema.ts
+++ b/libs/portal-plugin-dashboard/src/ui/forms/deleteAccount.schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const stepOneSchema = z.object({
+  confirmText: z.literal("DELETE", {
+    errorMap: () => ({ message: "Please type DELETE to confirm" }),
+  }),
+});
+
+const stepTwoSchema = z.object({
+  confirmText: z.literal("I UNDERSTAND", {
+    errorMap: () => ({ message: "Please type I UNDERSTAND to confirm" }),
+  }),
+});
+
+export { stepOneSchema, stepTwoSchema };

--- a/libs/portal-plugin-dashboard/src/ui/forms/deleteAccount.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/deleteAccount.tsx
@@ -1,0 +1,40 @@
+import { type StepFormConfig } from "@lumeweb/portal-framework-ui";
+
+import { stepOneSchema, stepTwoSchema } from "./deleteAccount.schema";
+
+export default function deleteAccountForm(): StepFormConfig {
+  return {
+    steps: [
+      {
+        fields: [
+          {
+            description:
+              "Are you sure you want to delete your account? This action cannot be undone.",
+            label: 'Type "DELETE" to confirm:',
+            name: "confirmText",
+            placeholder: "DELETE",
+            required: true,
+            type: "text",
+          },
+        ],
+        title: "Confirm Deletion",
+        validationSchema: stepOneSchema,
+      },
+      {
+        fields: [
+          {
+            description:
+              "This is your final chance to reconsider. Your account will be permanently deleted.",
+            label: 'Type "I UNDERSTAND" to proceed:',
+            name: "confirmText",
+            placeholder: "I UNDERSTAND",
+            required: true,
+            type: "text",
+          },
+        ],
+        title: "Final Confirmation",
+        validationSchema: stepTwoSchema,
+      },
+    ],
+  };
+}

--- a/libs/portal-plugin-dashboard/src/ui/widgets/account/delete.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/widgets/account/delete.tsx
@@ -1,0 +1,32 @@
+import { useDialog } from "@lumeweb/portal-framework-ui";
+import { Button } from "@lumeweb/portal-framework-ui-core";
+import { useDelete, useLogout } from "@refinedev/core";
+import { AlertTriangle } from "lucide-react";
+
+import { Card } from "@/ui/components/Card";
+import { deleteAccountDialogConfig } from "@/ui/dialogs/deleteAccount";
+
+export default function DeleteAccount() {
+  const { openDialog } = useDialog();
+  const { mutateAsync: logout } = useLogout();
+  const deleteMutator = useDelete();
+
+  const handleDeleteClick = () => {
+    openDialog(deleteAccountDialogConfig(deleteMutator, logout, openDialog));
+  };
+
+  return (
+    <Card
+      border
+      description="Permanently delete your account and all data"
+      icon={AlertTriangle}
+      title="Delete Account">
+      <Button
+        className="w-full"
+        onClick={handleDeleteClick}
+        variant="destructive">
+        Delete Account
+      </Button>
+    </Card>
+  );
+}

--- a/libs/portal-plugin-dashboard/src/widgetRegistrations.ts
+++ b/libs/portal-plugin-dashboard/src/widgetRegistrations.ts
@@ -18,6 +18,12 @@ export const widgetRegistrations = [
     rows: 2,
   },
   {
+    area: "core:dashboard:profile",
+    cols: 2,
+    componentName: "widgets/account/delete",
+    rows: 2,
+  },
+  {
     area: "core:dashboard:security",
     cols: 2,
     componentName: "widgets/account/password",


### PR DESCRIPTION
- Added new account deletion feature with 2-step confirmation
- Created delete account dialog and form components
- Extracted form submission logic to core.ts and step.ts handlers
- Improved CancelActionItem dialog closing behavior
- Added conditional rendering support to SchemaForm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a Delete Account widget in Profile with a two-step confirmation flow; deletion is scheduled (48 hours) and triggers logout after confirmation.
* **Bug Fixes**
  - Cancel buttons in dialogs now reliably close the dialog first, then run any attached action.
* **Refactor**
  - Multi-step forms now preserve per-step inputs, render steps independently, and support an optional active toggle.
  - Centralized form submission and step orchestration for consistent success/error handling and progression.
* **Chores**
  - Exported step-form support and related types; plugin exposes and widget registration updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->