### PR TITLE
refactor!: remove patch dependencies and update lockfile

### DIFF
--- a/libs/portal-framework-core/src/plugins/remoteComponentLoader.spec.tsx
+++ b/libs/portal-framework-core/src/plugins/remoteComponentLoader.spec.tsx
@@ -1,10 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import React, {
-  ComponentType,
-  createContext,
-  forwardRef,
-  useContext,
-} from "react";
+import React, { ComponentType, createContext, useContext } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Import necessary parts from context-bridge
@@ -159,9 +154,14 @@ describe("remoteComponentLoader", () => {
     });
 
     it("should forward refs to the wrapped component", () => {
-      const MockComponent = forwardRef<HTMLDivElement, { label: string }>(
-        ({ label }, ref) => <div ref={ref}>{label}</div>,
-      );
+      const MockComponent = (
+        {
+          ref,
+          label
+        }: { label: string } & {
+          ref: React.RefObject<HTMLDivElement>;
+        }
+      ) => <div ref={ref}>{label}</div>;
       MockComponent.displayName = "MockComponentWithRef";
 
       const bridgeFactory = createBridgeComponent(MockComponent);

--- a/libs/portal-framework-core/src/plugins/remoteComponentLoader.tsx
+++ b/libs/portal-framework-core/src/plugins/remoteComponentLoader.tsx
@@ -3,13 +3,7 @@ import {
   type ProviderParams,
   type RenderParams,
 } from "@module-federation/bridge-react/v18";
-import React, {
-  ComponentType,
-  forwardRef,
-  ForwardRefExoticComponent,
-  PropsWithoutRef,
-  RefAttributes,
-} from "react";
+import React, { ComponentType, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from "react";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
 
 import type { Framework } from "../api/framework";
@@ -149,20 +143,25 @@ export function createBridgeComponent<T>(
 ): () => BridgeResult<T> {
   type ComponentRef = React.ElementRef<typeof Component>;
 
-  const WrappedComponent: BridgeableComponent<T> = forwardRef<ComponentRef, T>(
-    (props, ref) => {
-      return store
-        .getRegisteredContextIds()
-        .reduce(
-          (children, contextId) => (
-            <RemoteContextBridge contextId={contextId}>
-              {children}
-            </RemoteContextBridge>
-          ),
-          <Component {...props} ref={ref} />,
-        );
-    },
-  );
+  const WrappedComponent: BridgeableComponent<T> = (
+    {
+      ref,
+      ...props
+    }: T & {
+      ref: React.RefObject<ComponentRef>;
+    }
+  ) => {
+    return store
+      .getRegisteredContextIds()
+      .reduce(
+        (children, contextId) => (
+          <RemoteContextBridge contextId={contextId}>
+            {children}
+          </RemoteContextBridge>
+        ),
+        <Component {...props} ref={ref} />,
+      );
+  };
 
   WrappedComponent.displayName = `Bridge(${
     (Component.displayName ?? Component.name) || "Component"
@@ -180,24 +179,31 @@ export function createRemoteComponent<
   E extends keyof T = keyof T,
 >(info: LazyRemoteComponentInfo<T, E>) {
   const LazyComponent = createLazyRemoteComponent(info);
-  return forwardRef<HTMLDivElement, RemoteComponentProps>((props, ref) => {
+  return (
+    {
+      ref,
+      ...props
+    }: RemoteComponentProps & {
+      ref: React.RefObject<HTMLDivElement>;
+    }
+  ) => {
     // Destructure to separate wrapper props from component props
     const { props: componentProps } = props;
 
     return (
-      <ErrorBoundary FallbackComponent={info.fallback}>
+      (<ErrorBoundary FallbackComponent={info.fallback}>
         <React.Suspense fallback={info.loading}>
           {componentProps !== undefined ? (
             //@ts-ignore
-            <LazyComponent {...componentProps} />
+            (<LazyComponent {...componentProps} />)
           ) : (
             //@ts-ignore
-            <LazyComponent />
+            (<LazyComponent />)
           )}
         </React.Suspense>
-      </ErrorBoundary>
+      </ErrorBoundary>)
     );
-  });
+  };
 }
 
 function createLazyRemoteComponent<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,24 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@module-federation/bridge-react':
-    hash: 24e5a7a8eea712aadb8f904acbf6d777793c1a227eeffcbedff1ee4c99e1f5c5
-    path: patches/@module-federation__bridge-react.patch
-  '@module-federation/vite':
-    hash: 03cadc2ddc818b0479e211a44d057ec73fe3791da97bbd10ff2825a6af17f6b8
-    path: patches/@module-federation__vite.patch
-  '@refinedev/core':
-    hash: dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104
-    path: patches/@refinedev__core.patch
-  '@refinedev/devtools-internal':
-    hash: d3c7d5c7b45262bbaa53bef873e2663a3b41afea259747e9c67f840150ab842d
-    path: patches/@refinedev__devtools-internal.patch
   '@uppy/core':
     hash: 2d89b80edba24c2f38a6efc42dda118163a2d4cfa14f83cccc13176cd4c85ec1
     path: patches/@uppy__core.patch
-  '@vitejs/plugin-react':
-    hash: 806c4c1163047d94f0e19ed32edc55adc586255404c8d3e47cf7de1ec4c93e63
-    path: patches/@vitejs__plugin-react.patch
   object-inspect:
     hash: 58d41550bac212c6dff14bd065070f98aa763f5cfcdd9bf73f9f83f728e19cd8
     path: patches/object-inspect.patch
@@ -42,7 +27,7 @@ importers:
     dependencies:
       '@refinedev/core':
         specifier: 4.57.10
-        version: 4.57.10(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
+        version: 4.57.10(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       autoprefixer:
         specifier: ^10.4.22
         version: 10.4.22(postcss@8.4.49)
@@ -67,7 +52,7 @@ importers:
         version: 9.39.1
       '@module-federation/vite':
         specifier: ^1.9.2
-        version: 1.9.2(patch_hash=03cadc2ddc818b0479e211a44d057ec73fe3791da97bbd10ff2825a6af17f6b8)(rollup@4.41.0)
+        version: 1.9.2(rollup@4.41.0)
       '@playwright/test':
         specifier: ^1.57.0
         version: 1.57.0
@@ -109,7 +94,7 @@ importers:
         version: 22.19.1
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.1(patch_hash=806c4c1163047d94f0e19ed32edc55adc586255404c8d3e47cf7de1ec4c93e63)(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
+        version: 5.1.1(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
       '@vitest/browser':
         specifier: ^4.0.15
         version: 4.0.15(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))(vitest@4.0.15(@types/node@22.19.1)(happy-dom@20.0.11)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
@@ -322,7 +307,7 @@ importers:
     dependencies:
       '@refinedev/core':
         specifier: ^5.0.6
-        version: 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ky:
         specifier: ^1.14.0
         version: 1.14.0
@@ -358,7 +343,7 @@ importers:
         version: link:../portal-sdk
       '@refinedev/core':
         specifier: ^5.0.6
-        version: 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -398,13 +383,13 @@ importers:
         version: link:../portal-sdk
       '@module-federation/bridge-react':
         specifier: ^0.21.6
-        version: 0.21.6(patch_hash=24e5a7a8eea712aadb8f904acbf6d777793c1a227eeffcbedff1ee4c99e1f5c5)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 0.21.6(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@module-federation/enhanced':
         specifier: ^0.21.6
         version: 0.21.6(@rspack/core@1.3.11(@swc/helpers@0.5.17))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@refinedev/react-router':
         specifier: ^2.0.3
-        version: 2.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@t3-oss/env-core':
         specifier: ^0.13.8
         version: 0.13.8(typescript@5.9.3)(zod@3.24.2)
@@ -501,13 +486,13 @@ importers:
         version: 1.3.2(react@19.2.1)
       '@refinedev/react-hook-form':
         specifier: ^5.0.3
-        version: 5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)
+        version: 5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)
       '@refinedev/react-router':
         specifier: ^2.0.3
-        version: 2.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@refinedev/react-table':
         specifier: ^6.0.1
-        version: 6.0.1(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-table@8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 6.0.1(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-table@8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -719,19 +704,19 @@ importers:
         version: link:../portal-plugin-abuse-common
       '@module-federation/bridge-react':
         specifier: ^0.21.6
-        version: 0.21.6(patch_hash=24e5a7a8eea712aadb8f904acbf6d777793c1a227eeffcbedff1ee4c99e1f5c5)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 0.21.6(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@refinedev/core':
         specifier: ^5.0.6
-        version: 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@refinedev/react-hook-form':
         specifier: ^5.0.3
-        version: 5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.68.0(react@19.2.1))(react@19.2.1)
+        version: 5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.68.0(react@19.2.1))(react@19.2.1)
       '@refinedev/react-router':
         specifier: ^2.0.3
-        version: 2.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@refinedev/react-table':
         specifier: ^6.0.1
-        version: 6.0.1(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-table@8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 6.0.1(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-table@8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.12(react@19.2.1)
@@ -765,7 +750,7 @@ importers:
     devDependencies:
       '@module-federation/vite':
         specifier: ^1.9.2
-        version: 1.9.2(patch_hash=03cadc2ddc818b0479e211a44d057ec73fe3791da97bbd10ff2825a6af17f6b8)(rollup@4.41.0)
+        version: 1.9.2(rollup@4.41.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
@@ -867,7 +852,7 @@ importers:
         version: link:../portal-framework-ui-core
       '@refinedev/core':
         specifier: ^5.0.6
-        version: 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.12(react@19.2.1)
@@ -918,7 +903,7 @@ importers:
         version: link:../portal-sdk
       '@refinedev/react-hook-form':
         specifier: ^5.0.3
-        version: 5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.68.0(react@19.2.1))(react@19.2.1)
+        version: 5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.68.0(react@19.2.1))(react@19.2.1)
       '@t3-oss/env-core':
         specifier: ^0.13.8
         version: 0.13.8(typescript@5.9.3)(zod@3.24.2)
@@ -955,7 +940,7 @@ importers:
     devDependencies:
       '@module-federation/bridge-react':
         specifier: ^0.21.6
-        version: 0.21.6(patch_hash=24e5a7a8eea712aadb8f904acbf6d777793c1a227eeffcbedff1ee4c99e1f5c5)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 0.21.6(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
@@ -985,7 +970,7 @@ importers:
         version: link:../portal-sdk
       '@refinedev/react-hook-form':
         specifier: ^5.0.3
-        version: 5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)
+        version: 5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query':
         specifier: 4.36.1
         version: 4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
@@ -1093,7 +1078,7 @@ importers:
         version: link:../portal-sdk
       '@refinedev/react-router':
         specifier: ^2.0.3
-        version: 2.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.5.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 2.0.3(@refinedev/core@5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.5.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query':
         specifier: 4.36.1
         version: 4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
@@ -11646,7 +11631,7 @@ snapshots:
     dependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
-      '@vitejs/plugin-react': 4.7.0(patch_hash=806c4c1163047d94f0e19ed32edc55adc586255404c8d3e47cf7de1ec4c93e63)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       ultrahtml: 1.6.0
@@ -13915,7 +13900,7 @@ snapshots:
       '@types/semver': 7.5.8
       semver: 7.6.3
 
-  '@module-federation/bridge-react@0.21.6(patch_hash=24e5a7a8eea712aadb8f904acbf6d777793c1a227eeffcbedff1ee4c99e1f5c5)(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@module-federation/bridge-react@0.21.6(react-dom@19.2.1(react@19.2.1))(react-router-dom@7.5.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@module-federation/bridge-shared': 0.21.6
       '@module-federation/sdk': 0.21.6
@@ -14109,7 +14094,7 @@ snapshots:
       fs-extra: 9.1.0
       resolve: 1.22.8
 
-  '@module-federation/vite@1.9.2(patch_hash=03cadc2ddc818b0479e211a44d057ec73fe3791da97bbd10ff2825a6af17f6b8)(rollup@4.41.0)':
+  '@module-federation/vite@1.9.2(rollup@4.41.0)':
     dependencies:
       '@module-federation/runtime': 0.18.4
       '@module-federation/sdk': 0.18.4
@@ -15296,9 +15281,9 @@ snapshots:
       react: 19.2.1
       react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.1)(redux@5.0.1)
 
-  '@refinedev/core@4.57.10(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)':
+  '@refinedev/core@4.57.10(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/devtools-internal': 1.1.16(patch_hash=d3c7d5c7b45262bbaa53bef873e2663a3b41afea259747e9c67f840150ab842d)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
+      '@refinedev/devtools-internal': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query': 5.90.12(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -15314,9 +15299,9 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@refinedev/core@5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/devtools-internal': 2.0.1(patch_hash=d3c7d5c7b45262bbaa53bef873e2663a3b41afea259747e9c67f840150ab842d)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/devtools-internal': 2.0.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query': 4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -15330,9 +15315,9 @@ snapshots:
       tslib: 2.8.1
       warn-once: 0.1.1(patch_hash=5720ed82c72c077a0bf56dcede206d50538aa93a6bc2c943e8610ea924298b87)
 
-  '@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/devtools-internal': 2.0.1(patch_hash=d3c7d5c7b45262bbaa53bef873e2663a3b41afea259747e9c67f840150ab842d)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/devtools-internal': 2.0.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query': 5.90.12(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -15346,7 +15331,7 @@ snapshots:
       tslib: 2.8.1
       warn-once: 0.1.1(patch_hash=5720ed82c72c077a0bf56dcede206d50538aa93a6bc2c943e8610ea924298b87)
 
-  '@refinedev/devtools-internal@1.1.16(patch_hash=d3c7d5c7b45262bbaa53bef873e2663a3b41afea259747e9c67f840150ab842d)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)':
+  '@refinedev/devtools-internal@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@refinedev/devtools-shared': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query': 4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.3)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1)
@@ -15358,7 +15343,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@refinedev/devtools-internal@2.0.1(patch_hash=d3c7d5c7b45262bbaa53bef873e2663a3b41afea259747e9c67f840150ab842d)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@refinedev/devtools-internal@2.0.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@refinedev/devtools-shared': 2.0.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-query': 5.90.12(react@19.2.1)
@@ -15388,9 +15373,9 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@refinedev/react-hook-form@5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)':
+  '@refinedev/react-hook-form@5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/core': 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/core': 5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       lodash: 4.17.21
@@ -15399,9 +15384,9 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       react-hook-form: 7.54.0(react@19.2.1)
 
-  '@refinedev/react-hook-form@5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)':
+  '@refinedev/react-hook-form@5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.54.0(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/core': 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/core': 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       lodash: 4.17.21
@@ -15410,9 +15395,9 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       react-hook-form: 7.54.0(react@19.2.1)
 
-  '@refinedev/react-hook-form@5.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.68.0(react@19.2.1))(react@19.2.1)':
+  '@refinedev/react-hook-form@5.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-hook-form@7.68.0(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/core': 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/core': 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       lodash: 4.17.21
@@ -15421,9 +15406,9 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       react-hook-form: 7.68.0(react@19.2.1)
 
-  '@refinedev/react-router@2.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.5.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@refinedev/react-router@2.0.3(@refinedev/core@5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.5.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/core': 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/core': 5.0.6(@tanstack/react-query@4.36.1(react-dom@19.2.1(react@19.2.1))(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       qs: 6.14.0
@@ -15431,9 +15416,9 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       react-router: 7.5.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@refinedev/react-router@2.0.3(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+  '@refinedev/react-router@2.0.3(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react-router@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/core': 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/core': 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       qs: 6.14.0
@@ -15441,9 +15426,9 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       react-router: 7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@refinedev/react-table@6.0.1(@refinedev/core@5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-table@8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@refinedev/react-table@6.0.1(@refinedev/core@5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/react-table@8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
-      '@refinedev/core': 5.0.6(patch_hash=dd77179754d9c0ec947ca9c6fff854acf119afb5b0fee50b1125f5d34f838104)(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@refinedev/core': 5.0.6(@tanstack/react-query@5.90.12(react@19.2.1))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tanstack/react-table': 8.21.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       lodash: 4.17.21
       lodash-es: 4.17.21
@@ -16855,7 +16840,7 @@ snapshots:
       '@uppy/utils': 7.0.2
       preact: 10.26.9
 
-  '@vitejs/plugin-react@4.7.0(patch_hash=806c4c1163047d94f0e19ed32edc55adc586255404c8d3e47cf7de1ec4c93e63)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -16867,7 +16852,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.1(patch_hash=806c4c1163047d94f0e19ed32edc55adc586255404c8d3e47cf7de1ec4c93e63)(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.1(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)


### PR DESCRIPTION
- Removed patch dependencies for `@module-federation/bridge-react`, `@module-federation/vite`, `@refinedev/core`, `@refinedev/devtools-internal`, `@vitejs/plugin-react`
- Updated pnpm-lock.yaml to reflect removal of patch hashes
- Updated dependency versions in lockfile to remove patch hash suffixes
- Modified component implementation in `remoteComponentLoader` to use direct prop spreading instead of `forwardRef` (react 19 upgrade)