### PR TITLE
fix(portal-framework-ui): add explicit JSX.Element return type to Loading component

### DIFF
--- a/libs/portal-framework-ui/src/components/Loading.tsx
+++ b/libs/portal-framework-ui/src/components/Loading.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes, ReactNode } from "react";
 
 function Loading(
   { className, children, ...rest }: HTMLAttributes<HTMLDivElement> & { children?: ReactNode }
-) {
+): JSX.Element {
   return (
     <div
       {...rest}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Internal type annotation update for the loading UI component. This change standardizes the return type and aligns with stricter typing across the codebase.
  - No impact on functionality, visuals, performance, or accessibility. Users should experience identical behavior.
  - No configuration or action required.
  - Included as part of routine code quality maintenance only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->