### PR TITLE
feat(portal-framework-auth, portal-framework-ui): add autocomplete support to forms and fields

### DIFF
--- a/libs/portal-framework-auth/src/ui/forms/login.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/login.tsx
@@ -26,7 +26,8 @@ export const getLoginFormConfig = (
       labelClassName: "font-semibold text-sm text-secondary-foreground",
       name: "email",
       required: true,
-      type: FormFieldType.TEXT,
+      type: FormFieldType.EMAIL,
+      autocomplete: "username",
     },
     {
       inputClassName: "mt-4 bg-input border placeholder-input-placeholder",
@@ -35,6 +36,7 @@ export const getLoginFormConfig = (
       name: "password",
       required: true,
       type: FormFieldType.PASSWORD,
+      autocomplete: "current-password",
     },
     {
       itemClassName: "flex items-center space-x-2 text-foreground",

--- a/libs/portal-framework-auth/src/ui/forms/register.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/register.tsx
@@ -26,6 +26,7 @@ export const getRegisterForm = (
       label: "First Name",
       name: "firstName",
       type: FormFieldType.TEXT,
+      autocomplete: "given-name",
     },
     {
       className: "space-y-2",
@@ -35,24 +36,28 @@ export const getRegisterForm = (
       label: "Last Name",
       name: "lastName",
       type: FormFieldType.TEXT,
+      autocomplete: "family-name",
     },
     {
       inputClassName: "h-14",
       label: "Email",
       name: "email",
       type: FormFieldType.EMAIL,
+      autocomplete: "email",
     },
     {
       inputClassName: "h-14",
       label: "Password",
       name: "password",
       type: FormFieldType.PASSWORD,
+      autocomplete: "new-password",
     },
     {
       inputClassName: "h-14",
       label: "Confirm Password",
       name: "confirmPassword",
       type: FormFieldType.PASSWORD,
+      autocomplete: "new-password",
     },
     {
       label: (

--- a/libs/portal-framework-auth/src/ui/forms/resetPasswordConfirm.ts
+++ b/libs/portal-framework-auth/src/ui/forms/resetPasswordConfirm.ts
@@ -23,6 +23,7 @@ export const getResetPasswordConfirmForm = (
         name: "email",
         required: true,
         type: FormFieldType.TEXT,
+        autocomplete: "username",
       },
       {
         inputProps: {
@@ -39,12 +40,14 @@ export const getResetPasswordConfirmForm = (
         name: "password",
         required: true,
         type: FormFieldType.PASSWORD,
+        autocomplete: "new-password",
       },
       {
         label: "Confirm New Password",
         name: "confirmPassword",
         required: true,
         type: FormFieldType.PASSWORD,
+        autocomplete: "new-password",
       },
     ],
     layout: "vertical",

--- a/libs/portal-framework-ui/src/components/form/FormRenderer.tsx
+++ b/libs/portal-framework-ui/src/components/form/FormRenderer.tsx
@@ -18,6 +18,7 @@ import {
 
 import { adapters } from "./adapters";
 import { useFormContext } from "./context";
+import { getAutocompleteValue } from "./autocomplete";
 import { FormFieldType, getFormComponent } from "./fields";
 import { FormGroup } from "./FormGroup";
 import { type FormFieldConfig, type FormGroupType, GroupOrder } from "./types";
@@ -244,13 +245,19 @@ function FieldRenderer<TFieldValues extends FieldValues = FieldValues>({
             {RegisteredComponent ? (
               <RegisteredComponent
                 {...formFieldRenderProps}
+                {...field.inputProps}
                 inputClassName={field.inputClassName}
                 label={componentEntry?.handlesLabel ? field.label : undefined}
                 options={field.options}
                 placeholder={field.placeholder}
                 required={field.required}
                 type={field.type}
-                {...field.inputProps}
+                // Derive and include autocomplete
+                autocomplete={useMemo(() => {
+                  return field.autocomplete ?? // Explicit field config wins
+                    getAutocompleteValue(field, { formPurpose: config.action }) ?? // Then try derivation
+                    field.inputProps?.autocomplete // Finally, any inputProps value
+                }, [field.autocomplete, field.name, field.type, field.inputProps?.autocomplete, field.inputProps?.autoComplete, config.action])}
               />
             ) : field.component ? (
               <field.component {...formFieldRenderProps} />

--- a/libs/portal-framework-ui/src/components/form/autocomplete/index.ts
+++ b/libs/portal-framework-ui/src/components/form/autocomplete/index.ts
@@ -1,0 +1,2 @@
+export * from "./rules";
+export * from "./register";

--- a/libs/portal-framework-ui/src/components/form/autocomplete/register.ts
+++ b/libs/portal-framework-ui/src/components/form/autocomplete/register.ts
@@ -1,0 +1,295 @@
+import { FormFieldType } from "../fields";
+import { AutocompleteRule, registerAutocompleteRule } from "./rules";
+
+const defaultRules: AutocompleteRule[] = [
+  // Explicit value always wins
+  {
+    evaluate: (fieldConfig: any) => {
+      return fieldConfig.autocomplete;
+    },
+    name: "explicit",
+    priority: 0,
+  },
+
+  // Field type based rules
+  {
+    evaluate: (fieldConfig: any) => {
+      if (fieldConfig.type === FormFieldType.EMAIL) {
+        return "email";
+      }
+      return undefined;
+    },
+    name: "email-type",
+    priority: 10,
+  },
+
+  // Name pattern based rules
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name?.includes("email")) {
+        return "email";
+      }
+      return undefined;
+    },
+    name: "email-name",
+    priority: 20,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (
+        name &&
+        (name.includes("first") || name.includes("given")) &&
+        name.includes("name")
+      ) {
+        return "given-name";
+      }
+      return undefined;
+    },
+    name: "given-name",
+    priority: 30,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (
+        name &&
+        (name.includes("last") ||
+          name.includes("family") ||
+          name.includes("sur")) &&
+        name.includes("name")
+      ) {
+        return "family-name";
+      }
+      return undefined;
+    },
+    name: "family-name",
+    priority: 30,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("username") || name.includes("login"))) {
+        return "username";
+      }
+      return undefined;
+    },
+    name: "username",
+    priority: 40,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (
+        name &&
+        (name.includes("otp") ||
+          (name.includes("verification") && name.includes("code")) ||
+          name.includes("one-time-code") ||
+          name.includes("2fa") ||
+          name.includes("twofactor") ||
+          name.includes("two-factor"))
+      ) {
+        return "one-time-code";
+      }
+      return undefined;
+    },
+    name: "one-time-code",
+    priority: 45,
+  },
+
+  {
+    evaluate: (fieldConfig: any, context?: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (fieldConfig.type === FormFieldType.PASSWORD) {
+        if (name?.includes("current") && name.includes("password")) {
+          return "current-password";
+        }
+        if (name === "password" && context?.formPurpose === "login") {
+          return "current-password";
+        }
+        if (name === "password" && context?.formPurpose === "change-password") {
+          return "current-password";
+        }
+      }
+      return undefined;
+    },
+    name: "current-password",
+    priority: 50,
+  },
+
+  {
+    evaluate: (fieldConfig: any, context?: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (fieldConfig.type === FormFieldType.PASSWORD) {
+        if (name?.includes("new") && name.includes("password")) {
+          return "new-password";
+        }
+        if (name?.includes("confirm") && name.includes("password")) {
+          return "new-password";
+        }
+        if (
+          name === "password" &&
+          (context?.formPurpose === "register" ||
+            context?.formPurpose === "reset-password")
+        ) {
+          return "new-password";
+        }
+      }
+      return undefined;
+    },
+    name: "new-password",
+    priority: 50,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name) {
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("number")
+        ) {
+          return "cc-number";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          (name.includes("exp") || name.includes("expiration"))
+        ) {
+          return "cc-exp";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("month")
+        ) {
+          return "cc-exp-month";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("year")
+        ) {
+          return "cc-exp-year";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          (name.includes("csc") || name.includes("cvv"))
+        ) {
+          return "cc-csc";
+        }
+      }
+      return undefined;
+    },
+    name: "credit-card",
+    priority: 60,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name) {
+        // address line 2 before generic street-address
+        if (
+          name.includes("address2") ||
+          name.includes("address_2") ||
+          name.includes("address line 2") ||
+          name.includes("address-line2")
+        ) {
+          return "address-line2";
+        }
+        if (
+          name.includes("address1") ||
+          name.includes("address_1") ||
+          name.includes("address line 1") ||
+          name.includes("address-line1")
+        ) {
+          return "address-line1";
+        }
+        if (name.includes("address") && !name.includes("email")) {
+          return "street-address";
+        }
+        if (name.includes("city")) {
+          return "address-level2";
+        }
+        if (name.includes("state") || name.includes("province")) {
+          return "address-level1";
+        }
+        if (name.includes("zip") || name.includes("postal")) {
+          return "postal-code";
+        }
+        if (name.includes("country")) {
+          // Default to full country name unless explicitly a code
+          if (name.includes("code") || name.includes("iso")) {
+            return "country";
+          }
+          return "country-name";
+        }
+      }
+      return undefined;
+    },
+    name: "address",
+    priority: 70,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("phone") || name.includes("tel"))) {
+        return "tel";
+      }
+      return undefined;
+    },
+    name: "phone",
+    priority: 80,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("bday") || name.includes("birth"))) {
+        return "bday";
+      }
+      return undefined;
+    },
+    name: "birthday",
+    priority: 90,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("sex") || name.includes("gender"))) {
+        return "sex";
+      }
+      return undefined;
+    },
+    name: "gender",
+    priority: 100,
+  },
+
+  {
+    evaluate: (fieldConfig: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("url") || name.includes("website"))) {
+        return "url";
+      }
+      return undefined;
+    },
+    name: "url",
+    priority: 110,
+  },
+];
+
+export function getDefaultAutocompleteRules(): AutocompleteRule[] {
+  return [...defaultRules];
+}
+
+export function registerDefaultRules(): void {
+  // Register all default rules
+  defaultRules.forEach((rule) => {
+    registerAutocompleteRule(rule);
+  });
+}

--- a/libs/portal-framework-ui/src/components/form/autocomplete/rules.spec.ts
+++ b/libs/portal-framework-ui/src/components/form/autocomplete/rules.spec.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FormFieldType } from "../fields";
+import { FormFieldConfig } from "../types";
+import {
+  getAutocompleteValue,
+  registerAutocompleteRule,
+  unregisterAutocompleteRule,
+} from "./rules";
+
+const TEST_RULE_NAME = "test-rule-to-remove";
+
+describe("Autocomplete Rules", () => {
+  // Clean up any registered rules after each test
+  afterEach(() => {
+    unregisterAutocompleteRule(TEST_RULE_NAME);
+  });
+
+  describe("getAutocompleteValue", () => {
+    it("should return explicit autocomplete value if set", () => {
+      const fieldConfig = {
+        autocomplete: "custom-value",
+        name: "test",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("custom-value");
+    });
+
+    it("should derive email from email field type", () => {
+      const fieldConfig = {
+        name: "emailAddress",
+        type: FormFieldType.EMAIL,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("email");
+    });
+
+    it("should derive email from field name containing email", () => {
+      const fieldConfig = {
+        name: "userEmail",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("email");
+    });
+
+    it("should derive given-name from first name field", () => {
+      const fieldConfig = {
+        name: "firstName",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("given-name");
+    });
+
+    it("should derive family-name from last name field", () => {
+      const fieldConfig = {
+        name: "lastName",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("family-name");
+    });
+
+    it("should derive username from username field", () => {
+      const fieldConfig = {
+        name: "username",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("username");
+    });
+
+    it("should derive current-password from password field with current in name", () => {
+      const fieldConfig = {
+        name: "currentPassword",
+        type: FormFieldType.PASSWORD,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("current-password");
+    });
+
+    it("should derive new-password from password field with new in name", () => {
+      const fieldConfig = {
+        name: "newPassword",
+        type: FormFieldType.PASSWORD,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("new-password");
+    });
+
+    it("should derive new-password from password field with confirm in name", () => {
+      const fieldConfig = {
+        name: "confirmPassword",
+        type: FormFieldType.PASSWORD,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("new-password");
+    });
+
+    it("should derive current-password from password field in login context", () => {
+      const fieldConfig = {
+        name: "password",
+        type: FormFieldType.PASSWORD,
+      };
+      const context = {
+        formPurpose: "login",
+      };
+
+      expect(getAutocompleteValue(fieldConfig, context)).toBe(
+        "current-password",
+      );
+    });
+
+    it("should derive new-password from password field in register context", () => {
+      const fieldConfig = {
+        name: "password",
+        type: FormFieldType.PASSWORD,
+      };
+      const context = {
+        formPurpose: "register",
+      };
+
+      expect(getAutocompleteValue(fieldConfig, context)).toBe("new-password");
+    });
+
+    it("should derive credit card number", () => {
+      const fieldConfig = {
+        name: "ccNumber",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("cc-number");
+    });
+
+    it("should derive credit card expiration", () => {
+      const fieldConfig = {
+        name: "ccExpiration",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("cc-exp");
+    });
+
+    it("should derive credit card CSC", () => {
+      const fieldConfig = {
+        name: "ccCsc",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("cc-csc");
+    });
+
+    it("should derive address fields", () => {
+      expect(
+        getAutocompleteValue({
+          name: "streetAddress",
+          type: FormFieldType.TEXT,
+        }),
+      ).toBe("street-address");
+      expect(
+        getAutocompleteValue({ name: "city", type: FormFieldType.TEXT }),
+      ).toBe("address-level2");
+      expect(
+        getAutocompleteValue({ name: "state", type: FormFieldType.TEXT }),
+      ).toBe("address-level1");
+      expect(
+        getAutocompleteValue({ name: "zipCode", type: FormFieldType.TEXT }),
+      ).toBe("postal-code");
+      expect(
+        getAutocompleteValue({ name: "country", type: FormFieldType.TEXT }),
+      ).toBe("country-name");
+      expect(
+        getAutocompleteValue({
+          name: "country-name",
+          type: FormFieldType.TEXT,
+        }),
+      ).toBe("country-name");
+    });
+
+    it("should derive phone number", () => {
+      const fieldConfig = {
+        name: "phoneNumber",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("tel");
+    });
+
+    it("should derive birthday", () => {
+      const fieldConfig = {
+        name: "birthDate",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("bday");
+    });
+
+    it("should derive gender", () => {
+      const fieldConfig = {
+        name: "gender",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("sex");
+    });
+
+    it("should derive URL", () => {
+      const fieldConfig = {
+        name: "website",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("url");
+    });
+
+    it("should return undefined for unknown fields", () => {
+      const fieldConfig = {
+        name: "unknownField",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBeUndefined();
+    });
+  });
+
+  describe("registerAutocompleteRule", () => {
+    const testRule = {
+      evaluate: vi.fn(() => "test-value"),
+      name: TEST_RULE_NAME,
+      priority: 1000,
+    };
+
+    beforeEach(() => {
+      // Clear any existing test rules
+      unregisterAutocompleteRule(TEST_RULE_NAME);
+    });
+
+    afterEach(() => {
+      // Clean up after each test
+      unregisterAutocompleteRule(TEST_RULE_NAME);
+    });
+
+    it("should register a new rule", () => {
+      registerAutocompleteRule(testRule);
+
+      const fieldConfig = {
+        name: "test",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("test-value");
+      expect(testRule.evaluate).toHaveBeenCalledWith(fieldConfig, undefined);
+    });
+
+    it("should replace an existing rule with the same name", () => {
+      const newRule = {
+        evaluate: vi.fn(() => "new-value"),
+        name: TEST_RULE_NAME,
+        priority: 1000,
+      };
+
+      registerAutocompleteRule(testRule);
+      registerAutocompleteRule(newRule);
+
+      const fieldConfig = {
+        name: "test",
+        type: FormFieldType.TEXT,
+      };
+
+      expect(getAutocompleteValue(fieldConfig)).toBe("new-value");
+      expect(newRule.evaluate).toHaveBeenCalledWith(fieldConfig, undefined);
+    });
+  });
+
+  describe("unregisterAutocompleteRule", () => {
+    const testRule = {
+      evaluate: (fieldConfig: FormFieldConfig) => {
+        if (fieldConfig.name === TEST_RULE_NAME) {
+          return "new-value";
+        }
+        return undefined;
+      },
+      name: TEST_RULE_NAME,
+      priority: 1000,
+    };
+
+    beforeEach(() => {
+      registerAutocompleteRule(testRule);
+    });
+
+    it("should remove a registered rule", () => {
+      const fieldConfig = {
+        name: TEST_RULE_NAME,
+        type: FormFieldType.TEXT,
+      };
+
+      // First verify the rule matches and returns the expected value
+      expect(getAutocompleteValue(fieldConfig)).toBe("new-value");
+
+      // Now unregister it
+      unregisterAutocompleteRule(TEST_RULE_NAME);
+
+      // Should not use the removed rule and return undefined
+      expect(getAutocompleteValue(fieldConfig)).toBeUndefined();
+    });
+  });
+});

--- a/libs/portal-framework-ui/src/components/form/autocomplete/rules.ts
+++ b/libs/portal-framework-ui/src/components/form/autocomplete/rules.ts
@@ -1,0 +1,382 @@
+import { FormFieldType, FormFieldConfig, AutocompleteToken } from "../types";
+import { registerDefaultRules } from "./register";
+
+export interface AutocompleteRule {
+  evaluate: (fieldConfig: FormFieldConfig, context?: any) => AutocompleteToken | undefined;
+  name: string;
+  priority: number;
+}
+
+let autocompleteRules: AutocompleteRule[] = [
+  // Explicit value always wins
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      return fieldConfig.autocomplete;
+    },
+    name: "explicit",
+    priority: 0,
+  },
+
+  // Field type based rules
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      if (fieldConfig.type === FormFieldType.EMAIL) {
+        return "email";
+      }
+      return undefined;
+    },
+    name: "email-type",
+    priority: 10,
+  },
+
+  // Name pattern based rules
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name?.includes("email")) {
+        return "email";
+      }
+      return undefined;
+    },
+    name: "email-name",
+    priority: 20,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (
+        name &&
+        (name.includes("first") || name.includes("given")) &&
+        name.includes("name")
+      ) {
+        return "given-name";
+      }
+      return undefined;
+    },
+    name: "given-name",
+    priority: 30,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (
+        name &&
+        (name.includes("last") ||
+          name.includes("family") ||
+          name.includes("sur")) &&
+        name.includes("name")
+      ) {
+        return "family-name";
+      }
+      return undefined;
+    },
+    name: "family-name",
+    priority: 31,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("username") || name.includes("login"))) {
+        return "username";
+      }
+      return undefined;
+    },
+    name: "username",
+    priority: 40,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (
+        name &&
+        (name.includes("otp") ||
+          (name.includes("verification") && name.includes("code")) ||
+          name.includes("one-time-code") ||
+          name.includes("2fa") ||
+          name.includes("mfa") ||
+          name.includes("totp") ||
+          name.includes("twofactor") ||
+          name.includes("two-factor") ||
+          name.includes("two factor"))
+      ) {
+        return "one-time-code";
+      }
+      return undefined;
+    },
+    name: "one-time-code",
+    priority: 45,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig, context?: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (fieldConfig.type === FormFieldType.PASSWORD) {
+        if (name?.includes("current") && name.includes("password")) {
+          return "current-password";
+        }
+        if (name === "password" && context?.formPurpose === "login") {
+          return "current-password";
+        }
+        if (name === "password" && context?.formPurpose === "change-password") {
+          return "current-password";
+        }
+      }
+      return undefined;
+    },
+    name: "current-password",
+    priority: 51,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig, context?: any) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (fieldConfig.type === FormFieldType.PASSWORD) {
+        if (name?.includes("new") && name.includes("password")) {
+          return "new-password";
+        }
+        if (name?.includes("confirm") && name.includes("password")) {
+          return "new-password";
+        }
+        if (
+          name === "password" &&
+          (context?.formPurpose === "register" ||
+            context?.formPurpose === "reset-password")
+        ) {
+          return "new-password";
+        }
+      }
+      return undefined;
+    },
+    name: "new-password",
+    priority: 49,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name) {
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("name")
+        ) {
+          return "cc-name";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("number")
+        ) {
+          return "cc-number";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("month")
+        ) {
+          return "cc-exp-month";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          name.includes("year")
+        ) {
+          return "cc-exp-year";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          (name.includes("exp") || name.includes("expiration"))
+        ) {
+          return "cc-exp";
+        }
+        if (
+          (name.includes("cc") || name.includes("card")) &&
+          (name.includes("csc") || name.includes("cvv") || name.includes("cvc") || name.includes("cvn"))
+        ) {
+          return "cc-csc";
+        }
+      }
+      return undefined;
+    },
+    name: "credit-card",
+    priority: 60,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name) {
+        // address line 2 before generic street-address
+        if (
+          name.includes("address2") ||
+          name.includes("address_2") ||
+          name.includes("address line 2") ||
+          name.includes("address-line2")
+        ) {
+          return "address-line2";
+        }
+        if (
+          name.includes("address1") ||
+          name.includes("address_1") ||
+          name.includes("address line 1") ||
+          name.includes("address-line1")
+        ) {
+          return "address-line1";
+        }
+        if (name.includes("address") && !name.includes("email")) {
+          return "street-address";
+        }
+        if (name.includes("city")) {
+          return "address-level2";
+        }
+        if (name.includes("state") || name.includes("province") || name.includes("region")) {
+          return "address-level1";
+        }
+        if (name.includes("zip") || name.includes("postal") || name.includes("postcode")) {
+          return "postal-code";
+        }
+        if (name.includes("country")) {
+          // Default to full country name unless explicitly a code
+          if (name.includes("code") || name.includes("iso")) {
+            return "country";
+          }
+          return "country-name";
+        }
+      }
+      return undefined;
+    },
+    name: "address",
+    priority: 70,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("phone") || name.includes("tel") || name.includes("mobile") || name.includes("cell"))) {
+        return "tel";
+      }
+      return undefined;
+    },
+    name: "phone",
+    priority: 80,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("bday") || name.includes("birth") || name.includes("dob"))) {
+        return "bday";
+      }
+      return undefined;
+    },
+    name: "birthday",
+    priority: 90,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("company") || name.includes("organization") || name.includes("organisation"))) {
+        return "organization";
+      }
+      return undefined;
+    },
+    name: "organization",
+    priority: 85,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name === "name" || name.includes("full") && name.includes("name"))) {
+        return "name";
+      }
+      return undefined;
+    },
+    name: "full-name",
+    priority: 32,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("sex") || name.includes("gender"))) {
+        return "sex";
+      }
+      return undefined;
+    },
+    name: "gender",
+    priority: 100,
+  },
+
+  {
+    evaluate: (fieldConfig: FormFieldConfig) => {
+      const name = fieldConfig.name?.toString().toLowerCase();
+      if (name && (name.includes("url") || name.includes("website"))) {
+        return "url";
+      }
+      return undefined;
+    },
+    name: "url",
+    priority: 110,
+  },
+];
+
+// Keep a sorted copy for efficient lookups
+let sortedRules = [...autocompleteRules].sort(
+  (a, b) => a.priority - b.priority,
+);
+
+export function getAutocompleteValue(
+  fieldConfig: FormFieldConfig,
+  context?: any,
+): AutocompleteToken | undefined {
+  // Use the pre-sorted rules for better performance
+  for (const rule of sortedRules) {
+    const result = rule.evaluate(fieldConfig, context);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
+  // No rule matched
+  return undefined;
+}
+
+export function getRegisteredAutocompleteRules(): ReadonlyArray<AutocompleteRule> {
+  return sortedRules;
+}
+
+export function registerAutocompleteRule(rule: AutocompleteRule): void {
+  // Check if rule with same name already exists
+  const existingIndex = autocompleteRules.findIndex(
+    (r) => r.name === rule.name,
+  );
+  let newRules: AutocompleteRule[];
+
+  if (existingIndex >= 0) {
+    // Replace existing rule
+    newRules = [...autocompleteRules];
+    newRules[existingIndex] = rule;
+  } else {
+    // Add new rule
+    newRules = [...autocompleteRules, rule];
+  }
+
+  // Update both arrays immutably
+  autocompleteRules = newRules;
+  sortedRules = [...newRules].sort((a, b) => a.priority - b.priority);
+}
+
+export function unregisterAutocompleteRule(name: string): void {
+  const newRules = autocompleteRules.filter((r) => r.name !== name);
+
+  // Only update if something actually changed
+  if (newRules.length !== autocompleteRules.length) {
+    autocompleteRules = newRules;
+    sortedRules = [...newRules].sort((a, b) => a.priority - b.priority);
+  }
+}
+
+// Initialize with default rules
+registerDefaultRules();

--- a/libs/portal-framework-ui/src/components/form/fields/Checkbox.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Checkbox.tsx
@@ -17,10 +17,11 @@ interface CheckboxProps {
   onBlur?: () => void;
   onChange?: (checked: boolean) => void;
   value?: boolean;
+  autocomplete?: string;
 }
 
 export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
-  ({ label, ...props }, ref) => {
+  ({ label, autocomplete, ...props }, ref) => {
     return (
       <>
         <BaseCheckbox
@@ -31,6 +32,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
           onBlur={props.onBlur}
           onCheckedChange={props.onChange}
           ref={ref}
+          autoComplete={autocomplete}
         />
         {label && (
           <Label

--- a/libs/portal-framework-ui/src/components/form/fields/DatePicker.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/DatePicker.tsx
@@ -11,10 +11,11 @@ interface DatePickerProps {
   onBlur?: () => void;
   onChange: (date: Date | undefined) => void;
   placeholder?: string;
+  autocomplete?: React.InputHTMLAttributes<HTMLInputElement>["autoComplete"];
 }
 
 export const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>(
-  ({ ...props }, ref) => {
+  ({ autocomplete, ...props }, ref) => {
     return (
       <BaseDatePicker
         className="border-modal-input placeholder-modal-input placeholder:text-foreground/50 p-4"
@@ -24,6 +25,7 @@ export const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>(
         placeholder={props.placeholder}
         ref={ref}
         setDate={props.onChange}
+        {...(autocomplete ? { autoComplete: autocomplete } : {})}
       />
     );
   },

--- a/libs/portal-framework-ui/src/components/form/fields/EmailInput.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/EmailInput.tsx
@@ -9,11 +9,12 @@ interface EmailInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   inputClassName?: string;
   label?: string;
   placeholder?: string;
+  autocomplete?: string;
 }
 
 export const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
-  (props, ref) => {
-    return <Input ref={ref} type="email" {...props} />;
+  ({ autocomplete, ...props }, ref) => {
+    return <Input ref={ref} type="email" autoComplete={autocomplete} {...props} />;
   },
 );
 EmailInput.displayName = "EmailInput";

--- a/libs/portal-framework-ui/src/components/form/fields/FileInput.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/FileInput.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { registerFormComponent } from ".";
 import { FormFieldType } from "../";
+import type { AutocompleteToken } from "../types";
 
 interface FileInputProps {
   disabled?: boolean;
@@ -10,12 +11,12 @@ interface FileInputProps {
   name: string;
   onBlur?: () => void;
   onChange?: (files: FileList | null) => void;
-  ref?: React.Ref<HTMLInputElement>;
   value?: FileList;
+  autocomplete?: AutocompleteToken;
 }
 
 export const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
-  ({ ...props }, ref) => {
+  ({ autocomplete, ...props }, ref) => {
     return (
       <Input
         disabled={props.disabled}
@@ -24,6 +25,7 @@ export const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
         onChange={(e) => props.onChange?.(e.target.files)}
         ref={ref}
         type="file"
+        autoComplete={autocomplete}
       />
     );
   },

--- a/libs/portal-framework-ui/src/components/form/fields/Input.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Input.tsx
@@ -9,12 +9,13 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   inputClassName?: string; // Use inputClassName for the actual input element
   label?: string;
   placeholder?: string;
+  autocomplete?: string;
   // onChange is included via React.InputHTMLAttributes
   // value is included via React.InputHTMLAttributes
 }
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ inputClassName, onChange, placeholder, type, value, ...props }, ref) => {
+  ({ inputClassName, onChange, placeholder, type, value, autocomplete, autoComplete: htmlAutoComplete, ...props }, ref) => {
     return (
       <BaseInput
         className={cn("border-none bg-input h-14", inputClassName)}
@@ -23,6 +24,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref={ref}
         type={type}
         value={value ?? ""} // Use value prop directly, default to empty string
+        autoComplete={autocomplete ?? htmlAutoComplete}
         {...props}
       />
     );

--- a/libs/portal-framework-ui/src/components/form/fields/RadioGroup.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/RadioGroup.tsx
@@ -16,6 +16,7 @@ interface RadioGroupProps {
   onChange?: (value: string) => void;
   options: string[];
   value?: string;
+  autocomplete?: string;
 }
 
 function slugify(str: string): string {
@@ -26,7 +27,7 @@ function slugify(str: string): string {
 }
 
 export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
-  ({ options, ...props }, ref) => {
+  ({ options, autocomplete, ...props }, ref) => {
     return (
       <BaseRadioGroup
         disabled={props.disabled}
@@ -37,7 +38,11 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
         value={props.value}>
         {options.map((option) => (
           <div className="radio-option" key={option}>
-            <RadioGroupItem id={`${props.name}-${slugify(option)}`} value={option} />
+            <RadioGroupItem 
+              id={`${props.name}-${slugify(option)}`} 
+              value={option}
+              {...(autocomplete ? { autoComplete: autocomplete } : {})}
+            />
             <label className={props.labelClassName} htmlFor={`${props.name}-${slugify(option)}`}>
               {option}
             </label>

--- a/libs/portal-framework-ui/src/components/form/fields/RichText.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/RichText.tsx
@@ -9,11 +9,12 @@ import { FormComponentProps } from "./types";
 interface RichTextProps extends FormComponentProps {
   enablePreview?: boolean;
   toolbarOptions?: ToolbarOption[];
+  autocomplete?: string;
 }
 
 export const RichText = forwardRef<HTMLDivElement, RichTextProps>(
   (
-    { enablePreview, onChange, placeholder, required, toolbarOptions, value },
+    { enablePreview, onChange, placeholder, required, toolbarOptions, value, autocomplete },
     ref,
   ) => {
     return (
@@ -25,6 +26,7 @@ export const RichText = forwardRef<HTMLDivElement, RichTextProps>(
         required={required}
         toolbarOptions={toolbarOptions}
         value={value}
+        {...(autocomplete ? { autoComplete: autocomplete } : {})}
       />
     );
   },

--- a/libs/portal-framework-ui/src/components/form/fields/Select.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Select.tsx
@@ -21,6 +21,7 @@ export const Select = React.forwardRef<
     label?: string;
     options: FormFieldOption[];
     placeholder?: string;
+    autocomplete?: string;
   }
 >(
   (
@@ -31,6 +32,7 @@ export const Select = React.forwardRef<
       placeholder = "Select...",
       required,
       value,
+      autocomplete,
       ...props
     },
     ref,
@@ -40,6 +42,7 @@ export const Select = React.forwardRef<
         onValueChange={onChange}
         required={required}
         value={value || ""}
+        {...(autocomplete ? { autoComplete: autocomplete } : {})}
         {...props}>
         <SelectTrigger
           className={cn(

--- a/libs/portal-framework-ui/src/components/form/fields/Switch.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Switch.tsx
@@ -16,10 +16,11 @@ interface SwitchProps {
   onBlur?: () => void;
   onChange?: (checked: boolean) => void;
   value?: boolean;
+  autocomplete?: string;
 }
 
 export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ label, ...props }, ref) => {
+  ({ label, autocomplete, ...props }, ref) => {
     return (
       <>
         <BaseSwitch
@@ -30,6 +31,7 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
           onBlur={props.onBlur}
           onCheckedChange={props.onChange}
           ref={ref}
+          {...(autocomplete ? { autoComplete: autocomplete } : {})}
         />
         {label && (
           <Label

--- a/libs/portal-framework-ui/src/components/form/fields/Textarea.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Textarea.tsx
@@ -15,8 +15,9 @@ export const Textarea = React.forwardRef<
     inputClassName?: string; // Use inputClassName for the actual textarea element
     label?: string;
     placeholder?: string;
+    autocomplete?: string;
   }
->(({ inputClassName, onChange, placeholder, value, ...props }, ref) => {
+>(({ inputClassName, onChange, placeholder, value, autocomplete, autoComplete: htmlAutoComplete, ...props }, ref) => {
   return (
     <BaseTextarea
       className={cn(
@@ -27,6 +28,7 @@ export const Textarea = React.forwardRef<
       placeholder={placeholder}
       ref={ref}
       value={value ?? ""} // Use value prop directly, default to empty string
+      autoComplete={autocomplete ?? htmlAutoComplete}
       {...props}
     />
   );

--- a/libs/portal-framework-ui/src/components/form/fields/types.ts
+++ b/libs/portal-framework-ui/src/components/form/fields/types.ts
@@ -32,4 +32,5 @@ export interface FormComponentProps {
   options?: FormFieldOption[];
   placeholder?: string;
   required?: boolean;
+  autocomplete?: string;
 }

--- a/libs/portal-framework-ui/src/components/form/types.ts
+++ b/libs/portal-framework-ui/src/components/form/types.ts
@@ -25,6 +25,17 @@ export enum GroupOrder {
 
 export type FormAutosaveConfig<T> = AutoSaveProps<T>["autoSave"];
 
+export type AutocompleteToken =
+  | "on"
+  | "off"
+  | "username"
+  | "email"
+  | "current-password"
+  | "new-password"
+  | "one-time-code"
+  | "given-name"
+  | "family-name";
+
 export interface FormConfig<
   TRequest extends BaseRecord = any,
   TResponse extends BaseRecord = any,
@@ -137,6 +148,11 @@ export interface FormFieldConfig<TRequest extends BaseRecord = any> {
   options?: FormFieldOption[];
   placeholder?: string;
   required?: boolean;
+  /**
+   * The HTML autocomplete attribute value for the field.
+   * If provided, it will be passed to the underlying input component.
+   */
+  autocomplete?: AutocompleteToken;
   /**
    * Declaratively define dependencies for field visibility.
    * The field will only be shown if *all* conditions in this object are met.


### PR DESCRIPTION
- Added autocomplete attribute support to login, register, and reset password forms in portal-framework-auth
- Implemented autocomplete value derivation rules based on field names and types
- Added autocomplete prop to all form field components (Input, Select, Checkbox, etc.) in portal-framework-ui
- Created autocomplete rules engine with priority-based evaluation
- Updated OTP type imports and references
- Refactored account provider custom method to handle subscription/otp/usage/key operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Broad browser autofill support added to login, register, and password-reset forms; fields now include autocomplete hints and inputs forward autocomplete to underlying controls.

- **Public API**
  - New AutocompleteToken type and autocomplete property added to form field configs and many form input components; runtime resolution uses precedence (explicit → inferred → input props) with memoization.

- **Tests**
  - Comprehensive tests for inference, priority, registration, override, and unregistration of autocomplete rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->