### PR TITLE
refactor(portal-framework-auth): refactor auth page layout and link handling

### DIFF
--- a/libs/portal-framework-auth/src/ui/components/common/AuthPage.tsx
+++ b/libs/portal-framework-auth/src/ui/components/common/AuthPage.tsx
@@ -1,4 +1,5 @@
 import { LumeLogo } from "@lumeweb/portal-framework-ui";
+import { InlineAuthLinkBanner } from "@lumeweb/portal-framework-ui";
 import React, { ReactNode } from "react";
 
 import { AuthFooter } from "./AuthFooter";
@@ -6,11 +7,24 @@ import { BackgroundImage } from "./BackgroundImage";
 import { BackgroundVariant } from "./types";
 
 interface AuthPageProps {
+  beforeLink?: ReactNode;
   children: ReactNode;
+  linkLabel?: string;
+  linkText?: string;
+  linkUrl?: string;
   variant?: BackgroundVariant;
 }
 
-export function AuthPage({ children, variant = "default" }: AuthPageProps) {
+export function AuthPage({
+  beforeLink,
+  children,
+  linkLabel,
+  linkText,
+  linkUrl,
+  variant = "default",
+}: AuthPageProps) {
+  const showBanner = linkLabel && linkUrl && linkText;
+
   return (
     <div className="h-screen relative sm:overflow-hidden">
       <div className="flex flex-col sm:flex-row-reverse items-center justify-center w-full h-full">
@@ -19,11 +33,31 @@ export function AuthPage({ children, variant = "default" }: AuthPageProps) {
         </header>
         <BackgroundImage variant={variant} />
         <div
-          role="main"
           className={
             "flex flex-col items-start justify-start bg-background w-full sm:max-w-md z-10 relative"
-          }>
+          }
+          role="main">
           <div className="sm:mt-20 p-5">
+            {showBanner && (
+              <div className="absolute inset-0 flex sm:hidden flex-col items-start justify-center gap-2 text-left p-4 mt-60 sm:mt-10">
+                {beforeLink}
+                <InlineAuthLinkBanner
+                  label={linkLabel}
+                  linkLabel={linkText}
+                  to={linkUrl}
+                />
+              </div>
+            )}
+            {showBanner && (
+              <div className="hidden sm:flex flex-col items-start justify-center gap-2 text-left mb-10">
+                {beforeLink}
+                <InlineAuthLinkBanner
+                  label={linkLabel}
+                  linkLabel={linkText}
+                  to={linkUrl}
+                />
+              </div>
+            )}
             {children}
             <AuthFooter />
           </div>

--- a/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
@@ -1,5 +1,4 @@
 import {
-  InlineAuthLinkBanner,
   useFeatureFlag,
   useRegisterUrl,
   withTheme,
@@ -7,37 +6,24 @@ import {
 import React from "react";
 
 import { AuthPage } from "@/ui/components/common/AuthPage";
+
 import { LoginForm } from "./LoginForm";
 import { SocialLogin } from "./SocialLogin";
 
 function LoginIndex() {
-  const showRegister = true;
   const socialLoginEnabled = useFeatureFlag("social_login");
   const registerUrl = useRegisterUrl();
 
   return (
-    <AuthPage variant="login">
-      <div className="absolute inset-0 flex sm:hidden flex-col items-start justify-center gap-2 text-left p-4 mt-60 sm:mt-10">
-        <h2 className="text-4xl sm:text-3xl font-bold">Welcome back</h2>
-        {showRegister && (
-          <InlineAuthLinkBanner
-            label="New user?"
-            linkLabel="Create an account →"
-            to={registerUrl}
-          />
-        )}
-      </div>
+    <AuthPage
+      beforeLink={
+        <h2 className="text-4xl sm:text-3xl font-bold mb-5">Welcome back</h2>
+      }
+      linkLabel="New user?"
+      linkText="Create an account →"
+      linkUrl={registerUrl}
+      variant="login">
       {socialLoginEnabled && <SocialLogin />}
-      <div className="hidden sm:flex flex-col items-start justify-center gap-2 text-left mb-10">
-        <h2 className="text-4xl mb-2">Welcome back</h2>
-        {showRegister && (
-          <InlineAuthLinkBanner
-            label="New user?"
-            linkLabel="Create an account →"
-            to={registerUrl}
-          />
-        )}
-      </div>
       <LoginForm />
     </AuthPage>
   );

--- a/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
@@ -1,4 +1,8 @@
-import { SchemaForm, useLoginUrl, withTheme } from "@lumeweb/portal-framework-ui";
+import {
+  SchemaForm,
+  useLoginUrl,
+  withTheme,
+} from "@lumeweb/portal-framework-ui";
 import { useRegister } from "@refinedev/core";
 import React from "react";
 
@@ -19,10 +23,14 @@ function RegisterIndex() {
     });
   };
 
-  const finalRegisterFormConfig = getRegisterForm(onSubmit, loginUrl);
+  const finalRegisterFormConfig = getRegisterForm(onSubmit);
 
   return (
-    <AuthPage variant="register">
+    <AuthPage
+      linkLabel="Already have an account?"
+      linkText="Login here →"
+      linkUrl={loginUrl}
+      variant="register">
       <SchemaForm config={finalRegisterFormConfig} />
     </AuthPage>
   );

--- a/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordLayout.tsx
+++ b/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordLayout.tsx
@@ -1,12 +1,17 @@
-import { withTheme } from "@lumeweb/portal-framework-ui";
+import { useLoginUrl, withTheme } from "@lumeweb/portal-framework-ui";
 import React from "react";
 import { Outlet } from "react-router";
 
 import { AuthPage } from "../common/AuthPage";
 
 function ResetPasswordLayout() {
+  const loginUrl = useLoginUrl();
   return (
-    <AuthPage variant="reset-password">
+    <AuthPage
+      linkLabel="Remember your login?"
+      linkText="Login here →"
+      linkUrl={loginUrl}
+      variant="reset-password">
       <Outlet />
     </AuthPage>
   );

--- a/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordReset.tsx
+++ b/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordReset.tsx
@@ -1,7 +1,6 @@
 import { SchemaForm } from "@lumeweb/portal-framework-ui";
 import { useForgotPassword } from "@refinedev/core";
 import React from "react";
-import { Link } from "react-router";
 
 import { ForgotPasswordRequest } from "../../../dataProviders/auth";
 import { getResetPasswordForm } from "../../forms/resetPassword";
@@ -10,19 +9,12 @@ function ResetPasswordForm() {
   const forgotPassword = useForgotPassword<ForgotPasswordRequest>();
 
   return (
-    <div className="w-full h-full p-4 sm:p-10 space-y-4 mt-12">
-      <p className="text-input-placeholder w-full text-left mb-10">
-        <Link
-          className="text-foreground text-md hover:underline hover:underline-offset-4"
-          to="/login">
-          ← Back to Login
-        </Link>
-      </p>
-      <div className="!mb-12 space-y-2">
+    <>
+      <div className="mb-12 space-y-2">
         <h2 className="text-3xl font-bold">Reset your password</h2>
       </div>
       <SchemaForm config={getResetPasswordForm(forgotPassword.mutate)} />
-    </div>
+    </>
   );
 }
 

--- a/libs/portal-framework-auth/src/ui/forms/register.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/register.tsx
@@ -10,7 +10,6 @@ import { schema } from "./register.schema";
 
 export const getRegisterForm = (
   onSubmit: (values: any) => Promise<void>,
-  loginUrl: string,
 ): FormConfig => ({
   actionButtons: [
     {
@@ -84,16 +83,6 @@ export const getRegisterForm = (
       id: "name",
     },
   ],
-  header: (
-    <>
-      <InlineAuthLinkBanner label="Already have an account?" to={loginUrl} />
-      <div className="mt-10">
-        <h3 className=" block  sm:hidden text-2xl text-foreground mb-10">
-          Create a New Account
-        </h3>
-      </div>
-    </>
-  ),
   layout: "vertical",
   onSubmit: onSubmit,
   validationSchema: schema,


### PR DESCRIPTION
- Added new props to AuthPage for flexible link banner configuration
- Consolidated link banner logic within AuthPage component
- Removed duplicate link banner code from login/register/reset pages
- Simplified form layouts by moving link banners to AuthPage
- Updated register form to remove hardcoded login link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline banner on auth pages to surface contextual links (e.g., “Sign up” on Login, “Log in” on Register, “Remember your login?” on Reset Password).
  * Banner displays responsively on mobile and desktop and is shown only when configured.

* **Style**
  * Simplified auth page layouts and headers; removed redundant mobile/desktop wrappers.
  * Reset Password flow refined: cleaner header spacing and navigation handled via the new banner instead of an inline link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->