### PR TITLE
fix(portal-framework-ui): move mobile column hiding logic to top level and update toolbar renderer

### DIFF
--- a/libs/portal-framework-ui/src/components/data-table/DefaultTableLayout.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/DefaultTableLayout.tsx
@@ -45,6 +45,12 @@ function DefaultTableLayout<TData extends BaseRecord>({
   const getTableRowProps = useTableRowHandlers({ onRowClick, getRowProps });
   const getTableCellProps = useTableCellHandlers({ getCellProps });
   const getTableHeaderCellProps = useTableHeaderCellHandlers();
+  
+  // Get hidden columns at top level to avoid hooks violation
+  const hiddenColumns = useMobileColumnHiding({
+    responsive,
+    hideColumnsOnMobile,
+  });
 
   // Normalize table options
   const normalizedOptions = useMemo(
@@ -66,25 +72,6 @@ function DefaultTableLayout<TData extends BaseRecord>({
       table,
     ]
   );
-
-  // Compute hidden columns once to avoid calling hook inside loops
-  const hiddenColumns = useMemo(() => {
-    const hiddenSet = new Set<string>();
-    if (responsive) {
-      table.getAllLeafColumns().forEach((column) => {
-        if (
-          useMobileColumnHiding({
-            responsive,
-            hideColumnsOnMobile,
-            columnId: column.id,
-          })
-        ) {
-          hiddenSet.add(column.id);
-        }
-      });
-    }
-    return hiddenSet;
-  }, [table, responsive, hideColumnsOnMobile]);
 
   return (
     <div className={className}>

--- a/libs/portal-framework-ui/src/components/data-table/ToolbarRenderer.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/ToolbarRenderer.tsx
@@ -26,7 +26,7 @@ type ToolbarItemRenderer<TData extends BaseRecord> = (
 const toolbarItemRenderers = new Map<string, ToolbarItemRenderer<any>>();
 
 // Define core supported breakpoints
-const coreSupported = new Set(["xs", "sm", "md", "lg", "xl", "2xl"]);
+const coreSupported = new Set(["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl", "5xl", "6xl", "7xl", "auto", "full"]);
 
 // Internal renderer components
 function ActionItemRenderer<TData extends BaseRecord>(

--- a/libs/portal-framework-ui/src/components/data-table/ToolbarRenderer.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/ToolbarRenderer.tsx
@@ -9,14 +9,13 @@ import {
   ToolbarCustomItem,
   ToolbarFilterGroupItem,
   ToolbarFilterItem,
-  ToolbarItem,
   ToolbarItemComponentProps,
+  ToolbarItemType,
 } from "./DataTable.types";
-import { ToolbarItemType } from "./DataTable.types";
 import { BaseRecord } from "@refinedev/core";
 import { getAction } from "./ToolbarRegistry";
 import { useMobileDetection } from "./useMobileDetection";
-import { ComponentSize } from "@lumeweb/portal-framework-ui-core";
+import { ComponentSize } from "@/components";
 
 // Registry for toolbar item renderers
 type ToolbarItemRenderer<TData extends BaseRecord> = (
@@ -166,10 +165,12 @@ function ToolbarRenderer<TData extends BaseRecord>({
 }: ToolbarRendererProps<TData>) {
   // Validate mobileBreakpoint value
   const mobileBreakpoint = commonProps.context?.toolbarConfig?.mobileBreakpoint;
-  const candidate = Object.values(ComponentSize).includes(mobileBreakpoint as ComponentSize)
-    ? mobileBreakpoint
-    : mobileBreakpoint;
-  
+  const candidate =
+    mobileBreakpoint &&
+    Object.values(ComponentSize).includes(mobileBreakpoint as ComponentSize)
+      ? mobileBreakpoint
+      : ComponentSize.SM;
+
   const breakpointName =
     typeof candidate === "string" && !coreSupported.has(candidate)
       ? ComponentSize.SM
@@ -177,7 +178,7 @@ function ToolbarRenderer<TData extends BaseRecord>({
 
   // Check if we're on mobile to adjust button sizing
   const { isMobile } = useMobileDetection({
-    breakpoint: breakpointName || ComponentSize.SM,
+    mobileBreakpoint: breakpointName || ComponentSize.SM,
   });
 
   const containerClassName = cn(


### PR DESCRIPTION
- Extracted `useMobileColumnHiding` hook call outside of loop in `DefaultTableLayout.tsx` to prevent hooks violation
- Removed redundant `useMemo` wrapper for hidden columns computation
- Updated import paths and logic in `ToolbarRenderer.tsx` for better consistency
- Adjusted mobile breakpoint handling to default to `ComponentSize.SM` when invalid or missing
- Fixed prop name from `breakpoint` to `mobileBreakpoint` in `useMobileDetection` hook call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Data table toolbar now correctly respects the configured mobile breakpoint, improving responsiveness on small screens.
  * Hidden columns are applied consistently across headers and cells on mobile, preventing layout glitches.

* **Refactor**
  * Streamlined mobile column-hiding logic for more predictable behavior and improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->