### PR TITLE
fix(portal-framework-core): bundle all CSS in module federation builds

### DIFF
--- a/libs/portal-framework-core/src/vite/plugin.ts
+++ b/libs/portal-framework-core/src/vite/plugin.ts
@@ -119,9 +119,8 @@ export function Config(opts: ConfigOptions) {
   const normalizedOpts = normalizeConfigOptions(opts);
   const resolvedRuntimePlugins: string[] = [];
   try {
-    const bridgeReactPluginPath = require.resolve(
-      "@module-federation/bridge-react/plugin",
-    );
+    const bridgeReactPluginPath =
+      require.resolve("@module-federation/bridge-react/plugin");
     resolvedRuntimePlugins.push(bridgeReactPluginPath);
   } catch (error) {
     console.error(
@@ -149,6 +148,7 @@ export function Config(opts: ConfigOptions) {
       remotePlugin: isPlugin,
       runtimePlugins,
       shared: sharedModules,
+      bundleAllCSS: true,
       ...configOverrides,
     });
   }


### PR DESCRIPTION
- Added `bundleAllCSS: true` to module federation configuration to ensure proper CSS handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSS bundling in runtime configuration is now enabled by default for improved CSS handling during module federation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->