### PR TITLE
fix(portal-plugin-dashboard): safely handle CID object format in operations UI, as future proofing

### DIFF
--- a/libs/portal-plugin-dashboard/src/ui/routes/operations.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/operations.tsx
@@ -102,7 +102,17 @@ const OperationsContent = () => {
     }),
     columnHelper.accessor("cid", {
       cell: (info) => {
-        const cid = info.getValue();
+        const cidValue = info.getValue();
+        
+        // Handle CID object format { "/": "bafy..." } or string
+        const getSafeCidString = (cid: any): string | undefined => {
+          if (typeof cid === 'string') return cid;
+          if (cid && typeof cid === 'object' && cid['/']) return cid['/'];
+          return undefined;
+        };
+
+        const cid = getSafeCidString(cidValue);
+        
         if (!cid) {
           return <span className="text-gray-500">-</span>;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CIDs in the Operations dashboard now display correctly whether provided as plain strings or object-formatted values.
  * When a CID is missing or invalid, the cell shows a dash instead of appearing empty or causing errors.
  * Preserves the ability to copy the CID when available, improving reliability and consistency in CID handling across varied data inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->