### PR TITLE
fix(portal-framework-ui): add return type to `useMobileDetection` hook

### DIFF
--- a/libs/portal-framework-ui/src/components/data-table/useMobileDetection.ts
+++ b/libs/portal-framework-ui/src/components/data-table/useMobileDetection.ts
@@ -1,4 +1,4 @@
-import { useMobileDetection as useCoreMobileDetection } from "@lumeweb/portal-framework-ui-core";
+import { useMobileDetection as useCoreMobileDetection, type UseMobileDetectionReturn } from "@lumeweb/portal-framework-ui-core";
 import { ComponentSize } from "@/components";
 
 interface UseMobileDetectionProps {
@@ -29,7 +29,7 @@ const breakpointSizeMap: Record<ComponentSize, string> = {
  */
 function useMobileDetection({
   mobileBreakpoint = ComponentSize.SM,
-}: UseMobileDetectionProps = {}) {
+}: UseMobileDetectionProps = {}): UseMobileDetectionReturn {
   // Convert ComponentSize to Tailwind breakpoint name if needed
   const breakpointName = Object.values(ComponentSize).includes(
     mobileBreakpoint as ComponentSize,


### PR DESCRIPTION
- Imported `UseMobileDetectionReturn` type from `@lumeweb/portal-framework-ui-core`
- Added explicit return type annotation to the `useMobileDetection` function
- This improves type safety and code clarity for the hook's return value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for internal components through enhanced type annotations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->