### PR TITLE
refactor(portal-plugin-dashboard): add item prop to CollapseMenuButton and update route navigation labels

### DIFF
--- a/libs/portal-framework-ui/src/components/MainNavigation.tsx
+++ b/libs/portal-framework-ui/src/components/MainNavigation.tsx
@@ -30,6 +30,7 @@ interface CollapseMenuButtonProps {
   isOpen: boolean;
   label: string;
   submenus: Submenu[];
+  item: NavigationItemType;
 }
 
 interface Submenu {
@@ -44,26 +45,32 @@ const CollapseMenuButton: React.FC<CollapseMenuButtonProps> = ({
   isOpen,
   label,
   submenus,
+  item,
 }) => {
   const location = useLocation();
   const pathname = location.pathname; // Get current path
   const isSubmenuActive = submenus.some((submenu) =>
     submenu.active === undefined ? submenu.href === pathname : submenu.active,
   );
-  const [isCollapsed, setIsCollapsed] =
-    React.useState<boolean>(isSubmenuActive);
+  const [isOpenState, setIsOpenState] =
+    React.useState<boolean>(active || isSubmenuActive);
+  const headerHref = item.path || submenus[0]?.href;
+
+  React.useEffect(() => {
+    setIsOpenState(active || isSubmenuActive);
+  }, [active, isSubmenuActive]);
 
   return (
     <Collapsible
       className="w-full"
-      onOpenChange={setIsCollapsed}
-      open={isCollapsed}>
+      onOpenChange={setIsOpenState}
+      open={isOpenState}>
       <CollapsibleTrigger
         asChild
         className="[&[data-state=open]>div>div>svg]:rotate-180 mb-1">
         <Button
           className="w-full justify-start h-10"
-          variant={isSubmenuActive ? "secondary" : "ghost"}>
+          variant={active || isSubmenuActive ? "secondary" : "ghost"}>
           <div className="w-full items-center flex justify-between">
             <div className="flex items-center">
               {Icon && (
@@ -71,16 +78,41 @@ const CollapseMenuButton: React.FC<CollapseMenuButtonProps> = ({
                   <Icon size={18} />
                 </span>
               )}
-              <Link to={submenus[0]?.href || "#"}>
-                {/* Link only wraps the text */}
+              {headerHref ? (
+                <Link
+                  to={headerHref}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === " ") {
+                      e.preventDefault(); // avoid page scroll
+                      e.stopPropagation();
+                    }
+                    if (e.key === "Enter") {
+                      e.stopPropagation();
+                    }
+                  }}
+                  aria-label={label}
+                >
+                  <p
+                    className={cn({
+                      "-translate-x-96 opacity-0": !isOpen,
+                      "translate-x-0 opacity-100": isOpen,
+                    })}
+                  >
+                    {label}
+                  </p>
+                </Link>
+              ) : (
                 <p
                   className={cn({
                     "-translate-x-96 opacity-0": !isOpen,
                     "translate-x-0 opacity-100": isOpen,
-                  })}>
+                  })}
+                  aria-disabled="true"
+                >
                   {label}
                 </p>
-              </Link>
+              )}
             </div>
             <div
               className={cn(
@@ -198,6 +230,7 @@ export const MainNavigation: React.FC<MenuProps> = ({ isOpen }) => {
           key={item.id}
           label={item.label}
           submenus={submenus}
+          item={item}
         />
       );
     } else {

--- a/libs/portal-plugin-dashboard/src/routes.ts
+++ b/libs/portal-plugin-dashboard/src/routes.ts
@@ -24,11 +24,17 @@ const routes = [
       {
         component: "account/security",
         id: "account_security",
+        navigation: {
+          label: "Security",
+        },
         path: "security",
       },
       {
         component: "account/api-keys",
         id: "account_api_keys",
+        navigation: {
+          label: "API Keys",
+        },
         path: "api-keys",
       },
     ],


### PR DESCRIPTION
- Added `item` prop to CollapseMenuButton component to access full navigation item data
- Updated link generation to prefer item.path over submenu href
- Added navigation labels for account security and API keys routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account navigation now includes labeled entries for “Security” and “API Keys.”
  * Collapsible menu headers now support direct navigation using the primary item path.

* **Bug Fixes**
  * Header links in collapsible menus now reliably point to the correct destination with a safe fallback and improved keyboard/ARIA behavior for better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->