### PR TITLE
feat(portal-plugin-ipfs): replace file with stream to enable large file uploads

### DIFF
--- a/libs/portal-plugin-dashboard/src/features/upload/Manager.ts
+++ b/libs/portal-plugin-dashboard/src/features/upload/Manager.ts
@@ -227,6 +227,10 @@ export class Manager implements IUploadManager {
     return this.#uploadErrors;
   }
 
+  public getUploadLimit(): number | null {
+    return this.#uploadLimit;
+  }
+
   public getUploadProgress(): number {
     const files = this.#uppy.getFiles();
 
@@ -325,6 +329,7 @@ export class Manager implements IUploadManager {
     this.#uppy.use<any>(plugin.module as any, {
       ...plugin.options,
       id: plugin.name,
+      uploadManager: this, // Pass upload manager instance
     });
   }
 

--- a/libs/portal-plugin-dashboard/src/ui/forms/uploadWizard.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/uploadWizard.tsx
@@ -287,6 +287,18 @@ const ProgressComponent = ({
       handleProgress,
     );
 
+    // Add preprocess progress listener
+    const cleanupPreprocessProgress = uploadManager?.on(
+      "preprocess-progress",
+      handleProgress,
+    );
+
+    // Add preprocess complete listener
+    const cleanupPreprocessComplete = uploadManager?.on(
+      "preprocess-complete",
+      handleProgress,
+    );
+
     // Listen for upload errors and display notifications
     // Retrigger when retryCount changes
     const handleError = (error: unknown) => {
@@ -304,6 +316,8 @@ const ProgressComponent = ({
     // Cleanup listeners on component unmount or when retryCount changes
     return () => {
       if (cleanupProgress) cleanupProgress();
+      if (cleanupPreprocessProgress) cleanupPreprocessProgress();
+      if (cleanupPreprocessComplete) cleanupPreprocessComplete();
       if (cleanupError) cleanupError();
       if (cleanupUploadError) cleanupUploadError();
     };

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -97,6 +97,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     // Set fields to null immediately to prevent further usage
     this.#blockstore = null;
     this.#datastore = null;
+    this.#helia = null;
 
     // Initiate async teardown with the captured references
     this.teardown(blockstore, datastore).catch((error) => {
@@ -183,10 +184,16 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
       }, abortController.signal);
 
       // Get upload limit from upload manager
-      const uploadLimit = this.#uploadManager?.getUploadLimit?.();
+      const rawLimit = this.#uploadManager?.getUploadLimit?.();
+      const uploadLimitBigInt =
+        rawLimit == null
+          ? null
+          : typeof rawLimit === "bigint"
+          ? rawLimit
+          : BigInt(rawLimit);
 
       // Conditionally handle large vs small files
-      if (uploadLimit !== null && uploadLimit !== undefined && streamSize >= BigInt(uploadLimit)) {
+      if (uploadLimitBigInt !== null && streamSize >= uploadLimitBigInt) {
         // Large file - use ReadableStream reader approach
         // @ts-ignore
         file.data = streamForProcessing.getReader();
@@ -218,7 +225,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
       
       // Signal preprocessing completion only after all steps are done
       this.uppy.emit("preprocess-complete", file, {
-        message: "Processing file...",
+        message: "Preprocessing complete",
         mode: "determinate",
         value: 100,
       });
@@ -308,7 +315,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
         throw new Error("File processing aborted");
       }
       
-      tracker.updateDataProgress("fileRead", BigInt(progress));
+      // UnixFS importer updates fileRead; this just emits overall progress
       onProgress(tracker.getOverallProgress());
     }, abortSignal);
 
@@ -390,15 +397,9 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
 
     try {
       // Create IndexedDB blockstore and datastore
-      if (!this.#blockstore) {
-        this.#blockstore = new IDBBlockstore("helia-blocks");
-        await this.#blockstore.open();
-      }
-
-      if (!this.#datastore) {
-        this.#datastore = new IDBDatastore("helia-data");
-        await this.#datastore.open();
-      }
+      if (!this.#blockstore) this.#blockstore = new IDBBlockstore("helia-blocks");
+      if (!this.#datastore) this.#datastore = new IDBDatastore("helia-data");
+      await Promise.all([this.#blockstore.open(), this.#datastore.open()]);
 
       // Create Helia instance with IndexedDB stores
       this.#helia = await createHeliaHTTP({
@@ -504,7 +505,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     }
 
     // Then process remaining non-directory files
-    let processedCount = directoryCount;
+    let processedCount = 0;
     const remainingFiles = files.filter(
       (file) =>
         !isFolderBundle(file) &&
@@ -614,12 +615,12 @@ async function* fileSource(
   let totalBytes = 0n;
   let processedBytes = 0n;
 
-  console.log("[fileSource] Starting to process files:", files.length);
+  console.debug("[fileSource] Starting to process files:", files.length);
 
   // Calculate total bytes for progress tracking
   files.forEach((file) => {
     totalBytes += BigInt(file.size);
-    console.log("[fileSource] File details:", {
+    console.debug("[fileSource] File details:", {
       name: file.name,
       size: file.size,
       webkitRelativePath: (file as any).webkitRelativePath,
@@ -627,7 +628,7 @@ async function* fileSource(
     });
   });
 
-  console.log("[fileSource] Total bytes to process:", totalBytes);
+  console.debug("[fileSource] Total bytes to process:", totalBytes);
 
   for (const file of files) {
     // Check if operation was aborted
@@ -636,17 +637,17 @@ async function* fileSource(
     }
 
     const fullPath = (file as any).webkitRelativePath ?? file.name;
-    console.log("[fileSource] Processing file with fullPath:", fullPath);
+    console.debug("[fileSource] Processing file with fullPath:", fullPath);
 
     // Skip hidden files if they're not explicitly allowed
     if (fullPath.includes("/.")) {
-      console.log("[fileSource] Skipping hidden file:", fullPath);
+      console.debug("[fileSource] Skipping hidden file:", fullPath);
       continue;
     }
 
     // Yield intermediate directories
     const parts = fullPath.split("/").filter((part: string) => part.length > 0);
-    console.log("[fileSource] Path parts:", parts);
+    console.debug("[fileSource] Path parts:", parts);
 
     for (let i = 1; i < parts.length; i++) {
       // Check if operation was aborted
@@ -655,10 +656,10 @@ async function* fileSource(
       }
 
       const dirPath = parts.slice(0, i).join("/");
-      console.log("[fileSource] Checking directory path:", dirPath);
+      console.debug("[fileSource] Checking directory path:", dirPath);
 
       if (!seenDirs.has(dirPath)) {
-        console.log("[fileSource] Yielding intermediate directory:", dirPath);
+        console.debug("[fileSource] Yielding intermediate directory:", dirPath);
         seenDirs.add(dirPath);
         yield {
           content: (async function* () {
@@ -667,12 +668,12 @@ async function* fileSource(
           path: dirPath,
         };
       } else {
-        console.log("[fileSource] Directory already seen, skipping:", dirPath);
+        console.debug("[fileSource] Directory already seen, skipping:", dirPath);
       }
     }
 
     // Yield the file with its content stream
-    console.log("[fileSource] Yielding file with path:", fullPath);
+    console.debug("[fileSource] Yielding file with path:", fullPath);
     yield {
       content: readableStreamToAsyncIterable(file.stream()),
       path: fullPath,
@@ -682,7 +683,7 @@ async function* fileSource(
     if (onProgress && totalBytes > 0n) {
       processedBytes += BigInt(file.size);
       const progressPercent = Number((processedBytes * 100n) / totalBytes);
-      console.log("[fileSource] Progress tracking:", {
+      console.debug("[fileSource] Progress tracking:", {
         processedBytes: processedBytes,
         totalBytes: totalBytes,
         progressPercent: progressPercent,
@@ -690,12 +691,12 @@ async function* fileSource(
       onProgress(progressPercent);
     } else if (onProgress) {
       // Fallback progress if totalBytes is 0 (shouldn't happen but just in case)
-      console.log("[fileSource] Fallback progress (100%)");
+      console.debug("[fileSource] Fallback progress (100%)");
       onProgress(100);
     }
   }
 
-  console.log("[fileSource] Finished processing all files");
+  console.debug("[fileSource] Finished processing all files");
 }
 
 export default CarPreprocessorPlugin;

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -90,26 +90,33 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     this.#abortControllers.forEach((controller) => controller.abort());
     this.#abortControllers.clear();
 
-    // Initiate async teardown without awaiting (since uppy doesn't await uninstall)
-    this.teardown().catch((error) => {
-      console.error("Error during carPreprocessor teardown:", error);
-    });
+    // Capture store references before initiating async teardown
+    const blockstore = this.#blockstore;
+    const datastore = this.#datastore;
 
-    // Set fields to null immediately
+    // Set fields to null immediately to prevent further usage
     this.#blockstore = null;
     this.#datastore = null;
+
+    // Initiate async teardown with the captured references
+    this.teardown(blockstore, datastore).catch((error) => {
+      console.error("Error during carPreprocessor teardown:", error);
+    });
   }
 
   /**
    * Async teardown method to properly close resources.
    * This should be called by the host environment when needed.
    */
-  async teardown(): Promise<void> {
+  async teardown(
+    blockstore: IDBBlockstore | null = this.#blockstore,
+    datastore: IDBDatastore | null = this.#datastore
+  ): Promise<void> {
     try {
       // Close the blockstore and datastore concurrently
       await Promise.all([
-        this.#blockstore?.close(),
-        this.#datastore?.close()
+        blockstore?.close(),
+        datastore?.close()
       ]);
     } catch (error) {
       console.error("Error closing stores:", error);
@@ -192,6 +199,12 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
       }
 
       // Update the file in Uppy's state with the CID in meta and tus upload size
+      // Validate streamSize is within safe integer range for Number conversion
+      // This limits uploads to approximately 9 PB, which should be sufficient for most use cases
+      if (streamSize > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error(`File size ${streamSize.toString()} bytes exceeds maximum safe integer for upload. Please use a smaller file.`);
+      }
+      
       this.uppy.setFileState(file.id, {
         data: file.data,
         // @ts-ignore

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -173,7 +173,8 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
           throw new Error("File processing aborted");
         }
         
-        tracker.updateDataProgress("sizeCalculation", BigInt(progress));
+        // progress is a percent [0..100]
+        tracker.setStagePercent("sizeCalculation", progress);
         this.uppy.emit("preprocess-progress", file, {
           message: "Calculating file size...",
           mode: "determinate",
@@ -592,7 +593,14 @@ class ProgressTracker {
   }
 
   updateDataProgress(stage: ProgressStage, value: bigint) {
-    this.state[stage] = Number((value * 100n) / this.fileSize);
+    const denom = this.fileSize > 0n ? this.fileSize : 1n; // avoid div-by-zero
+    this.state[stage] = Number((value * 100n) / denom);
+  }
+
+  setStagePercent(stage: ProgressStage, percent: number) {
+    // clamp 0..100 and floor
+    const p = Math.max(0, Math.min(100, Math.floor(percent)));
+    this.state[stage] = p;
   }
 }
 
@@ -601,7 +609,7 @@ async function* fileSource(
   files: File[],
   onProgress?: (progress: number) => void,
   abortSignal?: AbortSignal,
-): AsyncGenerator<{ content: AsyncIterable<Uint8Array>; path: string }> {
+): AsyncGenerator<{ content: AsyncIterable<Uint8Array> | undefined; path: string }> {
   const seenDirs = new Set<string>();
   let totalBytes = 0n;
   let processedBytes = 0n;
@@ -653,7 +661,9 @@ async function* fileSource(
         console.log("[fileSource] Yielding intermediate directory:", dirPath);
         seenDirs.add(dirPath);
         yield {
-          content: undefined,
+          content: (async function* () {
+            // Empty async iterable for directory entries
+          })(),
           path: dirPath,
         };
       } else {
@@ -664,7 +674,7 @@ async function* fileSource(
     // Yield the file with its content stream
     console.log("[fileSource] Yielding file with path:", fullPath);
     yield {
-      content: file.stream(),
+      content: readableStreamToAsyncIterable(file.stream()),
       path: fullPath,
     };
 

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -90,19 +90,30 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     this.#abortControllers.forEach((controller) => controller.abort());
     this.#abortControllers.clear();
 
-    // Close blockstore and datastore if they exist
-    if (this.#blockstore) {
-      this.#blockstore.close().catch((error) => {
-        console.error("Error closing blockstore:", error);
-      });
-      this.#blockstore = null;
-    }
+    // Initiate async teardown without awaiting (since uppy doesn't await uninstall)
+    this.teardown().catch((error) => {
+      console.error("Error during carPreprocessor teardown:", error);
+    });
 
-    if (this.#datastore) {
-      this.#datastore.close().catch((error) => {
-        console.error("Error closing datastore:", error);
-      });
-      this.#datastore = null;
+    // Set fields to null immediately
+    this.#blockstore = null;
+    this.#datastore = null;
+  }
+
+  /**
+   * Async teardown method to properly close resources.
+   * This should be called by the host environment when needed.
+   */
+  async teardown(): Promise<void> {
+    try {
+      // Close the blockstore and datastore concurrently
+      await Promise.all([
+        this.#blockstore?.close(),
+        this.#datastore?.close()
+      ]);
+    } catch (error) {
+      console.error("Error closing stores:", error);
+      throw error;
     }
   }
 
@@ -560,7 +571,7 @@ class ProgressTracker {
   getOverallProgress(): number {
     const { carExport, fileRead, unixfsImport, sizeCalculation } = this.state;
     // Allocate 5% to size calculation, distribute the rest among other stages
-    return fileRead * 0.3 + unixfsImport * 0.36 + carExport * 0.3 + sizeCalculation * 0.05;
+    return fileRead * 0.3 + unixfsImport * 0.35 + carExport * 0.3 + sizeCalculation * 0.05;
   }
 
   updateBlockProgress(value: bigint) {

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -12,18 +12,29 @@ import type { CID } from "multiformats/cid";
 import type { ProgressOptions } from "progress-events";
 
 import { car } from "@helia/car";
-import { CarReader } from "@ipld/car";
-import { createHeliaHTTP, GetBlockProgressEvents } from "@helia/http";
+import { GetBlockProgressEvents } from "@helia/interface";
+import { createHeliaHTTP } from "@helia/http";
 import { unixfs } from "@helia/unixfs";
 import { asyncIterableReader, createDecoder } from "@ipld/car/decoder";
+import { IDBBlockstore } from "blockstore-idb";
+import { IDBDatastore } from "datastore-idb";
 import {
   BundleMetadata,
   isDirectoryFile,
   isFolderBundle,
 } from "@lumeweb/portal-plugin-dashboard";
-import { streamToBlob, readableStreamToAsyncIterable } from "../utils/stream";
+import {
+  asyncGeneratorToReadableStream,
+  calculateStreamSize,
+  readableStreamToAsyncIterable,
+} from "../utils/stream";
+import { Sdk } from "@lumeweb/portal-sdk";
+import { streamToBlob } from "../utils/stream";
 
-type CarPreprocessorOpts<M extends Meta, B extends Body> = PluginOpts;
+type CarPreprocessorOpts<M extends Meta, B extends Body> = PluginOpts & {
+  sdk?: Sdk;
+  uploadManager?: any;
+};
 
 const defaultOptions = {} satisfies Partial<CarPreprocessorOpts<any, any>>;
 
@@ -32,12 +43,13 @@ type Opts<M extends Meta, B extends Body> = DefinePluginOpts<
   keyof typeof defaultOptions
 >;
 
-type ProgressStage = "fileRead" | "unixfsImport";
+type ProgressStage = "fileRead" | "unixfsImport" | "sizeCalculation";
 
 interface ProgressState {
   carExport: number;
   fileRead: number;
   unixfsImport: number;
+  sizeCalculation: number;
 }
 
 class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
@@ -46,58 +58,160 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
   B
 > {
   #helia: any;
+  #blockstore: IDBBlockstore | null = null;
+  #datastore: IDBDatastore | null = null;
+  #abortControllers: Map<string, AbortController> = new Map();
+  #sdk: Sdk | undefined;
+  #uploadManager: any;
 
   constructor(uppy: Uppy<M, B>, opts: CarPreprocessorOpts<M, B>) {
     super(uppy, { ...defaultOptions, ...opts });
     this.id = this.opts.id || "CarPreprocessor";
     this.type = "preprocessor";
     this.#helia = null;
+    this.#sdk = opts.sdk;
+    this.#uploadManager = opts.uploadManager;
   }
 
   install(): void {
     this.uppy.addPreProcessor(this.#processor.bind(this));
+    // Listen for upload cancellation events
+    this.uppy.on("cancel-all", this.#handleCancelAll.bind(this));
+  }
+
+  uninstall(): void {
+    this.uppy.removePreProcessor(this.#processor.bind(this));
+    this.uppy.off("cancel-all", this.#handleCancelAll.bind(this));
+    // Clean up any remaining abort controllers
+    this.#abortControllers.forEach((controller) => controller.abort());
+    this.#abortControllers.clear();
+
+    // Close blockstore and datastore if they exist
+    if (this.#blockstore) {
+      this.#blockstore.close().catch((error) => {
+        console.error("Error closing blockstore:", error);
+      });
+      this.#blockstore = null;
+    }
+
+    if (this.#datastore) {
+      this.#datastore.close().catch((error) => {
+        console.error("Error closing datastore:", error);
+      });
+      this.#datastore = null;
+    }
+  }
+
+  #handleCancelAll(): void {
+    // Abort all ongoing operations when all uploads are cancelled
+    this.#abortControllers.forEach((controller) => {
+      controller.abort();
+    });
+    this.#abortControllers.clear();
   }
 
   async processFile(file: UppyFile<M, B>) {
+    // Create an abort controller for this file processing operation
+    const abortController = new AbortController();
+    this.#abortControllers.set(file.id, abortController);
+
     try {
+      const tracker = new ProgressTracker(BigInt(file.size || 0));
+      
       const [carStream, rootCid] = await this.#createCarStream(
         file,
         (progress) => {
+          // Check if operation was aborted
+          if (abortController.signal.aborted) {
+            throw new Error("File processing aborted");
+          }
+
           this.uppy.emit("preprocess-progress", file, {
             message: "Processing file...",
             mode: "determinate",
             value: progress,
           });
         },
+        abortController.signal,
+        tracker,
       );
 
-      this.uppy.emit("preprocess-complete", file, {
-        message: "Processing file...",
-        mode: "determinate",
-        value: 100,
+      // Check if operation was aborted after async operation
+      if (abortController.signal.aborted) {
+        throw new Error("File processing aborted");
+      }
+
+      // Use stream tee to create two identical streams - one for size calculation, one for processing
+      const [streamForSize, streamForProcessing] = carStream.tee();
+
+      // Calculate the stream size with progress tracking
+      const streamSize = await calculateStreamSize(streamForSize, (progress) => {
+        // Check if operation was aborted
+        if (abortController.signal.aborted) {
+          throw new Error("File processing aborted");
+        }
+        
+        tracker.updateDataProgress("sizeCalculation", BigInt(progress));
+        this.uppy.emit("preprocess-progress", file, {
+          message: "Calculating file size...",
+          mode: "determinate",
+          value: tracker.getOverallProgress(),
+        });
       });
 
-      // Create a new File from the CAR stream
-      const carBlob = await streamToBlob(carStream, "application/vnd.ipld.car");
+      // Get upload limit from upload manager
+      const uploadLimit = this.#uploadManager.getUploadLimit();
 
-      // Preserve the original filename - don't replace it with cid.toString()
-      file.data = new File([carBlob], file.name, {
-        type: "application/vnd.ipld.car",
-      });
+      // Conditionally handle large vs small files
+      if (streamSize >= uploadLimit) {
+        // Large file - use ReadableStream reader approach
+        // @ts-ignore
+        file.data = streamForProcessing.getReader();
+      } else {
+        // Small file - use File object approach
+        const carBlob = await streamToBlob(streamForProcessing, "application/vnd.ipld.car");
+        // @ts-ignore
+        file.data = new File([carBlob], file.name, {
+          type: "application/vnd.ipld.car",
+        });
+      }
 
-      // Update the file in Uppy's state with the CID in meta
+      // Update the file in Uppy's state with the CID in meta and tus upload size
       this.uppy.setFileState(file.id, {
-        car: true,
         data: file.data,
+        // @ts-ignore
+        tus: { uploadSize: Number(streamSize) },
         meta: {
           ...file.meta,
           cid: rootCid.toString(),
         },
       });
+      
+      // Signal preprocessing completion only after all steps are done
+      this.uppy.emit("preprocess-complete", file, {
+        message: "Processing file...",
+        mode: "determinate",
+        value: 100,
+      });
     } catch (error) {
+      // Clean up abort controller on error
+      this.#abortControllers.delete(file.id);
+
+      // If it's an abort error, emit preprocess-complete instead of throwing
+      if (
+        error instanceof Error &&
+        error.message === "File processing aborted"
+      ) {
+        this.uppy.emit("preprocess-complete", file);
+        return;
+      }
+
       console.error("Error processing file:", error);
       throw error;
     }
+
+    // Clean up abort controller on success
+    this.#abortControllers.delete(file.id);
   }
 
   #collectDirectoryFiles(
@@ -123,14 +237,14 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
   }
 
   async #createCarStream(
-    file: UuppyFile<M, B>,
+    file: UppyFile<M, B>,
     onProgress: (progress: number) => void,
+    abortSignal: AbortSignal,
+    tracker: ProgressTracker,
   ): Promise<[ReadableStream, CID]> {
     const helia = await this.#createHelia();
     const fs = unixfs(helia);
     const c = car(helia);
-
-    const tracker = new ProgressTracker(BigInt(file.size || 0));
 
     let blocksCount = 0n;
 
@@ -160,15 +274,25 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     }
 
     const src = fileSource(files, (progress) => {
+      // Check if operation was aborted
+      if (abortSignal.aborted) {
+        throw new Error("File processing aborted");
+      }
+      
       tracker.updateDataProgress("fileRead", BigInt(progress));
       onProgress(tracker.getOverallProgress());
-    });
+    }, abortSignal);
 
     const addOptions = {
       // Use protobuf format for all nodes to preserve metadata
       cidVersion: 1,
       rawLeaves: false,
+      signal: abortSignal,
       onProgress(event) {
+        if (abortSignal.aborted) {
+          throw new Error("File processing aborted");
+        }
+        
         if (event.type === "unixfs:importer:progress:file:read") {
           tracker.updateDataProgress("fileRead", event.detail.bytesRead);
         } else if (event.type === "unixfs:importer:progress:file:write") {
@@ -183,9 +307,20 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     // Add all files to UnixFS and get the root CID
     let cid: CID;
 
-    for await (const result of fs.addAll(src, addOptions)) {
-      // Store the last result which should be the root directory
-      cid = result.cid;
+    try {
+      for await (const result of fs.addAll(src, addOptions)) {
+        // Check for abort during async iteration
+        if (abortSignal.aborted) {
+          throw new Error("File processing aborted");
+        }
+        // Store the last result which should be the root directory
+        cid = result.cid;
+      }
+    } catch (error) {
+      if (abortSignal.aborted) {
+        throw new Error("File processing aborted");
+      }
+      throw error;
     }
 
     if (!cid) {
@@ -194,7 +329,12 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
 
     let carBlocksWritten = 0n;
     const options: AbortOptions & ProgressOptions<GetBlockProgressEvents> = {
+      signal: abortSignal,
       onProgress(event: GetBlockProgressEvents) {
+        if (abortSignal.aborted) {
+          throw new Error("File processing aborted");
+        }
+        
         if (event.type === "blocks:get:blockstore:get") {
           carBlocksWritten++;
 
@@ -220,12 +360,29 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     }
 
     try {
-      // Create Helia HTTP instance without specifying servers
-      // This will use the default remote Helia server configuration
-      this.#helia = await createHeliaHTTP();
+      // Create IndexedDB blockstore and datastore
+      if (!this.#blockstore) {
+        this.#blockstore = new IDBBlockstore("helia-blocks");
+        await this.#blockstore.open();
+      }
+
+      if (!this.#datastore) {
+        this.#datastore = new IDBDatastore("helia-data");
+        await this.#datastore.open();
+      }
+
+      // Create Helia instance with IndexedDB stores
+      this.#helia = await createHeliaHTTP({
+        blockstore: this.#blockstore,
+        datastore: this.#datastore,
+      });
+
       return this.#helia;
     } catch (error) {
-      console.error("Error creating Helia HTTP instance:", error);
+      console.error(
+        "Error creating Helia instance with IndexedDB stores:",
+        error,
+      );
       throw error;
     }
   }
@@ -380,6 +537,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
   #shouldProcessFile(file: UppyFile<M, B>): boolean {
     return this.#isIPFSFile(file);
   }
+
 }
 
 class ProgressTracker {
@@ -388,6 +546,7 @@ class ProgressTracker {
     carExport: 0,
     fileRead: 0,
     unixfsImport: 0,
+    sizeCalculation: 0,
   };
 
   constructor(fileSize: bigint) {
@@ -395,8 +554,9 @@ class ProgressTracker {
   }
 
   getOverallProgress(): number {
-    const { carExport, fileRead, unixfsImport } = this.state;
-    return fileRead * 0.3 + unixfsImport * 0.4 + carExport * 0.3;
+    const { carExport, fileRead, unixfsImport, sizeCalculation } = this.state;
+    // Allocate 5% to size calculation, distribute the rest among other stages
+    return fileRead * 0.3 + unixfsImport * 0.36 + carExport * 0.3 + sizeCalculation * 0.05;
   }
 
   updateBlockProgress(value: bigint) {
@@ -408,27 +568,11 @@ class ProgressTracker {
   }
 }
 
-function asyncGeneratorToReadableStream<T>(
-  asyncGenerator: AsyncGenerator<T>,
-): ReadableStream<T> {
-  return new ReadableStream({
-    async start(controller) {
-      try {
-        for await (const chunk of asyncGenerator) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      } catch (err) {
-        controller.error(err);
-      }
-    },
-  });
-}
-
 // File source for handling File objects with webkitRelativePath
 async function* fileSource(
   files: File[],
   onProgress?: (progress: number) => void,
+  abortSignal?: AbortSignal,
 ): AsyncGenerator<{ content: AsyncIterable<Uint8Array>; path: string }> {
   const seenDirs = new Set<string>();
   let totalBytes = 0n;
@@ -450,6 +594,11 @@ async function* fileSource(
   console.log("[fileSource] Total bytes to process:", totalBytes);
 
   for (const file of files) {
+    // Check if operation was aborted
+    if (abortSignal?.aborted) {
+      throw new Error("Operation aborted");
+    }
+
     const fullPath = (file as any).webkitRelativePath ?? file.name;
     console.log("[fileSource] Processing file with fullPath:", fullPath);
 
@@ -464,6 +613,11 @@ async function* fileSource(
     console.log("[fileSource] Path parts:", parts);
 
     for (let i = 1; i < parts.length; i++) {
+      // Check if operation was aborted
+      if (abortSignal?.aborted) {
+        throw new Error("Operation aborted");
+      }
+
       const dirPath = parts.slice(0, i).join("/");
       console.log("[fileSource] Checking directory path:", dirPath);
 

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -63,6 +63,8 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
   #abortControllers: Map<string, AbortController> = new Map();
   #sdk: Sdk | undefined;
   #uploadManager: any;
+  #boundProcessor: (fileIDs: string[], uploadID: string) => Promise<void>;
+  #boundCancelAll: () => void;
 
   constructor(uppy: Uppy<M, B>, opts: CarPreprocessorOpts<M, B>) {
     super(uppy, { ...defaultOptions, ...opts });
@@ -71,17 +73,19 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     this.#helia = null;
     this.#sdk = opts.sdk;
     this.#uploadManager = opts.uploadManager;
+    this.#boundProcessor = this.#processor.bind(this);
+    this.#boundCancelAll = this.#handleCancelAll.bind(this);
   }
 
   install(): void {
-    this.uppy.addPreProcessor(this.#processor.bind(this));
+    this.uppy.addPreProcessor(this.#boundProcessor);
     // Listen for upload cancellation events
-    this.uppy.on("cancel-all", this.#handleCancelAll.bind(this));
+    this.uppy.on("cancel-all", this.#boundCancelAll);
   }
 
   uninstall(): void {
-    this.uppy.removePreProcessor(this.#processor.bind(this));
-    this.uppy.off("cancel-all", this.#handleCancelAll.bind(this));
+    this.uppy.removePreProcessor(this.#boundProcessor);
+    this.uppy.off("cancel-all", this.#boundCancelAll);
     // Clean up any remaining abort controllers
     this.#abortControllers.forEach((controller) => controller.abort());
     this.#abortControllers.clear();
@@ -157,13 +161,13 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
           mode: "determinate",
           value: tracker.getOverallProgress(),
         });
-      });
+      }, abortController.signal);
 
       // Get upload limit from upload manager
-      const uploadLimit = this.#uploadManager.getUploadLimit();
+      const uploadLimit = this.#uploadManager?.getUploadLimit?.();
 
       // Conditionally handle large vs small files
-      if (streamSize >= uploadLimit) {
+      if (uploadLimit !== null && uploadLimit !== undefined && streamSize >= BigInt(uploadLimit)) {
         // Large file - use ReadableStream reader approach
         // @ts-ignore
         file.data = streamForProcessing.getReader();

--- a/libs/portal-plugin-ipfs/src/utils/stream.ts
+++ b/libs/portal-plugin-ipfs/src/utils/stream.ts
@@ -36,3 +36,89 @@ export function readableStreamToAsyncIterable<T>(
     },
   };
 }
+
+/**
+ * Calculate the total size of a ReadableStream by consuming it entirely
+ * @param stream - The ReadableStream<Uint8Array> to calculate size for
+ * @param onProgress - Optional callback to report progress (0% at start, 100% at end)
+ * @param abortSignal - Optional abort signal to cancel the operation
+ * @returns Promise that resolves to the total size as bigint
+ */
+export async function calculateStreamSize(
+  stream: ReadableStream<Uint8Array>,
+  onProgress?: (progress: number) => void,
+  abortSignal?: AbortSignal
+): Promise<bigint> {
+  let size = 0n;
+  const reader = stream.getReader();
+  
+  try {
+    // Report 0% progress at the start if callback provided
+    if (onProgress) {
+      onProgress(0);
+    }
+    
+    while (true) {
+      // Check for abort signal
+      if (abortSignal?.aborted) {
+        throw new Error("Operation aborted");
+      }
+      
+      const { done, value } = await reader.read();
+      if (done) break;
+      
+      size += BigInt(value.byteLength);
+    }
+    
+    // Report 100% progress at the end if callback provided
+    if (onProgress) {
+      onProgress(100);
+    }
+  } catch (err) {
+    throw err;
+  } finally {
+    reader.releaseLock();
+  }
+  return size;
+}
+
+/**
+ * Convert an AsyncGenerator to a ReadableStream
+ * @param asyncGenerator - The async generator to convert
+ * @param abortSignal - Optional abort signal to cancel the stream
+ * @returns ReadableStream that yields values from the async generator
+ */
+export function asyncGeneratorToReadableStream<T>(
+  asyncGenerator: AsyncGenerator<T>,
+  abortSignal?: AbortSignal,
+): ReadableStream<T> {
+  return new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const chunk of asyncGenerator) {
+          // Check if operation was aborted
+          if (abortSignal?.aborted) {
+            controller.error(new Error("Operation aborted"));
+            return;
+          }
+
+          controller.enqueue(chunk);
+        }
+
+        // Check if operation was aborted before closing
+        if (abortSignal?.aborted) {
+          controller.error(new Error("Operation aborted"));
+        } else {
+          controller.close();
+        }
+      } catch (err) {
+        // Handle abort errors specifically
+        if (abortSignal?.aborted) {
+          controller.error(new Error("Operation aborted"));
+        } else {
+          controller.error(err);
+        }
+      }
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
       "warn-once": "patches/warn-once.patch",
       "pluralize": "patches/pluralize.patch",
       "papaparse": "patches/papaparse.patch",
-      "@uppy/core": "patches/@uppy__core.patch"
+      "@uppy/core": "patches/@uppy__core.patch",
+      "@uppy/tus": "patches/@uppy__tus.patch"
     },
     "overrides": {
       "react": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ patchedDependencies:
   '@uppy/core':
     hash: 2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1
     path: patches/@uppy__core.patch
+  '@uppy/tus':
+    hash: d6ff40c128dee640bbd3624c5d061bb91ca9617936ec9503762fb04bd54817c0
+    path: patches/@uppy__tus.patch
   '@vitejs/plugin-react':
     hash: 806c4c1163047d94f0e19ed32edc55adc586255404c8d3e47cf7de1ec4c93e63
     path: patches/@vitejs__plugin-react.patch
@@ -1009,7 +1012,7 @@ importers:
         version: 4.0.0(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))
       '@uppy/tus':
         specifier: 5.0.1
-        version: 5.0.1(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))
+        version: 5.0.1(patch_hash=d6ff40c128dee640bbd3624c5d061bb91ca9617936ec9503762fb04bd54817c0)(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))
       '@uppy/xhr-upload':
         specifier: 5.0.1
         version: 5.0.1(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))
@@ -15339,7 +15342,7 @@ snapshots:
       '@uppy/utils': 7.0.2
       exifr: 7.1.3
 
-  '@uppy/tus@5.0.1(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))':
+  '@uppy/tus@5.0.1(patch_hash=d6ff40c128dee640bbd3624c5d061bb91ca9617936ec9503762fb04bd54817c0)(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))':
     dependencies:
       '@uppy/companion-client': 5.0.1(@uppy/core@5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1))
       '@uppy/core': 5.0.2(patch_hash=2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1)


### PR DESCRIPTION
* Refactored CAR preprocessor to use ReadableStream instead of File blob for large uploads
* Added stream size calculation via stream tee to support tus upload protocol
* Integrated IndexedDB blockstore and datastore for Helia HTTP instance
* Implemented abort signal support for upload cancellation
* Added preprocess progress and completion event listeners
* Enhanced cleanup logic for abort controllers and stores on uninstall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload wizard shows more granular preprocess progress (including size calculation) and emits explicit preprocess completion.
  * Better handling for very large files with improved resumable and cancelable pre-processing; plugins can access upload manager/upload limits.

* **Bug Fixes**
  * Cancelling uploads reliably aborts background work and frees resources to avoid stalled states.

* **Chores**
  * Updated patched dependencies (added a patch for @uppy/tus).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->