### PR TITLE
refactor(portal-framework-ui): convert forwardRef components to regular function components with explicit ref handling

### DIFF
--- a/libs/portal-framework-ui/src/components/MainNavigation.tsx
+++ b/libs/portal-framework-ui/src/components/MainNavigation.tsx
@@ -282,10 +282,16 @@ const NavItem: React.FC<{
   active: boolean;
   item: NavigationItemType;
   onItemClick?: () => void;
-}> = React.forwardRef<
-  HTMLLIElement,
-  { active: boolean; item: NavigationItemType; onItemClick?: () => void }
->(({ active, item, onItemClick }, ref) => {
+}> = (
+  {
+    ref,
+    active,
+    item,
+    onItemClick
+  }: { active: boolean; item: NavigationItemType; onItemClick?: () => void } & {
+    ref: React.RefObject<HTMLLIElement>;
+  }
+) => {
   const { isCollapsed } = useSidebarContext();
 
   let IconComponent: React.FC<NavigationItemIconProps> | undefined = undefined;
@@ -315,7 +321,7 @@ const NavItem: React.FC<{
       )}
     </li>
   );
-});
+};
 NavItem.displayName = "NavItem";
 
 export const MainNavigation: React.FC<MenuProps> = ({

--- a/libs/portal-framework-ui/src/components/editor/Editor.tsx
+++ b/libs/portal-framework-ui/src/components/editor/Editor.tsx
@@ -18,7 +18,7 @@ import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { $getRoot } from "lexical";
-import React, { forwardRef, useState } from "react";
+import React, { useState } from "react";
 
 import { Preview } from "./Preview";
 import { ToolbarProvider } from "./ToolbarContext";
@@ -45,102 +45,111 @@ export type ToolbarOption =
   | "underline"
   | "undo";
 
-export const Editor = forwardRef<HTMLDivElement, EditorProps>(
-  ({ enablePreview, onChange, placeholder, toolbarOptions, value }, ref) => {
-    const [isPreview, setIsPreview] = useState(false);
+export const Editor = (
+  {
+    ref,
+    enablePreview,
+    onChange,
+    placeholder,
+    toolbarOptions,
+    value
+  }: EditorProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  const [isPreview, setIsPreview] = useState(false);
 
-    const handleChange = React.useCallback(
-      (editorState) => {
-        const content = editorState.read(() => $getRoot().getTextContent());
-        onChange?.(content);
-      },
-      [onChange],
-    );
+  const handleChange = React.useCallback(
+    (editorState) => {
+      const content = editorState.read(() => $getRoot().getTextContent());
+      onChange?.(content);
+    },
+    [onChange],
+  );
 
-    const initialConfig = React.useMemo(
-      () =>
-        ({
-          editable: !isPreview,
-          editorState: () => {
-            $convertFromMarkdownString(value ?? "", TRANSFORMERS);
+  const initialConfig = React.useMemo(
+    () =>
+      ({
+        editable: !isPreview,
+        editorState: () => {
+          $convertFromMarkdownString(value ?? "", TRANSFORMERS);
+        },
+        namespace: "MarkdownEditor",
+        nodes: [
+          HorizontalRuleNode,
+          CodeNode,
+          LinkNode,
+          ListNode,
+          ListItemNode,
+          HeadingNode,
+          QuoteNode,
+        ],
+        onError: (error: Error) => {
+          throw error;
+        },
+        theme: {
+          heading: {
+            h1: "text-2xl font-bold",
+            h2: "text-xl font-bold",
+            h3: "text-lg font-semibold",
+            h4: "text-base font-semibold",
+            h5: "text-sm font-semibold",
+            h6: "text-xs font-semibold",
           },
-          namespace: "MarkdownEditor",
-          nodes: [
-            HorizontalRuleNode,
-            CodeNode,
-            LinkNode,
-            ListNode,
-            ListItemNode,
-            HeadingNode,
-            QuoteNode,
-          ],
-          onError: (error: Error) => {
-            throw error;
+          link: "cursor-pointer",
+          root: "p-3 border rounded-md bg-modal-input text-foreground",
+          text: {
+            bold: "font-semibold",
+            italic: "italic",
+            underline: "underline",
           },
-          theme: {
-            heading: {
-              h1: "text-2xl font-bold",
-              h2: "text-xl font-bold",
-              h3: "text-lg font-semibold",
-              h4: "text-base font-semibold",
-              h5: "text-sm font-semibold",
-              h6: "text-xs font-semibold",
-            },
-            link: "cursor-pointer",
-            root: "p-3 border rounded-md bg-modal-input text-foreground",
-            text: {
-              bold: "font-semibold",
-              italic: "italic",
-              underline: "underline",
-            },
-          },
-        }) satisfies InitialConfigType,
-      [isPreview, value],
-    );
+        },
+      }) satisfies InitialConfigType,
+    [isPreview, value],
+  );
 
-    return (
-      <div className="bg-modal-input text-foreground rounded-md border">
-        <LexicalComposer initialConfig={initialConfig}>
-          <ToolbarProvider>
-            <div className="border-border flex items-center justify-between gap-1 border-b p-1">
-              <ToolbarPlugin
-                isPreview={isPreview}
-                setIsPreview={setIsPreview}
-                toolbarOptions={toolbarOptions}
+  return (
+    <div className="bg-modal-input text-foreground rounded-md border">
+      <LexicalComposer initialConfig={initialConfig}>
+        <ToolbarProvider>
+          <div className="border-border flex items-center justify-between gap-1 border-b p-1">
+            <ToolbarPlugin
+              isPreview={isPreview}
+              setIsPreview={setIsPreview}
+              toolbarOptions={toolbarOptions}
+            />
+          </div>
+          {!isPreview ? (
+            <>
+              <RichTextPlugin
+                contentEditable={
+                  <ContentEditable
+                    aria-placeholder={placeholder ?? ""}
+                    className="text-foreground min-h-[150px] w-full resize-none bg-transparent outline-none"
+                    placeholder={
+                      <div className="text-foreground/50">{placeholder}</div>
+                    }
+                  />
+                }
+                ErrorBoundary={LexicalErrorBoundary}
               />
-            </div>
-            {!isPreview ? (
-              <>
-                <RichTextPlugin
-                  contentEditable={
-                    <ContentEditable
-                      aria-placeholder={placeholder ?? ""}
-                      className="text-foreground min-h-[150px] w-full resize-none bg-transparent outline-none"
-                      placeholder={
-                        <div className="text-foreground/50">{placeholder}</div>
-                      }
-                    />
-                  }
-                  ErrorBoundary={LexicalErrorBoundary}
-                />
-                <HistoryPlugin />
-                <ListPlugin />
-                <CheckListPlugin />
-                <LinkPlugin />
-                <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
-                <OnChangePlugin
-                  ignoreHistoryMergeTagChange={true}
-                  ignoreSelectionChange={true}
-                  onChange={handleChange}
-                />
-              </>
-            ) : (
-              <Preview />
-            )}
-          </ToolbarProvider>
-        </LexicalComposer>
-      </div>
-    );
-  },
-);
+              <HistoryPlugin />
+              <ListPlugin />
+              <CheckListPlugin />
+              <LinkPlugin />
+              <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
+              <OnChangePlugin
+                ignoreHistoryMergeTagChange={true}
+                ignoreSelectionChange={true}
+                onChange={handleChange}
+              />
+            </>
+          ) : (
+            <Preview />
+          )}
+        </ToolbarProvider>
+      </LexicalComposer>
+    </div>
+  );
+};
 Editor.displayName = "Markdown";

--- a/libs/portal-framework-ui/src/components/form/fields/DatePicker.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/DatePicker.tsx
@@ -14,22 +14,28 @@ interface DatePickerProps {
   placeholder?: string;
 }
 
-export const DatePicker = React.forwardRef<HTMLDivElement, DatePickerProps>(
-  ({ autocomplete, ...props }, ref) => {
-    return (
-      <BaseDatePicker
-        className="border-modal-input placeholder-modal-input placeholder:text-foreground/50 p-4"
-        date={props.date}
-        disabled={props.disabled}
-        onBlur={props.onBlur}
-        placeholder={props.placeholder}
-        ref={ref}
-        setDate={props.onChange}
-        {...(autocomplete ? { autoComplete: autocomplete } : {})}
-      />
-    );
-  },
-);
+export const DatePicker = (
+  {
+    ref,
+    autocomplete,
+    ...props
+  }: DatePickerProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  return (
+    <BaseDatePicker
+      className="border-modal-input placeholder-modal-input placeholder:text-foreground/50 p-4"
+      date={props.date}
+      disabled={props.disabled}
+      onBlur={props.onBlur}
+      placeholder={props.placeholder}
+      ref={ref}
+      setDate={props.onChange}
+      {...(autocomplete ? { autoComplete: autocomplete } : {})}
+    />
+  );
+};
 DatePicker.displayName = "DatePicker";
 
 export function registerDatePicker() {

--- a/libs/portal-framework-ui/src/components/form/fields/EmailInput.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/EmailInput.tsx
@@ -12,13 +12,19 @@ interface EmailInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   placeholder?: string;
 }
 
-export const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
-  ({ autocomplete, ...props }, ref) => {
-    return (
-      <Input autoComplete={autocomplete} ref={ref} type="email" {...props} />
-    );
-  },
-);
+export const EmailInput = (
+  {
+    ref,
+    autocomplete,
+    ...props
+  }: EmailInputProps & {
+    ref: React.RefObject<HTMLInputElement>;
+  }
+) => {
+  return (
+    <Input autoComplete={autocomplete} ref={ref} type="email" {...props} />
+  );
+};
 EmailInput.displayName = "EmailInput";
 
 export function registerEmailInput() {

--- a/libs/portal-framework-ui/src/components/form/fields/FileInput.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/FileInput.tsx
@@ -16,21 +16,27 @@ interface FileInputProps {
   value?: FileList;
 }
 
-export const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
-  ({ autocomplete, ...props }, ref) => {
-    return (
-      <Input
-        autoComplete={autocomplete}
-        disabled={props.disabled}
-        name={props.name}
-        onBlur={props.onBlur}
-        onChange={(e) => props.onChange?.(e.target.files)}
-        ref={ref}
-        type="file"
-      />
-    );
-  },
-);
+export const FileInput = (
+  {
+    ref,
+    autocomplete,
+    ...props
+  }: FileInputProps & {
+    ref: React.RefObject<HTMLInputElement>;
+  }
+) => {
+  return (
+    <Input
+      autoComplete={autocomplete}
+      disabled={props.disabled}
+      name={props.name}
+      onBlur={props.onBlur}
+      onChange={(e) => props.onChange?.(e.target.files)}
+      ref={ref}
+      type="file"
+    />
+  );
+};
 FileInput.displayName = "FileInput";
 
 export function registerFileInput() {

--- a/libs/portal-framework-ui/src/components/form/fields/Input.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Input.tsx
@@ -14,34 +14,34 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   // value is included via React.InputHTMLAttributes
 }
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  (
-    {
-      autocomplete,
-      autoComplete: htmlAutoComplete,
-      inputClassName,
-      onChange,
-      placeholder,
-      type,
-      value,
-      ...props
-    },
+export const Input = (
+  {
     ref,
-  ) => {
-    return (
-      <BaseInput
-        autoComplete={autocomplete ?? htmlAutoComplete}
-        className={cn("bg-input h-14 border-none", inputClassName)}
-        onChange={onChange}
-        placeholder={placeholder}
-        ref={ref}
-        type={type}
-        value={value ?? ""} // Use value prop directly, default to empty string
-        {...props}
-      />
-    );
-  },
-);
+    autocomplete,
+    autoComplete: htmlAutoComplete,
+    inputClassName,
+    onChange,
+    placeholder,
+    type,
+    value,
+    ...props
+  }: InputProps & {
+    ref: React.RefObject<HTMLInputElement>;
+  }
+) => {
+  return (
+    <BaseInput
+      autoComplete={autocomplete ?? htmlAutoComplete}
+      className={cn("bg-input h-14 border-none", inputClassName)}
+      onChange={onChange}
+      placeholder={placeholder}
+      ref={ref}
+      type={type}
+      value={value ?? ""} // Use value prop directly, default to empty string
+      {...props}
+    />
+  );
+};
 Input.displayName = "Input";
 
 export function registerInput() {

--- a/libs/portal-framework-ui/src/components/form/fields/RadioGroup.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/RadioGroup.tsx
@@ -26,34 +26,41 @@ function slugify(str: string): string {
     .replace(/^-|-$/g, "");
 }
 
-export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
-  ({ autocomplete, options, ...props }, ref) => {
-    return (
-      <BaseRadioGroup
-        disabled={props.disabled}
-        name={props.name}
-        onBlur={props.onBlur}
-        onValueChange={props.onChange}
-        ref={ref}
-        value={props.value}>
-        {options.map((option) => (
-          <div className="radio-option" key={option}>
-            <RadioGroupItem
-              id={`${props.name}-${slugify(option)}`}
-              value={option}
-              {...(autocomplete ? { autoComplete: autocomplete } : {})}
-            />
-            <label
-              className={props.labelClassName}
-              htmlFor={`${props.name}-${slugify(option)}`}>
-              {option}
-            </label>
-          </div>
-        ))}
-      </BaseRadioGroup>
-    );
-  },
-);
+export const RadioGroup = (
+  {
+    ref,
+    autocomplete,
+    options,
+    ...props
+  }: RadioGroupProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  return (
+    <BaseRadioGroup
+      disabled={props.disabled}
+      name={props.name}
+      onBlur={props.onBlur}
+      onValueChange={props.onChange}
+      ref={ref}
+      value={props.value}>
+      {options.map((option) => (
+        <div className="radio-option" key={option}>
+          <RadioGroupItem
+            id={`${props.name}-${slugify(option)}`}
+            value={option}
+            {...(autocomplete ? { autoComplete: autocomplete } : {})}
+          />
+          <label
+            className={props.labelClassName}
+            htmlFor={`${props.name}-${slugify(option)}`}>
+            {option}
+          </label>
+        </div>
+      ))}
+    </BaseRadioGroup>
+  );
+};
 RadioGroup.displayName = "RadioGroup";
 
 export function registerRadioGroup() {

--- a/libs/portal-framework-ui/src/components/form/fields/RichText.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/RichText.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from "react";
 
 import { Editor as BaseEditor, ToolbarOption } from "@/components/editor";
 
@@ -12,33 +12,33 @@ interface RichTextProps extends FormComponentProps {
   toolbarOptions?: ToolbarOption[];
 }
 
-export const RichText = forwardRef<HTMLDivElement, RichTextProps>(
-  (
-    {
-      autocomplete,
-      enablePreview,
-      onChange,
-      placeholder,
-      required,
-      toolbarOptions,
-      value,
-    },
+export const RichText = (
+  {
     ref,
-  ) => {
-    return (
-      <BaseEditor
-        enablePreview={enablePreview}
-        onChange={onChange}
-        placeholder={placeholder}
-        ref={ref}
-        required={required}
-        toolbarOptions={toolbarOptions}
-        value={value}
-        {...(autocomplete ? { autoComplete: autocomplete } : {})}
-      />
-    );
-  },
-);
+    autocomplete,
+    enablePreview,
+    onChange,
+    placeholder,
+    required,
+    toolbarOptions,
+    value
+  }: RichTextProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  return (
+    <BaseEditor
+      enablePreview={enablePreview}
+      onChange={onChange}
+      placeholder={placeholder}
+      ref={ref}
+      required={required}
+      toolbarOptions={toolbarOptions}
+      value={value}
+      {...(autocomplete ? { autoComplete: autocomplete } : {})}
+    />
+  );
+};
 RichText.displayName = "MarkdownEditor";
 
 export function registerRichText() {

--- a/libs/portal-framework-ui/src/components/form/fields/Select.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Select.tsx
@@ -13,61 +13,58 @@ import type { FormFieldOption } from "@/components";
 import { registerFormComponent } from ".";
 import { FormFieldType } from "@/components";
 
-export const Select = React.forwardRef<
-  HTMLButtonElement,
+export const Select = (
   {
+    ref,
+    autocomplete,
+    inputClassName,
+    onChange,
+    options,
+    placeholder = "Select...",
+    required,
+    value,
+    ...props
+  }: {
     [key: string]: any;
     autocomplete?: string;
     className?: string;
     label?: string;
     options: FormFieldOption[];
     placeholder?: string;
+  } & {
+    ref: React.RefObject<HTMLButtonElement>;
   }
->(
-  (
-    {
-      autocomplete,
-      inputClassName,
-      onChange,
-      options,
-      placeholder = "Select...",
-      required,
-      value,
-      ...props
-    },
-    ref,
-  ) => {
-    return (
-      <BaseSelect
-        onValueChange={onChange}
-        required={required}
-        value={value || ""}
-        {...(autocomplete ? { autoComplete: autocomplete } : {})}
-        {...props}>
-        <SelectTrigger
-          className={cn(
-            "bg-modal-input text-foreground placeholder:text-foreground/50 h-14 w-full border-none",
-            inputClassName,
-            "data-[placeholder]:text-foreground/50",
-          )}
-          ref={ref}>
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-        <SelectContent>
-          {(options || []).map((option: FormFieldOption) => {
-            const value = typeof option === "string" ? option : option.value;
-            const label = typeof option === "string" ? option : option.label;
-            return (
-              <SelectItem key={value} value={value}>
-                {label}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </BaseSelect>
-    );
-  },
-);
+) => {
+  return (
+    <BaseSelect
+      onValueChange={onChange}
+      required={required}
+      value={value || ""}
+      {...(autocomplete ? { autoComplete: autocomplete } : {})}
+      {...props}>
+      <SelectTrigger
+        className={cn(
+          "bg-modal-input text-foreground placeholder:text-foreground/50 h-14 w-full border-none",
+          inputClassName,
+          "data-[placeholder]:text-foreground/50",
+        )}
+        ref={ref}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {(options || []).map((option: FormFieldOption) => {
+          const value = typeof option === "string" ? option : option.value;
+          const label = typeof option === "string" ? option : option.label;
+          return (
+            <SelectItem key={value} value={value}>
+              {label}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </BaseSelect>
+  );
+};
 Select.displayName = "Select";
 
 export function registerSelect() {

--- a/libs/portal-framework-ui/src/components/form/fields/Slider.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Slider.tsx
@@ -17,22 +17,32 @@ interface SliderProps {
   value?: number;
 }
 
-export const Slider = React.forwardRef<HTMLSpanElement, SliderProps>(
-  ({ max = 100, min = 0, onChange, step = 1, value, ...props }, ref) => {
-    return (
-      <BaseSlider
-        disabled={props.disabled}
-        max={max}
-        min={min}
-        onBlur={props.onBlur}
-        onValueChange={(vals) => onChange?.(vals[0])}
-        ref={ref}
-        step={step}
-        value={[value || min]}
-      />
-    );
-  },
-);
+export const Slider = (
+  {
+    ref,
+    max = 100,
+    min = 0,
+    onChange,
+    step = 1,
+    value,
+    ...props
+  }: SliderProps & {
+    ref: React.RefObject<HTMLSpanElement>;
+  }
+) => {
+  return (
+    <BaseSlider
+      disabled={props.disabled}
+      max={max}
+      min={min}
+      onBlur={props.onBlur}
+      onValueChange={(vals) => onChange?.(vals[0])}
+      ref={ref}
+      step={step}
+      value={[value || min]}
+    />
+  );
+};
 Slider.displayName = "Slider";
 
 export function registerSlider() {

--- a/libs/portal-framework-ui/src/components/form/fields/Switch.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Switch.tsx
@@ -19,31 +19,38 @@ interface SwitchProps {
   value?: boolean;
 }
 
-export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ autocomplete, label, ...props }, ref) => {
-    return (
-      <>
-        <BaseSwitch
-          checked={props.value}
-          disabled={props.disabled}
-          id={props.name}
-          name={props.name}
-          onBlur={props.onBlur}
-          onCheckedChange={props.onChange}
-          ref={ref}
-          {...(autocomplete ? { autoComplete: autocomplete } : {})}
-        />
-        {label && (
-          <Label
-            className={cn("text-foreground", props.labelClassName)}
-            htmlFor={props.name}>
-            {label}
-          </Label>
-        )}
-      </>
-    );
-  },
-);
+export const Switch = (
+  {
+    ref,
+    autocomplete,
+    label,
+    ...props
+  }: SwitchProps & {
+    ref: React.RefObject<HTMLButtonElement>;
+  }
+) => {
+  return (
+    <>
+      <BaseSwitch
+        checked={props.value}
+        disabled={props.disabled}
+        id={props.name}
+        name={props.name}
+        onBlur={props.onBlur}
+        onCheckedChange={props.onChange}
+        ref={ref}
+        {...(autocomplete ? { autoComplete: autocomplete } : {})}
+      />
+      {label && (
+        <Label
+          className={cn("text-foreground", props.labelClassName)}
+          htmlFor={props.name}>
+          {label}
+        </Label>
+      )}
+    </>
+  );
+};
 Switch.displayName = "Switch";
 
 export function registerSwitch() {

--- a/libs/portal-framework-ui/src/components/form/fields/Textarea.tsx
+++ b/libs/portal-framework-ui/src/components/form/fields/Textarea.tsx
@@ -7,45 +7,34 @@ import React from "react";
 import { registerFormComponent } from ".";
 import { FormFieldType } from "@/components";
 
-export const Textarea = React.forwardRef<
-  HTMLTextAreaElement,
-  React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
-    [key: string]: any; // Allow other props
-    autocomplete?: string;
-    className?: string;
-    inputClassName?: string; // Use inputClassName for the actual textarea element
-    label?: string;
-    placeholder?: string;
-  }
->(
-  (
-    {
-      autocomplete,
-      autoComplete: htmlAutoComplete,
-      inputClassName,
-      onChange,
-      placeholder,
-      value,
-      ...props
-    },
+export const Textarea = // Use inputClassName for the actual textarea element
+(
+  {
     ref,
-  ) => {
-    return (
-      <BaseTextarea
-        autoComplete={autocomplete ?? htmlAutoComplete}
-        className={cn(
-          "border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
-          inputClassName,
-        )}
-        onChange={onChange}
-        placeholder={placeholder}
-        ref={ref}
-        value={value ?? ""} // Use value prop directly, default to empty string
-        {...props}
-      />
-    );
-  },
-);
+    autocomplete,
+    autoComplete: htmlAutoComplete,
+    inputClassName,
+    onChange,
+    placeholder,
+    value,
+    ...props
+  }
+) => {
+  return (
+    <BaseTextarea
+      autoComplete={autocomplete ?? htmlAutoComplete}
+      className={cn(
+        "border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+        inputClassName,
+      )}
+      onChange={onChange}
+      placeholder={placeholder}
+      ref={ref}
+      value={value ?? ""} // Use value prop directly, default to empty string
+      {...props}
+    />
+  );
+};
 Textarea.displayName = "Textarea";
 
 export function registerTextarea() {


### PR DESCRIPTION
- Refactor MainNavigation, Editor, DatePicker, EmailInput, FileInput, Input, RadioGroup, RichText, Select, Slider, Switch, and Textarea components
- Replace React.forwardRef with regular function components
- Explicitly type ref prop in component signatures
- Maintain existing functionality while improving component definition consistency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal component architecture to improve code maintainability and consistency across the form and navigation components. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->