### PR TITLE
refactor(portal-framework-auth, portal-framework-ui): refactor auth page components and styles

### DIFF
--- a/libs/portal-framework-auth/src/ui/components/common/AuthPage.tsx
+++ b/libs/portal-framework-auth/src/ui/components/common/AuthPage.tsx
@@ -37,21 +37,12 @@ export function AuthPage({
             "flex flex-col items-start justify-start bg-background w-full sm:max-w-md z-10 relative"
           }
           role="main">
-          <div className="sm:mt-20 p-5">
+          <div className="sm:mt-20 p-5 w-full">
             {showBanner && (
-              <div className="absolute inset-0 flex sm:hidden flex-col items-start justify-center gap-2 text-left p-4 mt-60 sm:mt-10">
+              <div className="flex flex-col gap-2 mb-10">
                 {beforeLink}
                 <InlineAuthLinkBanner
-                  label={linkLabel}
-                  linkLabel={linkText}
-                  to={linkUrl}
-                />
-              </div>
-            )}
-            {showBanner && (
-              <div className="hidden sm:flex flex-col items-start justify-center gap-2 text-left mb-10">
-                {beforeLink}
-                <InlineAuthLinkBanner
+                  className={"m-auto md:m-0"}
                   label={linkLabel}
                   linkLabel={linkText}
                   to={linkUrl}

--- a/libs/portal-framework-auth/src/ui/components/common/AuthPageTitle.tsx
+++ b/libs/portal-framework-auth/src/ui/components/common/AuthPageTitle.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@lumeweb/portal-framework-ui-core";
+import React, { ReactNode } from "react";
+
+interface AuthPageTitleProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function AuthPageTitle({ children, className }: AuthPageTitleProps) {
+  return (
+    <h2 className={cn("text-4xl sm:text-3xl font-bold mb-5 m-auto", className)}>
+      {children}
+    </h2>
+  );
+}

--- a/libs/portal-framework-auth/src/ui/components/login/LoginForm.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/LoginForm.tsx
@@ -28,7 +28,7 @@ export const LoginForm = () => {
   const formConfig = getLoginFormConfig(onSubmit);
 
   return (
-    <div className="w-full max-w-md">
+    <>
       <SchemaForm config={formConfig} />
       <p className="inline-block mt-4 text-input-placeholder">
         Forgot your password?{" "}
@@ -38,6 +38,6 @@ export const LoginForm = () => {
           Reset Password
         </Link>
       </p>
-    </div>
+    </>
   );
 };

--- a/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
@@ -6,6 +6,7 @@ import {
 import React from "react";
 
 import { AuthPage } from "@/ui/components/common/AuthPage";
+import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
 
 import { LoginForm } from "./LoginForm";
 import { SocialLogin } from "./SocialLogin";
@@ -16,9 +17,7 @@ function LoginIndex() {
 
   return (
     <AuthPage
-      beforeLink={
-        <h2 className="text-4xl sm:text-3xl font-bold mb-5">Welcome back</h2>
-      }
+      beforeLink={<AuthPageTitle>Welcome back 👋</AuthPageTitle>}
       linkLabel="New user?"
       linkText="Create an account →"
       linkUrl={registerUrl}

--- a/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
@@ -8,6 +8,7 @@ import React from "react";
 
 import { RegisterFormRequest } from "@/dataProviders/auth";
 import { AuthPage } from "@/ui/components/common/AuthPage";
+import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
 import { getRegisterForm } from "@/ui/forms/register";
 
 function RegisterIndex() {
@@ -27,6 +28,7 @@ function RegisterIndex() {
 
   return (
     <AuthPage
+      beforeLink={<AuthPageTitle>All Roads Lead to Lume 🎉</AuthPageTitle>}
       linkLabel="Already have an account?"
       linkText="Login here →"
       linkUrl={loginUrl}

--- a/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordConfirm.tsx
+++ b/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordConfirm.tsx
@@ -46,27 +46,15 @@ function ResetPasswordConfirm() {
   }
 
   return (
-    <div className="w-full h-full p-4 sm:p-10 space-y-4 mt-12">
-      <p className="text-input-placeholder w-full text-left mb-10">
-        <Link
-          className="text-foreground text-md hover:underline hover:underline-offset-4"
-          to="/login">
-          ← Back to Login
-        </Link>
-      </p>
-      <div className="!mb-12 space-y-2">
-        <h2 className="text-3xl font-bold">Reset your password</h2>
-      </div>
-      <SchemaForm
-        config={{
-          ...getResetPasswordConfirmForm(handleSubmit),
-          defaultValues: {
-            email,
-            token,
-          },
-        }}
-      />
-    </div>
+    <SchemaForm
+      config={{
+        ...getResetPasswordConfirmForm(handleSubmit),
+        defaultValues: {
+          email,
+          token,
+        },
+      }}
+    />
   );
 }
 export default ResetPasswordConfirm;

--- a/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordLayout.tsx
+++ b/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordLayout.tsx
@@ -1,15 +1,39 @@
 import { useLoginUrl, withTheme } from "@lumeweb/portal-framework-ui";
 import React from "react";
-import { Outlet } from "react-router";
+import { Outlet, useLocation, useMatches } from "react-router";
 
-import { AuthPage } from "../common/AuthPage";
+import { AuthPage } from "@/ui/components/common/AuthPage";
+import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
+
+const PAGE_CONFIG = {
+  "/reset-password": {
+    linkLabel: "Already have an account?",
+    linkText: "Login here →",
+    title: "Reset your Password",
+  },
+  "/reset-password/confirm": {
+    linkLabel: "Remember your password?",
+    linkText: "Back to login →",
+    title: "Confirm your password",
+  },
+};
 
 function ResetPasswordLayout() {
   const loginUrl = useLoginUrl();
+  const location = useLocation();
+  const matches = useMatches().filter(
+    (item) => item.pathname === location.pathname,
+  );
+
+  const currentPath = matches[0]?.pathname || "/reset-password";
+  const { linkLabel, linkText, title } =
+    PAGE_CONFIG[currentPath] || PAGE_CONFIG["/reset-password"];
+
   return (
     <AuthPage
-      linkLabel="Remember your login?"
-      linkText="Login here →"
+      beforeLink={<AuthPageTitle>{title}</AuthPageTitle>}
+      linkLabel={linkLabel}
+      linkText={linkText}
       linkUrl={loginUrl}
       variant="reset-password">
       <Outlet />

--- a/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordReset.tsx
+++ b/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordReset.tsx
@@ -8,14 +8,7 @@ import { getResetPasswordForm } from "../../forms/resetPassword";
 function ResetPasswordForm() {
   const forgotPassword = useForgotPassword<ForgotPasswordRequest>();
 
-  return (
-    <>
-      <div className="mb-12 space-y-2">
-        <h2 className="text-3xl font-bold">Reset your password</h2>
-      </div>
-      <SchemaForm config={getResetPasswordForm(forgotPassword.mutate)} />
-    </>
-  );
+  return <SchemaForm config={getResetPasswordForm(forgotPassword.mutate)} />;
 }
 
 export default ResetPasswordForm;

--- a/libs/portal-framework-auth/src/ui/forms/login.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/login.tsx
@@ -53,7 +53,7 @@ export const getLoginFormConfig = (
   ],
   footerClassName: false,
   // Update formClassName to match the target wrapper
-  formClassName: "w-full max-w-md",
+  formClassName: "w-full m-auto",
   onSubmit: (data) => {
     return login(data);
   },

--- a/libs/portal-framework-auth/src/ui/forms/register.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/register.tsx
@@ -1,10 +1,9 @@
 import {
+  ActionItemType,
   type FormConfig,
   FormFieldType,
   GroupOrder,
-  InlineAuthLinkBanner,
 } from "@lumeweb/portal-framework-ui";
-import { ActionItemType } from "@lumeweb/portal-framework-ui";
 
 import { schema } from "./register.schema";
 
@@ -75,7 +74,7 @@ export const getRegisterForm = (
     },
   ],
   footerClassName: "",
-  formClassName: "w-full max-w-md",
+  formClassName: "w-full m-auto",
   groupOrder: GroupOrder.GROUPS_FIRST,
   groups: [
     {

--- a/libs/portal-framework-auth/src/ui/forms/resetPassword.ts
+++ b/libs/portal-framework-auth/src/ui/forms/resetPassword.ts
@@ -9,7 +9,7 @@ export const getResetPasswordForm = (
   return {
     actionButtons: [
       {
-        label: "Reset Password",
+        label: "Continue",
         type: ActionItemType.SUBMIT,
       },
     ],

--- a/libs/portal-framework-auth/src/ui/forms/resetPasswordConfirm.ts
+++ b/libs/portal-framework-auth/src/ui/forms/resetPasswordConfirm.ts
@@ -7,6 +7,7 @@ export const getResetPasswordConfirmForm = (
   mutate: (values: { email: string; password: string; token: string }) => void,
 ): FormConfig => {
   return {
+    footerClassName: "",
     actionButtons: [
       {
         label: "Reset Password",
@@ -28,7 +29,7 @@ export const getResetPasswordConfirmForm = (
           readOnly: true,
           autoComplete: "off",
         },
-        label: "Reset Token", 
+        label: "Reset Token",
         name: "token",
         required: true,
         type: FormFieldType.PASSWORD,

--- a/libs/portal-framework-core/src/vite/plugin.ts
+++ b/libs/portal-framework-core/src/vite/plugin.ts
@@ -144,6 +144,7 @@ export function Config(opts: ConfigOptions) {
       ignoreOrigin: true,
       manifest: true,
       name,
+      publicPath: "auto",
       remotePlugin: isPlugin,
       runtimePlugins,
       shared: sharedModules,
@@ -251,7 +252,7 @@ export function Config(opts: ConfigOptions) {
   ].filter(Boolean);
 
   const viteConfig = defineConfig({
-    base: "",
+    base: "/",
     build: {
       ...(opts.type === "plugin"
         ? {

--- a/libs/portal-framework-ui/src/components/InlineAuthLinkBanner.tsx
+++ b/libs/portal-framework-ui/src/components/InlineAuthLinkBanner.tsx
@@ -1,22 +1,34 @@
+import { cn } from "@lumeweb/portal-framework-ui-core";
 import React from "react";
 import { Link } from "react-router";
 
 interface InlineAuthLinkBannerProps {
+  className?: string;
   label: string;
+  linkClassName?: string;
   linkLabel?: string;
   to: string;
 }
 
 function InlineAuthLinkBanner({
+  className,
   label,
+  linkClassName,
   linkLabel,
   to,
 }: InlineAuthLinkBannerProps) {
   return (
-    <p className="text-foreground text-sm w-fit flex items-center  gap-2 text-left bg-secondary p-3 rounded-lg">
+    <p
+      className={cn(
+        "text-foreground text-sm w-fit flex items-center gap-2 text-left bg-secondary p-3 rounded-lg",
+        className,
+      )}>
       <span className="text-foreground/80 whitespace-nowrap">{label}</span>
       <Link
-        className="text-foreground mx-auto whitespace-nowrap hover:underline hover:underline-offset-4"
+        className={cn(
+          "text-foreground mx-auto whitespace-nowrap hover:underline hover:underline-offset-4",
+          linkClassName,
+        )}
         to={to}>
         {linkLabel ?? "Login here →"}
       </Link>


### PR DESCRIPTION
- Created new AuthPageTitle component for consistent title styling
- Simplified auth page layouts and removed redundant elements
- Improved responsive styling for auth forms and banners
- Consolidated reset password layout configuration
- Updated form class names and container widths
- Added className props to InlineAuthLinkBanner
- Adjusted Vite base path configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Route-aware titles and link text on reset password pages.

- Improvements
  - Consistent page titles via a new title component across login/register/reset flows.
  - Streamlined banner rendering with better small/large-screen alignment.
  - Login and Register forms are now centered and full-width for improved readability.
  - Simplified reset-password screens by removing extra wrappers and headers.
  - Reset password primary action label updated to “Continue” for clearer guidance.

- Style
  - General layout and spacing refinements for a cleaner, more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->