### PR TITLE
refactor(portal-framework-ui): refactor refineTable usage to align with @refinedev/react-table v4 API

### DIFF
--- a/libs/portal-framework-ui/src/components/data-table/BaseTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/BaseTable.tsx
@@ -183,9 +183,9 @@ function BaseTableWithData<TData extends BaseRecord>(
               props.refineTable
                 ? {
                     tableInstance: props.refineTable,
-                    refetch: props.refineTable?.refineCore?.tableQuery?.refetch,
-                    isLoading: props.refineTable?.refineCore?.tableQuery?.isFetching,
-                    error: props.refineTable?.refineCore?.tableQuery?.error,
+                    refetch: props.refineTable?.tableQuery?.refetch,
+                    isLoading: props.refineTable?.tableQuery?.isFetching,
+                    error: props.refineTable?.tableQuery?.error,
                   }
                 : undefined
             }>
@@ -257,9 +257,9 @@ function BaseTable<TData extends object>(props: BaseTableProps<TData>) {
                 props.refineTable
                   ? {
                       tableInstance: props.refineTable,
-                      refetch: props.refineTable?.refineCore?.tableQuery?.refetch,
-                      isLoading: props.refineTable?.refineCore?.tableQuery?.isFetching,
-                      error: props.refineTable?.refineCore?.tableQuery?.error,
+                      refetch: props.refineTable?.tableQuery?.refetch,
+                      isLoading: props.refineTable?.tableQuery?.isFetching,
+                      error: props.refineTable?.tableQuery?.error,
                     }
                   : undefined
               }>

--- a/libs/portal-framework-ui/src/components/data-table/BaseTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/BaseTable.tsx
@@ -7,7 +7,8 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import React from "react";
-import { BaseRecord, useTableReturnType } from "@refinedev/core";
+import { BaseRecord } from "@refinedev/core";
+import type { UseTableReturnType } from "@refinedev/react-table";
 
 import { BaseTableInner } from "./BaseTableInner";
 import {
@@ -36,7 +37,7 @@ export type ActionColumnDef<TData> = ColumnDef<TData, unknown> & {
 
 export interface BaseTableRefineProps<TData extends BaseRecord> {
   /** Refine table instance */
-  refineTable?: useTableReturnType<TData, any>;
+  refineTable?: UseTableReturnType<TData, any>["refineCore"];
 }
 
 export interface BaseTableCommonProps<TData extends BaseRecord> {
@@ -83,7 +84,7 @@ export interface TableDataProps<TData> {
 
 export interface TableInstanceProps<TData extends BaseRecord> {
   table: Table<TData>;
-  refineTable?: useTableReturnType<TData, any>;
+  refineTable?: UseTableReturnType<TData, any>["refineCore"];
 }
 
 export interface TableInteractionProps<TData> {
@@ -182,9 +183,9 @@ function BaseTableWithData<TData extends BaseRecord>(
               props.refineTable
                 ? {
                     tableInstance: props.refineTable,
-                    refetch: props.refineTable?.tableQuery?.refetch,
-                    isLoading: props.refineTable?.tableQuery?.isFetching,
-                    error: props.refineTable?.tableQuery?.error,
+                    refetch: props.refineTable?.refineCore?.tableQuery?.refetch,
+                    isLoading: props.refineTable?.refineCore?.tableQuery?.isFetching,
+                    error: props.refineTable?.refineCore?.tableQuery?.error,
                   }
                 : undefined
             }>
@@ -256,9 +257,9 @@ function BaseTable<TData extends object>(props: BaseTableProps<TData>) {
                 props.refineTable
                   ? {
                       tableInstance: props.refineTable,
-                      refetch: props.refineTable?.tableQuery?.refetch,
-                      isLoading: props.refineTable?.tableQuery?.isFetching,
-                      error: props.refineTable?.tableQuery?.error,
+                      refetch: props.refineTable?.refineCore?.tableQuery?.refetch,
+                      isLoading: props.refineTable?.refineCore?.tableQuery?.isFetching,
+                      error: props.refineTable?.refineCore?.tableQuery?.error,
                     }
                   : undefined
               }>

--- a/libs/portal-framework-ui/src/components/data-table/DataTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/DataTable.tsx
@@ -1,7 +1,10 @@
-import { BaseRecord } from "@refinedev/core";
+import {
+  BaseRecord,
+  getDefaultFilter as refineGetDefaultFilter,
+} from "@refinedev/core";
 import { useTable as useRefineTable } from "@refinedev/react-table";
 import { Table } from "@tanstack/react-table";
-import React, { useMemo, useRef } from "react";
+import React, { useMemo } from "react";
 
 import type { DataTableProps } from "./DataTable.types";
 
@@ -14,14 +17,10 @@ import {
   TableConfigProvider,
   TableInstanceProvider,
 } from "./contexts";
-import { getDefaultFilter as refineGetDefaultFilter } from "@refinedev/core";
 import {
   getAvailableOperators as getAvailableOperatorsHelper,
   getDefaultOperatorForFieldType,
 } from "./toolbarItems/filters/hooks/useFilterOperators";
-
-// Instance counter to track component creations
-let instanceCounter = 0;
 
 function DataTable<
   TData extends BaseRecord = BaseRecord,
@@ -91,9 +90,9 @@ function DataTable<
   });
 
   const table: Table<TData> = {
-    ...refineTable,
+    ...refineTable.reactTable,
     options: {
-      ...refineTable.options,
+      ...refineTable.reactTable.options,
       refineCore: refineTable.refineCore,
     },
   } as unknown as Table<TData>;
@@ -112,7 +111,7 @@ function DataTable<
     getAvailableOperatorsHelper(fieldType);
 
   return (
-    <RefineTableProvider refineTable={refineTable.refineCore}>
+    <RefineTableProvider refineTable={refineTable}>
       <TableInstanceProvider table={table}>
         <FilterHelpersProvider
           refineTable={refineTable}

--- a/libs/portal-framework-ui/src/components/data-table/Toolbar.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/Toolbar.tsx
@@ -231,7 +231,7 @@ function Toolbar<TData extends BaseRecord>({
 
   // Access the rest of the properties from refineTable
   const { setFilters, setSorters, tableQuery, filters, sorters } =
-    refineTable || {};
+    refineTable?.refineCore || {};
 
   // Sort items by order if specified (compute regardless of config presence)
   const sortedItems = React.useMemo(() => {

--- a/libs/portal-framework-ui/src/components/data-table/Toolbar.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/Toolbar.tsx
@@ -194,7 +194,7 @@ function Toolbar<TData extends BaseRecord>({
   table,
   className,
 }: ToolbarProps<TData>) {
-  const { refineTable } = useRefineTable<TData>();
+  const { setFilters, setSorters, tableQuery, filters, sorters } = useRefineTable<TData>();
   const { toolbarConfig: config, refineContext } = useTableConfig<TData>();
   const { getDefaultFilter, getDefaultOperator } = useFilterHelpers<TData>();
 
@@ -229,9 +229,7 @@ function Toolbar<TData extends BaseRecord>({
     mobileBreakpoint: mobileBreakpoint,
   });
 
-  // Access the rest of the properties from refineTable
-  const { setFilters, setSorters, tableQuery, filters, sorters } =
-    refineTable?.refineCore || {};
+
 
   // Sort items by order if specified (compute regardless of config presence)
   const sortedItems = React.useMemo(() => {

--- a/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import type { UseTableReturnType } from "@refinedev/react-table";
 import type { BaseRecord } from "@refinedev/core";
@@ -28,15 +29,11 @@ export interface RefineTableProviderProps<TData extends BaseRecord> {
   refineTable?: UseTableReturnType<TData, any>;
 }
 
-// Generate unique instance ID for tracking multiple provider instances
-const generateInstanceId = () => Math.random().toString(36).substr(2, 9);
-
 export function RefineTableProvider<TData extends BaseRecord>({
   children,
   refineTable,
 }: RefineTableProviderProps<TData>) {
-  // Create unique instance identifier
-  const instanceId = useMemo(() => generateInstanceId(), []);
+  const [version, setVersion] = useState(0);
 
   // Use refs to stabilize references and prevent contexts thrashing
   const refineTableRef = useRef(refineTable);
@@ -82,6 +79,9 @@ export function RefineTableProvider<TData extends BaseRecord>({
     // Always update these refs as they may change reference without content change
     refineTableRef.current = refineTable;
     tableQueryRef.current = refineTable?.refineCore?.tableQuery;
+
+    // Signal that refs have been updated
+    setVersion((v) => v + 1);
   }, [refineTable]);
 
   // Create stable context value that only changes when refs are updated
@@ -94,14 +94,7 @@ export function RefineTableProvider<TData extends BaseRecord>({
       filters: filtersRef.current,
       sorters: sortersRef.current,
     };
-  }, [
-    refineTableRef.current,
-    setFiltersRef.current,
-    setSortersRef.current,
-    tableQueryRef.current,
-    filtersRef.current,
-    sortersRef.current,
-  ]);
+  }, [version]);
 
   return (
     <RefineTableContext.Provider value={value}>

--- a/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
@@ -106,7 +106,7 @@ export function RefineTableProvider<TData extends BaseRecord>({
       filters: filtersRef.current,
       sorters: sortersRef.current,
     };
-  }, [refineTable, filtersRef.current, sortersRef.current]);
+  }, [refineTable]);
 
   return (
     <RefineTableContext.Provider value={value}>

--- a/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
@@ -66,12 +66,6 @@ export function RefineTableProvider<TData extends BaseRecord>({
     const filtersChanged = !deepEqual(prevFiltersRef.current, newFilters);
 
     if (filtersChanged) {
-      // Check for filter state reset
-      const oldFilters = prevFiltersRef.current || [];
-      if (oldFilters.length > 0 && newFilters.length === 0) {
-        // Filter state reset detected
-      }
-
       filtersRef.current = newFilters;
       prevFiltersRef.current = newFilters;
     }
@@ -81,12 +75,6 @@ export function RefineTableProvider<TData extends BaseRecord>({
     const sortersChanged = !deepEqual(prevSortersRef.current, newSorters);
 
     if (sortersChanged) {
-      // Check for sorter state reset
-      const oldSorters = prevSortersRef.current || [];
-      if (oldSorters.length > 0 && newSorters.length === 0) {
-        // Sorter state reset detected
-      }
-
       sortersRef.current = newSorters;
       prevSortersRef.current = newSorters;
     }
@@ -94,19 +82,26 @@ export function RefineTableProvider<TData extends BaseRecord>({
     // Always update these refs as they may change reference without content change
     refineTableRef.current = refineTable;
     tableQueryRef.current = refineTable?.refineCore?.tableQuery;
-  }, [refineTable, instanceId]);
+  }, [refineTable]);
 
   // Create stable context value that only changes when refs are updated
   const value = useMemo(() => {
     return {
-      refineTable: refineTable,
-      setFilters: refineTable?.refineCore?.setFilters,
-      setSorters: refineTable?.refineCore?.setSorters,
-      tableQuery: refineTable?.refineCore?.tableQuery,
-      filters: refineTable?.refineCore?.filters,
-      sorters: refineTable?.refineCore?.sorters,
+      refineTable: refineTableRef.current,
+      setFilters: setFiltersRef.current,
+      setSorters: setSortersRef.current,
+      tableQuery: tableQueryRef.current,
+      filters: filtersRef.current,
+      sorters: sortersRef.current,
     };
-  }, [refineTable]);
+  }, [
+    refineTableRef.current,
+    setFiltersRef.current,
+    setSortersRef.current,
+    tableQueryRef.current,
+    filtersRef.current,
+    sortersRef.current,
+  ]);
 
   return (
     <RefineTableContext.Provider value={value}>

--- a/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
@@ -49,13 +49,17 @@ export function RefineTableProvider<TData extends BaseRecord>({
 
   // Update refs when values change (only update if actual data changed)
   useEffect(() => {
+    let hasChanges = false;
+
     // Update function refs if they've changed
     if (refineTable?.refineCore?.setFilters !== setFiltersRef.current) {
       setFiltersRef.current = refineTable?.refineCore?.setFilters;
+      hasChanges = true;
     }
 
     if (refineTable?.refineCore?.setSorters !== setSortersRef.current) {
       setSortersRef.current = refineTable?.refineCore?.setSorters;
+      hasChanges = true;
     }
 
     // Deep compare filters to prevent false positives
@@ -65,6 +69,7 @@ export function RefineTableProvider<TData extends BaseRecord>({
     if (filtersChanged) {
       filtersRef.current = newFilters;
       prevFiltersRef.current = newFilters;
+      hasChanges = true;
     }
 
     // Deep compare sorters to prevent false positives
@@ -74,14 +79,22 @@ export function RefineTableProvider<TData extends BaseRecord>({
     if (sortersChanged) {
       sortersRef.current = newSorters;
       prevSortersRef.current = newSorters;
+      hasChanges = true;
     }
 
     // Always update these refs as they may change reference without content change
+    const prevRefineTable = refineTableRef.current;
+    const prevTableQuery = tableQueryRef.current;
     refineTableRef.current = refineTable;
     tableQueryRef.current = refineTable?.refineCore?.tableQuery;
+    if (prevRefineTable !== refineTable || prevTableQuery !== refineTable?.refineCore?.tableQuery) {
+      hasChanges = true;
+    }
 
-    // Signal that refs have been updated
-    setVersion((v) => v + 1);
+    // Signal that refs have been updated only if changes occurred
+    if (hasChanges) {
+      setVersion((v) => v + 1);
+    }
   }, [refineTable]);
 
   // Create stable context value that only changes when refs are updated

--- a/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
@@ -99,12 +99,12 @@ export function RefineTableProvider<TData extends BaseRecord>({
   // Create stable context value that only changes when refs are updated
   const value = useMemo(() => {
     return {
-      refineTable: refineTableRef.current,
-      setFilters: setFiltersRef.current,
-      setSorters: setSortersRef.current,
-      tableQuery: tableQueryRef.current,
-      filters: filtersRef.current,
-      sorters: sortersRef.current,
+      refineTable: refineTable,
+      setFilters: refineTable?.refineCore?.setFilters,
+      setSorters: refineTable?.refineCore?.setSorters,
+      tableQuery: refineTable?.refineCore?.tableQuery,
+      filters: refineTable?.refineCore?.filters,
+      sorters: refineTable?.refineCore?.sorters,
     };
   }, [refineTable]);
 

--- a/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
+++ b/libs/portal-framework-ui/src/components/data-table/contexts/RefineTable.tsx
@@ -6,14 +6,14 @@ import React, {
   useMemo,
   useRef,
 } from "react";
-import type { useTableReturnType } from "@refinedev/core";
+import type { UseTableReturnType } from "@refinedev/react-table";
 import type { BaseRecord } from "@refinedev/core";
 import deepEqual from "fast-deep-equal";
 
 export interface RefineTableContextValue<TData extends BaseRecord> {
-  refineTable?: useTableReturnType<TData, any>;
-  setFilters?: useTableReturnType<TData, any>["setFilters"];
-  setSorters?: useTableReturnType<TData, any>["setSorters"];
+  refineTable?: UseTableReturnType<TData, any>;
+  setFilters?: UseTableReturnType<TData, any>["refineCore"]["setFilters"];
+  setSorters?: UseTableReturnType<TData, any>["refineCore"]["setSorters"];
   tableQuery?: any;
   filters?: any;
   sorters?: any;
@@ -25,7 +25,7 @@ const RefineTableContext = createContext<
 
 export interface RefineTableProviderProps<TData extends BaseRecord> {
   children: React.ReactNode;
-  refineTable?: useTableReturnType<TData, any>;
+  refineTable?: UseTableReturnType<TData, any>;
 }
 
 // Generate unique instance ID for tracking multiple provider instances
@@ -37,63 +37,63 @@ export function RefineTableProvider<TData extends BaseRecord>({
 }: RefineTableProviderProps<TData>) {
   // Create unique instance identifier
   const instanceId = useMemo(() => generateInstanceId(), []);
-  
+
   // Use refs to stabilize references and prevent contexts thrashing
   const refineTableRef = useRef(refineTable);
-  const setFiltersRef = useRef(refineTable?.setFilters);
-  const setSortersRef = useRef(refineTable?.setSorters);
-  const tableQueryRef = useRef(refineTable?.tableQuery);
-  const filtersRef = useRef(refineTable?.filters);
-  const sortersRef = useRef(refineTable?.sorters);
-  
+  const setFiltersRef = useRef(refineTable?.refineCore?.setFilters);
+  const setSortersRef = useRef(refineTable?.refineCore?.setSorters);
+  const tableQueryRef = useRef(refineTable?.refineCore?.tableQuery);
+  const filtersRef = useRef(refineTable?.refineCore?.filters);
+  const sortersRef = useRef(refineTable?.refineCore?.sorters);
+
   // Track previous values for deep comparison
-  const prevFiltersRef = useRef(refineTable?.filters);
-  const prevSortersRef = useRef(refineTable?.sorters);
+  const prevFiltersRef = useRef(refineTable?.refineCore?.filters);
+  const prevSortersRef = useRef(refineTable?.refineCore?.sorters);
 
   // Update refs when values change (only update if actual data changed)
   useEffect(() => {
     // Update function refs if they've changed
-    if (refineTable?.setFilters !== setFiltersRef.current) {
-      setFiltersRef.current = refineTable?.setFilters;
+    if (refineTable?.refineCore?.setFilters !== setFiltersRef.current) {
+      setFiltersRef.current = refineTable?.refineCore?.setFilters;
     }
-    
-    if (refineTable?.setSorters !== setSortersRef.current) {
-      setSortersRef.current = refineTable?.setSorters;
+
+    if (refineTable?.refineCore?.setSorters !== setSortersRef.current) {
+      setSortersRef.current = refineTable?.refineCore?.setSorters;
     }
-    
+
     // Deep compare filters to prevent false positives
-    const newFilters = refineTable?.filters || [];
+    const newFilters = refineTable?.refineCore?.filters || [];
     const filtersChanged = !deepEqual(prevFiltersRef.current, newFilters);
-    
+
     if (filtersChanged) {
       // Check for filter state reset
       const oldFilters = prevFiltersRef.current || [];
       if (oldFilters.length > 0 && newFilters.length === 0) {
         // Filter state reset detected
       }
-      
+
       filtersRef.current = newFilters;
       prevFiltersRef.current = newFilters;
     }
-    
+
     // Deep compare sorters to prevent false positives
-    const newSorters = refineTable?.sorters || [];
+    const newSorters = refineTable?.refineCore?.sorters || [];
     const sortersChanged = !deepEqual(prevSortersRef.current, newSorters);
-    
+
     if (sortersChanged) {
       // Check for sorter state reset
       const oldSorters = prevSortersRef.current || [];
       if (oldSorters.length > 0 && newSorters.length === 0) {
         // Sorter state reset detected
       }
-      
+
       sortersRef.current = newSorters;
       prevSortersRef.current = newSorters;
     }
-    
+
     // Always update these refs as they may change reference without content change
     refineTableRef.current = refineTable;
-    tableQueryRef.current = refineTable?.tableQuery;
+    tableQueryRef.current = refineTable?.refineCore?.tableQuery;
   }, [refineTable, instanceId]);
 
   // Create stable context value that only changes when refs are updated
@@ -117,11 +117,11 @@ export function RefineTableProvider<TData extends BaseRecord>({
 
 export const useRefineTable = <TData extends BaseRecord>() => {
   const context = useContext(RefineTableContext);
-  
+
   if (context === undefined) {
     throw new Error("useRefineTable must be used within a RefineTableProvider");
   }
-  
+
   return context as RefineTableContextValue<TData>;
 };
 


### PR DESCRIPTION
- Updated imports and type references to use `UseTableReturnType` from `@refinedev/react-table`
- Modified `BaseTable` and `DataTable` components to access `refineCore` properties
- Updated `RefineTableProvider` to use `refineCore` for refs and context values
- Adjusted `Toolbar` to access `refineCore` properties


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized table internals around a single core-backed structure; table state and actions now surface via the core.
  * Toolbar and table components now source filters, sorters and query state consistently from the core, improving sync.
  * Provider now supplies the full refined table object while public DataTable export remains unchanged.
  * **Breaking change:** Integrations depending on prior table property shapes must update to the new core-backed access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->