### PR TITLE
refactor(portal-framework-auth, portal-plugin-dashboard): add event emitter to auth provider

### DIFF
--- a/libs/portal-framework-auth/package.json
+++ b/libs/portal-framework-auth/package.json
@@ -20,7 +20,8 @@
     "@lumeweb/portal-framework-core": "workspace:*",
     "@lumeweb/portal-framework-ui": "workspace:*",
     "@lumeweb/portal-framework-ui-core": "workspace:*",
-    "@lumeweb/portal-sdk": "workspace:*"
+    "@lumeweb/portal-sdk": "workspace:*",
+    "nanoevents": "^9.1.0"
   },
   "devDependencies": {
     "tsdown": "^0.11.12"

--- a/libs/portal-framework-auth/src/dataProviders/auth.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.ts
@@ -12,6 +12,7 @@ import type {
 } from "@refinedev/core";
 
 import { getApiBaseUrl } from "@lumeweb/portal-framework-core";
+import { createNanoEvents } from "nanoevents";
 
 export const DATA_PROVIDER_NAME = "account";
 
@@ -64,7 +65,31 @@ const createAuthResponse = (
   ...params,
 });
 
-export const createAuthProvider = (sdk: Sdk): AuthProvider => {
+export interface AuthCheckFailedEvent {
+  error: Error;
+}
+
+export interface AuthCheckSuccessEvent {
+  token: string;
+}
+
+export interface AuthEvents {
+  authCheckFailed: (params: AuthCheckFailedEvent) => void;
+  authCheckSuccess: (params: AuthCheckSuccessEvent) => void;
+  registerAttempt: (params: RegisterAttemptEvent) => void;
+}
+
+export interface Auth1ProviderWithEmitter extends AuthProvider {
+  on<E extends keyof AuthEvents>(event: E, callback: AuthEvents[E]): () => void;
+}
+
+export interface RegisterAttemptEvent {
+  email: string;
+  firstName: string;
+}
+
+export const createAuthProvider = (sdk: Sdk): AuthProviderWithEmitter => {
+  const emitter = createNanoEvents<AuthEvents>();
   const maybeSetupAuth = () => {
     const token = localStorage.getItem("jwt");
     if (token) {
@@ -78,6 +103,7 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
       const response = await sdk.account().ping();
 
       if (isErrorResult(response)) {
+        emitter.emit("authCheckFailed", { error: response.error });
         return {
           authenticated: false,
           error: response.error,
@@ -87,13 +113,13 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
 
       if (response.data.token) {
         sdk.setAuthToken(response.data.token);
+        emitter.emit("authCheckSuccess", { token: response.data.token });
       }
 
       return {
         authenticated: true,
       };
     },
-
     async forgotPassword(
       params: ForgotPasswordRequest,
     ): Promise<AuthActionResponse> {
@@ -183,6 +209,7 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
 
           if (response.data.token) {
             sdk.setAuthToken(response.data.token);
+            emitter.emit("authCheckSuccess", { token: response.data.token });
             const baseUrl = getApiBaseUrl();
             if (baseUrl) {
               try {
@@ -287,11 +314,19 @@ export const createAuthProvider = (sdk: Sdk): AuthProvider => {
       });
     },
 
+    on<E extends keyof AuthEvents>(event: E, callback: AuthEvents[E]) {
+      return emitter.on(event, callback);
+    },
+
     async onError(): Promise<{ logout?: boolean; redirectTo?: string }> {
       return {};
     },
 
     async register(params: RegisterFormRequest): Promise<AuthActionResponse> {
+      emitter.emit("registerAttempt", {
+        email: params.email,
+        firstName: params.firstName,
+      });
       const response = await sdk.account().register({
         email: params.email,
         first_name: params.firstName,

--- a/libs/portal-plugin-dashboard/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-dashboard/src/capabilities/refineConfig.ts
@@ -1,7 +1,10 @@
 import type { RefineProps } from "@refinedev/core";
 
 import dataProvider from "@lumeweb/advanced-rest-provider";
-import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
+import {
+  type AuthProviderWithEmitter,
+  DATA_PROVIDER_NAME,
+} from "@lumeweb/portal-framework-auth";
 import {
   env,
   Framework,
@@ -26,6 +29,15 @@ export class Capability implements RefineConfigCapability {
 
     if (token) {
       acctProvider.setAuthToken(token);
+    }
+
+    const authProvider = existing?.authProvider as
+      | AuthProviderWithEmitter
+      | undefined;
+    if (authProvider) {
+      authProvider.on("authCheckSuccess", (params) => {
+        acctProvider.setAuthToken(params.token);
+      });
     }
 
     return mergeRefineConfig(existing, { [DATA_PROVIDER_NAME]: acctProvider }, [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@18.3.1)
+      nanoevents:
+        specifier: ^9.1.0
+        version: 9.1.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -6628,6 +6631,10 @@ packages:
 
   namespace-emitter@2.0.1:
     resolution: {integrity: sha512-N/sMKHniSDJBjfrkbS/tpkPj4RAbvW3mr8UAzvlMHyun93XEm83IAvhWtJVHo+RHn/oO8Job5YN4b+wRjSVp5g==}
+
+  nanoevents@9.1.0:
+    resolution: {integrity: sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -15195,6 +15202,8 @@ snapshots:
       thenify-all: 1.6.0
 
   namespace-emitter@2.0.1: {}
+
+  nanoevents@9.1.0: {}
 
   nanoid@3.3.11: {}
 


### PR DESCRIPTION
- Added nanoevents dependency for event handling
- Implemented AuthEvents interface with auth check and registration events
- Extended AuthProvider to include event emitter functionality
- Updated dashboard plugin to listen for auth success events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication provider now emits events and supports subscriptions.
  * Dashboard listens for successful sign-in/OTP events and auto-syncs the API token to avoid re-auth prompts.
  * Registration attempts and auth success/failure are observable for integrations.

* **Chores**
  * Added a dependency to enable the event system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->