### PR TITLE
feat(portal-sdk): add query builder integration and update tests

### DIFF
--- a/libs/portal-sdk/package.json
+++ b/libs/portal-sdk/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "orval && tsdown",
-    "lint": "eslint .",
+    "lint": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage"
@@ -31,6 +31,9 @@
   "private": false,
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@lumeweb/query-builder": "workspace:*"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.16",

--- a/libs/portal-sdk/src/__tests__/account.test.ts
+++ b/libs/portal-sdk/src/__tests__/account.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { AccountApi } from "@/account";
-import type { Result } from "@/types";
+import { AccountApi, OPERATION_STATUS } from "@/account";
+import { createEqFilter, calculatePagination } from "@/query-utils";
+import { expectSuccess, expectFailure, expectOperationStatus, getPrivateProperty, setPrivateProperty } from "./test-helpers";
 
 // Mock types for testing
 interface MockResponse {
@@ -53,15 +54,15 @@ describe("AccountApi", () => {
   describe("setToken and clearToken", () => {
     it("should set JWT token", () => {
       accountApi.setToken("test-token");
-      const api = accountApi as any;
-      expect(api._jwtToken).toBe("test-token");
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("test-token");
     });
 
     it("should clear JWT token", () => {
       accountApi.setToken("test-token");
       accountApi.clearToken();
-      const api = accountApi as any;
-      expect(api._jwtToken).toBeUndefined();
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBeUndefined();
     });
   });
 
@@ -78,10 +79,11 @@ describe("AccountApi", () => {
       const result = await accountApi.login({
         email: "test@test.com",
         password: "password",
+        remember: false,
       });
 
-      expect(result.success).toBe(true);
-      expect(result.data?.token).toBe("jwt-token-123");
+      expectSuccess(result);
+      expect(result.data.token).toBe("jwt-token-123");
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("https://account.test.com/api/auth/login"),
         expect.objectContaining({
@@ -102,9 +104,10 @@ describe("AccountApi", () => {
       const result = await accountApi.login({
         email: "test@test.com",
         password: "wrong",
+        remember: false,
       });
 
-      expect(result.success).toBe(false);
+      expectFailure(result);
       expect(result.error).toBeDefined();
     });
   });
@@ -116,9 +119,9 @@ describe("AccountApi", () => {
 
       const result = await accountApi.logout();
 
-      expect(result.success).toBe(true);
-      const api = accountApi as any;
-      expect(api._jwtToken).toBeUndefined();
+      expectSuccess(result);
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBeUndefined();
     });
 
     it("should handle logout failure", async () => {
@@ -129,9 +132,9 @@ describe("AccountApi", () => {
 
       const result = await accountApi.logout();
 
-      expect(result.success).toBe(false);
-      const api = accountApi as any;
-      expect(api._jwtToken).toBe("test-token"); // Token should not be cleared on error
+      expectFailure(result);
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("test-token"); // Token should not be cleared on error
     });
   });
 
@@ -142,6 +145,8 @@ describe("AccountApi", () => {
       const result = await accountApi.register({
         email: "test@test.com",
         password: "password",
+        first_name: "Test",
+        last_name: "User",
       });
 
       expect(result.success).toBe(true);
@@ -159,6 +164,8 @@ describe("AccountApi", () => {
       const result = await accountApi.register({
         email: "existing@test.com",
         password: "password",
+        first_name: "Test",
+        last_name: "User",
       });
 
       expect(result.success).toBe(false);
@@ -177,7 +184,9 @@ describe("AccountApi", () => {
       const result = await accountApi.info();
 
       expect(result.success).toBe(true);
-      expect(result.data).toEqual(mockData);
+      if (result.success) {
+        expect(result.data).toEqual(mockData);
+      }
     });
 
     it("should handle unauthorized access", async () => {
@@ -198,10 +207,10 @@ describe("AccountApi", () => {
 
       const result = await accountApi.ping();
 
-      expect(result.success).toBe(true);
-      expect(result.data?.token).toBe("new-token");
-      const api = accountApi as any;
-      expect(api._jwtToken).toBe("new-token");
+      expectSuccess(result);
+      expect(result.data.token).toBe("new-token");
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("new-token");
     });
   });
 
@@ -225,10 +234,11 @@ describe("AccountApi", () => {
 
       const result = await accountApi.confirmPasswordReset({
         token: "reset-token",
-        new_password: "newpassword",
+        password: "newpassword",
+        email: "test@test.com",
       });
 
-      expect(result.success).toBe(true);
+      expectSuccess(result);
     });
   });
 
@@ -248,6 +258,7 @@ describe("AccountApi", () => {
 
       const result = await accountApi.verifyEmail({
         token: "verify-token",
+        email: "test@test.com",
       });
 
       expect(result.success).toBe(true);
@@ -268,7 +279,7 @@ describe("AccountApi", () => {
       mockFetch.mockResolvedValue(mockResponse);
 
       const result = await accountApi.verifyEmail(
-        { token: "verify-token" },
+        { token: "verify-token", email: "test@test.com" },
         true
       );
 
@@ -306,21 +317,21 @@ describe("AccountApi", () => {
 
   describe("OTP methods", () => {
     it("should generate OTP", async () => {
-      const mockData = { secret: "ABC123", qr_code: "data:image/png;base64,..." };
+      const mockData = { otp: "ABC123" };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
 
       const result = await accountApi.generateOtp();
 
-      expect(result.success).toBe(true);
-      expect(result.data?.secret).toBe("ABC123");
+      expectSuccess(result);
+      expect(result.data.otp).toBe("ABC123");
     });
 
     it("should verify OTP", async () => {
       mockFetch.mockResolvedValue(createMockFetchResponse({}, 200));
 
-      const result = await accountApi.verifyOtp({ code: "123456" });
+      const result = await accountApi.verifyOtp({ otp: "123456" });
 
-      expect(result.success).toBe(true);
+      expectSuccess(result);
     });
 
     it("should validate OTP for login", async () => {
@@ -329,21 +340,20 @@ describe("AccountApi", () => {
 
       const result = await accountApi.validateOtp({
         otp: "123456",
-        login_token: "login-token",
       });
 
-      expect(result.success).toBe(true);
-      expect(result.data?.token).toBe("jwt-token");
-      const api = accountApi as any;
-      expect(api._jwtToken).toBe("jwt-token");
+      expectSuccess(result);
+      expect(result.data.token).toBe("jwt-token");
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("jwt-token");
     });
 
     it("should disable OTP", async () => {
       mockFetch.mockResolvedValue(createMockFetchResponse({}, 200));
 
-      const result = await accountApi.disableOtp({ code: "123456" });
+      const result = await accountApi.disableOtp({ password: "testpassword" });
 
-      expect(result.success).toBe(true);
+      expectSuccess(result);
     });
   });
 
@@ -358,8 +368,8 @@ describe("AccountApi", () => {
 
       const result = await accountApi.uploadLimit();
 
-      expect(result.success).toBe(true);
-      expect(result.data?.limit).toBe(10485760);
+      expectSuccess(result);
+      expect(result.data.limit).toBe(10485760);
     });
   });
 
@@ -380,32 +390,48 @@ describe("AccountApi", () => {
   describe("operations", () => {
     it("should list operations", async () => {
       const mockData = {
-        items: [
-          { id: 1, status: "completed" },
-          { id: 2, status: "pending" },
-        ],
-        total: 2,
+        data: {
+          id: 1,
+          status: OPERATION_STATUS.COMPLETED,
+          operation: "upload",
+        },
+        total: 1,
       };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
 
       const result = await accountApi.listOperations();
 
-      expect(result.success).toBe(true);
-      expect(result.data?.items).toHaveLength(2);
+      expectSuccess(result);
+      expect(result.data.data.id).toBe(1);
     });
 
     it("should list operations with filters", async () => {
-      const mockData = { items: [], total: 0 };
+      const mockData = {
+        data: {
+          id: 1,
+          status: OPERATION_STATUS.COMPLETED,
+          operation: "upload",
+        },
+        total: 1,
+      };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
 
       const result = await accountApi.listOperations({
-        status: "completed",
-        limit: 10,
+        filters: [createEqFilter("status", OPERATION_STATUS.COMPLETED)],
+        pagination: { start: 0, end: 10 },
       });
 
-      expect(result.success).toBe(true);
+      expectSuccess(result);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("status=completed"),
+        expect.stringContaining("filters"),
+        expect.anything()
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("status"),
+        expect.anything()
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(OPERATION_STATUS.COMPLETED),
         expect.anything()
       );
     });
@@ -413,48 +439,57 @@ describe("AccountApi", () => {
     it("should get operation details", async () => {
       const mockData = {
         id: 1,
-        status: "completed",
+        status: OPERATION_STATUS.COMPLETED,
         result: { success: true },
       };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
 
       const result = await accountApi.getOperation(1);
 
-      expect(result.success).toBe(true);
-      expect(result.data?.id).toBe(1);
+      expectSuccess(result);
+      expect(result.data.id).toBe(1);
     });
 
     it("should get operation filters", async () => {
       const mockData = {
-        statuses: ["completed", "pending", "failed"],
-        types: ["upload", "download"],
+        data: {
+          data: {
+            statuses: [
+              { id: OPERATION_STATUS.COMPLETED, name: "Completed" },
+              { id: OPERATION_STATUS.PENDING, name: "Pending" },
+              { id: OPERATION_STATUS.FAILED, name: "Failed" },
+            ],
+            operations: [],
+            protocols: [],
+          },
+        },
+        total: 3,
       };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
 
       const result = await accountApi.getOperationFilters();
 
-      expect(result.success).toBe(true);
-      expect(result.data?.statuses).toContain("completed");
+      expectSuccess(result);
+      expect(result.data.data.data.statuses).toHaveLength(3);
     });
 
     it("should wait for operation to complete", async () => {
       const mockData = {
         id: 1,
-        status: "completed",
+        status: OPERATION_STATUS.COMPLETED,
         result: { success: true },
       };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
 
       const result = await accountApi.waitForOperation(1, { interval: 10 });
 
-      expect(result.success).toBe(true);
-      expect(result.data?.status).toBe("completed");
+      expectOperationStatus(result, OPERATION_STATUS.COMPLETED);
     });
 
     it("should timeout when waiting for operation", async () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(
-          createMockFetchResponse({ id: 1, status: "pending" }, 200)
+          createMockFetchResponse({ id: 1, status: OPERATION_STATUS.PENDING }, 200)
         )
       );
 
@@ -463,8 +498,8 @@ describe("AccountApi", () => {
         timeout: 50,
       });
 
-      expect(result.success).toBe(false);
-      expect(result.error?.message).toContain("Polling timed out");
+      expectFailure(result);
+      expect(result.error.message).toContain("Polling timed out");
     });
   });
 
@@ -502,7 +537,7 @@ describe("AccountApi", () => {
 
       const result = await accountApi.info();
 
-      expect(result.success).toBe(false);
+      expectFailure(result);
       expect(result.error).toBeDefined();
     });
 

--- a/libs/portal-sdk/src/__tests__/account.test.ts
+++ b/libs/portal-sdk/src/__tests__/account.test.ts
@@ -390,11 +390,11 @@ describe("AccountApi", () => {
   describe("operations", () => {
     it("should list operations", async () => {
       const mockData = {
-        data: {
+        data: [{
           id: 1,
           status: OPERATION_STATUS.COMPLETED,
           operation: "upload",
-        },
+        }],
         total: 1,
       };
       mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
@@ -402,7 +402,7 @@ describe("AccountApi", () => {
       const result = await accountApi.listOperations();
 
       expectSuccess(result);
-      expect(result.data.data.id).toBe(1);
+      expect(result.data.data[0].id).toBe(1);
     });
 
     it("should list operations with filters", async () => {
@@ -434,6 +434,27 @@ describe("AccountApi", () => {
         expect.stringContaining(OPERATION_STATUS.COMPLETED),
         expect.anything()
       );
+    });
+
+    it("should serialize array filters with indexed keys", async () => {
+      const mockData = { data: [], total: 0 };
+      mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
+
+      await accountApi.listOperations({
+        filters: [
+          { field: "operation", operator: "in", value: ["upload", "download"] }
+        ],
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const url = callArgs[0] as string;
+      const urlObj = new URL(url);
+
+      // Verify indexed array format: filters[operation][in][0]=upload&filters[operation][in][1]=download
+      expect(urlObj.searchParams.get("filters[operation][in][0]")).toBe("upload");
+      expect(urlObj.searchParams.get("filters[operation][in][1]")).toBe("download");
+      // Ensure non-indexed format is NOT used (no direct filters[operation][in]=value)
+      expect(urlObj.searchParams.get("filters[operation][in]")).toBeNull();
     });
 
     it("should get operation details", async () => {

--- a/libs/portal-sdk/src/__tests__/http-utils.test.ts
+++ b/libs/portal-sdk/src/__tests__/http-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { isEmptyResponse, parseResponse, fetchWithHandling, delay, poll } from "@/http-utils";
+import type { Result } from "@/types";
+import { expectSuccess, expectFailure, createMockSuccess } from "./test-helpers";
 
 // Helper function to create mock Response objects with various status codes
 function createMockResponse(
@@ -158,10 +160,11 @@ describe("poll", () => {
     let counter = 0;
     const mockFetch = vi.fn().mockImplementation(async () => {
       counter++;
-      return { success: true, data: counter };
+      return createMockSuccess(counter);
     });
 
-    const result = await poll(mockFetch, (data) => data >= 3, { interval: 10 });
+    const result = await poll(mockFetch, (data: number) => data >= 3, { interval: 10 });
+    expectSuccess(result);
     expect(result.data).toBe(3);
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
@@ -173,9 +176,9 @@ describe("poll", () => {
     });
 
     const result = await poll(mockFetch, () => false, { interval: 10, timeout: 50 });
-    expect(result.success).toBe(false);
+    expectFailure(result);
     expect(result.error).toBeInstanceOf(Error);
-    expect(result.error?.message).toContain("Polling timed out");
+    expect(result.error.message).toContain("Polling timed out");
   });
 
   it("should return error result if fetch fails", async () => {
@@ -185,18 +188,17 @@ describe("poll", () => {
     });
 
     const result = await poll(mockFetch, () => true);
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toBe("Fetch failed");
+    expectFailure(result);
+    expect(result.error.message).toBe("Fetch failed");
   });
 
   it("should use default interval and timeout", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      success: true,
-      data: { status: "completed" },
-    });
+    const mockFetch = vi.fn().mockResolvedValue(
+      createMockSuccess({ status: "completed" })
+    );
 
-    const result = await poll(mockFetch, (data) => data.status === "completed");
-    expect(result.success).toBe(true);
+    const result = await poll(mockFetch, (data: { status: string }) => data.status === "completed");
+    expectSuccess(result);
     expect(result.data).toEqual({ status: "completed" });
   });
 
@@ -216,8 +218,8 @@ describe("poll", () => {
     const result = await poll(mockFetch, () => false, { interval: 10, timeout: 50 });
     const elapsed = Date.now() - startTime;
 
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain("Polling timed out");
+    expectFailure(result);
+    expect(result.error.message).toContain("Polling timed out");
     expect(callCount).toBeLessThanOrEqual(2); // Should only fit 1-2 calls due to latency
     // Total time should be close to timeout, not significantly longer
     expect(elapsed).toBeLessThan(80); // Allow some margin for test execution

--- a/libs/portal-sdk/src/__tests__/query-utils.test.ts
+++ b/libs/portal-sdk/src/__tests__/query-utils.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import type { OperationsQueryParams } from "@/query-utils";
+import {
+  buildOperationsQueryParams,
+  createEqFilter,
+  createInFilter,
+  createDescSort,
+  calculatePagination,
+} from "@/query-utils";
+
+describe("buildOperationsQueryParams", () => {
+  describe("search parameter", () => {
+    it("should include search parameter in URLSearchParams", () => {
+      const params: OperationsQueryParams = {
+        search: "myfile",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("myfile");
+      expect(result.toString()).toBe("search=myfile");
+    });
+
+    it("should combine search with filters", () => {
+      const params: OperationsQueryParams = {
+        filters: [createEqFilter("status", "completed")],
+        search: "test",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("test");
+      expect(result.get("filters[status]")).toBe("completed");
+    });
+
+    it("should combine search with sorters", () => {
+      const params: OperationsQueryParams = {
+        sorters: [createDescSort("id")],
+        search: "test",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("test");
+      expect(result.get("_sort")).toBe("id");
+      expect(result.get("_order")).toBe("desc");
+    });
+
+    it("should combine search with pagination", () => {
+      const params: OperationsQueryParams = {
+        pagination: { start: 0, end: 20 },
+        search: "test",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("test");
+      expect(result.get("_start")).toBe("0");
+      expect(result.get("_end")).toBe("20");
+    });
+
+    it("should handle search with special characters", () => {
+      const params: OperationsQueryParams = {
+        search: "test@example.com",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("test@example.com");
+    });
+
+    it("should handle unicode in search", () => {
+      const params: OperationsQueryParams = {
+        search: "hello 世界",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("hello 世界");
+    });
+  });
+
+  describe("parameter combination", () => {
+    it("should combine filters, sorters, pagination, and search", () => {
+      const params: OperationsQueryParams = {
+        filters: [
+          createEqFilter("status", "completed"),
+          createInFilter("operation", ["upload", "download"]),
+        ],
+        sorters: [createDescSort("id")],
+        pagination: { start: 0, end: 20 },
+        search: "myfile",
+      };
+      const result = buildOperationsQueryParams(params);
+
+      expect(result.get("filters[status]")).toBe("completed");
+      expect(result.get("filters[operation][in][0]")).toBe("upload");
+      expect(result.get("filters[operation][in][1]")).toBe("download");
+      expect(result.get("_sort")).toBe("id");
+      expect(result.get("_order")).toBe("desc");
+      expect(result.get("_start")).toBe("0");
+      expect(result.get("_end")).toBe("20");
+      expect(result.get("search")).toBe("myfile");
+    });
+
+    it("should work with calculatePagination utility", () => {
+      const pagination = calculatePagination(2, 10);
+      const params: OperationsQueryParams = {
+        pagination,
+        search: "test",
+      };
+      const result = buildOperationsQueryParams(params);
+
+      expect(result.get("_start")).toBe("10");
+      expect(result.get("_end")).toBe("20");
+      expect(result.get("search")).toBe("test");
+    });
+  });
+
+  describe("URLSearchParams behavior", () => {
+    it("should return URLSearchParams object", () => {
+      const params: OperationsQueryParams = { search: "test" };
+      const result = buildOperationsQueryParams(params);
+      expect(result).toBeInstanceOf(URLSearchParams);
+    });
+
+    it("should allow iteration over entries", () => {
+      const params: OperationsQueryParams = {
+        filters: [createEqFilter("status", "completed")],
+        search: "test",
+      };
+      const result = buildOperationsQueryParams(params);
+      const entries = Array.from(result.entries());
+      
+      expect(entries.length).toBeGreaterThan(0);
+      expect(entries.some(([key, value]) => key === "search" && value === "test")).toBe(true);
+    });
+
+    it("should allow checking if key exists", () => {
+      const params: OperationsQueryParams = { search: "test" };
+      const result = buildOperationsQueryParams(params);
+      
+      expect(result.has("search")).toBe(true);
+      expect(result.has("filters[status]")).toBe(false);
+    });
+
+    it("should produce valid URL string", () => {
+      const params: OperationsQueryParams = {
+        filters: [createEqFilter("status", "completed")],
+        search: "myfile",
+      };
+      const result = buildOperationsQueryParams(params);
+      const url = result.toString();
+      
+      expect(url).toContain("filters");
+      expect(url).toContain("status");
+      expect(url).toContain("completed");
+      expect(url).toContain("search=myfile");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty params", () => {
+      const params: OperationsQueryParams = {};
+      const result = buildOperationsQueryParams(params);
+      expect(result.toString()).toBe("");
+    });
+
+    it("should handle undefined filters, sorters, pagination", () => {
+      const params: OperationsQueryParams = {
+        filters: undefined,
+        sorters: undefined,
+        pagination: undefined,
+        search: "test",
+      };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe("test");
+      expect(result.get("_sort")).toBeNull();
+      expect(result.get("_order")).toBeNull();
+      expect(result.get("_start")).toBeNull();
+      expect(result.get("_end")).toBeNull();
+    });
+
+    it("should handle very long search terms", () => {
+      const longSearch = "a".repeat(1000);
+      const params: OperationsQueryParams = { search: longSearch };
+      const result = buildOperationsQueryParams(params);
+      expect(result.get("search")).toBe(longSearch);
+    });
+  });
+});

--- a/libs/portal-sdk/src/__tests__/sdk.test.ts
+++ b/libs/portal-sdk/src/__tests__/sdk.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { Sdk } from "@/sdk";
 import { AccountApi } from "@/account";
+import { getPrivateProperty, asMock } from "./test-helpers";
 
 describe("Sdk", () => {
   let sdk: Sdk;
@@ -19,11 +20,11 @@ describe("Sdk", () => {
     });
 
     it("should throw error when API URL is undefined", () => {
-      expect(() => new Sdk(undefined as any)).toThrow("API URL is required");
+      expect(() => new Sdk(asMock(undefined))).toThrow("API URL is required");
     });
 
     it("should throw error when API URL is null", () => {
-      expect(() => new Sdk(null as any)).toThrow("API URL is required");
+      expect(() => new Sdk(asMock(null))).toThrow("API URL is required");
     });
 
     it("should throw error when API URL is whitespace", () => {
@@ -47,22 +48,25 @@ describe("Sdk", () => {
   describe("setAuthToken", () => {
     it("should set JWT token on AccountApi", () => {
       sdk.setAuthToken("test-jwt-token");
-      const accountApi = sdk.account() as any;
-      expect(accountApi._jwtToken).toBe("test-jwt-token");
+      const accountApi = sdk.account();
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("test-jwt-token");
     });
 
     it("should overwrite existing token", () => {
       sdk.setAuthToken("first-token");
       sdk.setAuthToken("second-token");
-      const accountApi = sdk.account() as any;
-      expect(accountApi._jwtToken).toBe("second-token");
+      const accountApi = sdk.account();
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("second-token");
     });
 
     it("should handle empty string token", () => {
       sdk.setAuthToken("some-token");
       sdk.setAuthToken("");
-      const accountApi = sdk.account() as any;
-      expect(accountApi._jwtToken).toBe("");
+      const accountApi = sdk.account();
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe("");
     });
   });
 
@@ -70,14 +74,16 @@ describe("Sdk", () => {
     it("should share token between SDK and AccountApi", () => {
       const token = "shared-token-123";
       sdk.setAuthToken(token);
-      const accountApi = sdk.account() as any;
-      expect(accountApi._jwtToken).toBe(token);
+      const accountApi = sdk.account();
+      const jwtToken = getPrivateProperty(accountApi, "_jwtToken");
+      expect(jwtToken).toBe(token);
     });
 
     it("should initialize AccountApi with correct URL", () => {
       sdk = new Sdk("https://api.example.com");
-      const accountApi = sdk.account() as any;
-      expect(accountApi.apiUrl).toContain("account.api.example.com");
+      const accountApi = sdk.account();
+      const apiUrl = getPrivateProperty(accountApi, "apiUrl");
+      expect(apiUrl).toContain("account.api.example.com");
     });
   });
 });

--- a/libs/portal-sdk/src/__tests__/test-helpers.ts
+++ b/libs/portal-sdk/src/__tests__/test-helpers.ts
@@ -1,0 +1,73 @@
+import { expect } from "vitest";
+import type { Result } from "@/types";
+import type { AccountError } from "@/types";
+
+/**
+ * Type guards and helper functions for testing Result<T> types
+ */
+
+/**
+ * Asserts that a Result is successful and narrows the type
+ */
+export function expectSuccess<T>(result: Result<T>): asserts result is { success: true; data: T } {
+  expect(result.success).toBe(true);
+}
+
+/**
+ * Asserts that a Result failed and narrows the type
+ */
+export function expectFailure<T>(result: Result<T>): asserts result is { success: false; error: AccountError } {
+  expect(result.success).toBe(false);
+}
+
+/**
+ * Helper to check operation status in results
+ */
+export function expectOperationStatus<T extends { status: string }>(result: Result<T>, expectedStatus: string) {
+  expectSuccess(result);
+  expect(result.data.status).toBe(expectedStatus);
+}
+
+/**
+ * Creates a successful mock Result object with proper typing
+ */
+export function createMockSuccess<T>(data: T): Result<T> {
+  return { success: true, data };
+}
+
+/**
+ * Creates a failed mock Result object with proper typing
+ */
+export function createMockFailure(error: Error | string): Result<never> {
+  const errorObj = typeof error === 'string' 
+    ? new Error(error)
+    : error;
+  return { 
+    success: false, 
+    error: errorObj as AccountError 
+  };
+}
+
+/**
+ * Helper to access private properties for testing
+ * Use sparingly and only when testing internal state
+ */
+export function getPrivateProperty<T, K extends string>(obj: T, prop: K): any {
+  return (obj as any)[prop];
+}
+
+/**
+ * Sets a private property for testing
+ * Use sparingly and only when manipulating internal state
+ */
+export function setPrivateProperty<T, K extends string>(obj: T, prop: K, value: any): void {
+  (obj as any)[prop] = value;
+}
+
+/**
+ * Creates a mock with any type for testing invalid inputs
+ * Use sparingly - prefer proper typing when possible
+ */
+export function asMock<T>(value: unknown): T {
+  return value as any;
+}

--- a/libs/portal-sdk/src/account.ts
+++ b/libs/portal-sdk/src/account.ts
@@ -27,6 +27,10 @@ import {
   UploadLimitResponse,
   VerifyEmailRequest,
 } from "@/account/generated";
+import type {
+  OperationsListParams,
+} from "@/query-utils";
+import { buildOperationsQueryParams } from "@/query-utils";
 import { delay, parseResponse, poll } from "@/http-utils";
 
 /**
@@ -346,20 +350,31 @@ export class AccountApi {
 
   /**
    * List operations with filtering, searching, and pagination
-   * @param params Query parameters for filtering and pagination
+   * 
+   * @param params Query parameters using query-builder helpers
    * @returns Result containing list of operations
+   * 
+   * @example
+   * ```ts
+   * const result = await accountApi.listOperations({
+   *   filters: [
+   *     { field: "status", operator: "eq", value: "completed" },
+   *     { field: "operation", operator: "in", value: ["upload", "download"] }
+   *   ],
+   *   sorters: [{ field: "id", order: "desc" }],
+   *   pagination: { start: 0, end: 20, page: 1, pageSize: 20 },
+   *   search: "myfile"
+   * });
+   * ```
    */
   public async listOperations(
-    params?: GetApiOperationsParams,
+    params?: OperationsListParams,
   ): Promise<Result<OperationListItemResponse>> {
     const url = new URL("/api/operations", this.apiUrl);
     
     if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        if (value !== undefined && value !== null) {
-          url.searchParams.set(key, String(value));
-        }
-      }
+      const searchParams = buildOperationsQueryParams(params);
+      url.search = searchParams.toString();
     }
     
     return this.fetchJson<OperationListItemResponse>(url.toString(), {

--- a/libs/portal-sdk/src/account.ts
+++ b/libs/portal-sdk/src/account.ts
@@ -374,7 +374,9 @@ export class AccountApi {
     
     if (params) {
       const searchParams = buildOperationsQueryParams(params);
-      url.search = searchParams.toString();
+      searchParams.forEach((value, key) => {
+        url.searchParams.append(key, value);
+      });
     }
     
     return this.fetchJson<OperationListItemResponse>(url.toString(), {

--- a/libs/portal-sdk/src/index.ts
+++ b/libs/portal-sdk/src/index.ts
@@ -4,3 +4,6 @@ export * from "@/openapi";
 export { DEFAULT_SETTLED_STATES, OPERATION_STATUS } from "@/account";
 export * from "@/account/generated/accountAPI.schemas";
 export * from '@/account/generated/default';
+export * from '@/query-utils';
+export * from './account/generated/default';
+export * from './account/generated/accountAPI.schemas';

--- a/libs/portal-sdk/src/query-utils.ts
+++ b/libs/portal-sdk/src/query-utils.ts
@@ -1,0 +1,153 @@
+/**
+ * Query utilities for operations API
+ * 
+ * Provides types and functions for building query parameters with filters,
+ * sorters, and pagination using the @lumeweb/query-builder library.
+ */
+
+// Import types and functions from query-builder
+import type {
+  ParsedQuery,
+  QueryParams,
+  SerializeInput,
+} from "@lumeweb/query-builder";
+import {
+  serializeQueryParams,
+  calculatePagination,
+  createEqFilter,
+  createNeFilter,
+  createContainsFilter,
+  createInFilter,
+  createBetweenFilter,
+  createSort,
+  createAscSort,
+  createDescSort,
+  addFilter,
+  addFilters,
+  addSorter,
+  addSorters,
+  setFiltersByField,
+  setSorter,
+  clearFilters,
+  clearSorters,
+  LOGICAL_OPERATORS,
+  COMPARISON_OPERATORS,
+  OPERATORS,
+  ARRAY_OPERATORS,
+} from "@lumeweb/query-builder";
+
+// Re-export types
+export type { ParsedQuery, QueryParams, SerializeInput };
+
+// Re-export functions
+export {
+  serializeQueryParams,
+  calculatePagination,
+  createEqFilter,
+  createNeFilter,
+  createContainsFilter,
+  createInFilter,
+  createBetweenFilter,
+  createSort,
+  createAscSort,
+  createDescSort,
+  addFilter,
+  addFilters,
+  addSorter,
+  addSorters,
+  setFiltersByField,
+  setSorter,
+  clearFilters,
+  clearSorters,
+  LOGICAL_OPERATORS,
+  COMPARISON_OPERATORS,
+  OPERATORS,
+  ARRAY_OPERATORS,
+};
+
+/**
+ * Operations query parameters for the operations API
+ * 
+ * Uses query-builder helpers to construct the API query parameters:
+ * - filters: Array of filter objects → serialized to filters[field][operator]=value
+ * - sorters: Array of sort objects → serialized to _sort=field&_order=direction
+ * - pagination: Object with start/end → serialized to _start=0&_end=20
+ * - search: Search term → passed directly as search=value
+ * 
+ * @example
+ * ```ts
+ * const params: OperationsQueryParams = {
+ *   filters: [
+ *     { field: "status", operator: "eq", value: "completed" },
+ *     { field: "operation", operator: "in", value: ["upload", "download"] }
+ *   ],
+ *   sorters: [{ field: "id", order: "desc" }],
+ *   pagination: { start: 0, end: 20, page: 1, pageSize: 20 },
+ *   search: "myfile"
+ * };
+ * ```
+ */
+export interface OperationsQueryParams extends SerializeInput {
+  /** Search term for filename or other relevant operation data */
+  search?: string;
+}
+
+/**
+ * Unified operations query parameters
+ */
+export type OperationsListParams = OperationsQueryParams;
+
+/**
+ * Builds URL query parameters for operations API
+ * 
+ * Serializes query-builder parameters to the API's expected format:
+ * - filters → filters[field][operator]=value
+ * - sorters → _sort=field&_order=direction
+ * - pagination → _start=0&_end=20
+ * - search → search=value
+ * 
+ * @param params - Query parameters using query-builder helpers
+ * @returns URLSearchParams object ready to use with fetch
+ * 
+ * @example
+ * ```ts
+ * const searchParams = buildOperationsQueryParams({
+ *   filters: [
+ *     { field: "status", operator: "eq", value: "completed" },
+ *     { field: "operation", operator: "in", value: ["upload", "download"] }
+ *   ],
+ *   sorters: [{ field: "id", order: "desc" }],
+ *   pagination: { start: 0, end: 20, page: 1, pageSize: 20 },
+ *   search: "myfile"
+ * });
+ * 
+ * // Result URL: ?filters[status][eq]=completed&filters[operation][in][0]=upload&filters[operation][in][1]=download&_sort=id&_order=desc&_start=0&_end=20&search=myfile
+ * ```
+ */
+export function buildOperationsQueryParams(params: OperationsQueryParams): URLSearchParams {
+  const queryParams = serializeQueryParams({
+    filters: params.filters,
+    sorters: params.sorters,
+    pagination: params.pagination,
+  });
+
+  const searchParams = new URLSearchParams();
+
+  // Add serialized query parameters
+  for (const [key, value] of Object.entries(queryParams)) {
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        searchParams.append(key, v);
+      }
+    } else {
+      searchParams.set(key, value);
+    }
+  }
+
+  // Add search parameter if provided
+  if (params.search) {
+    searchParams.set("search", params.search);
+  }
+
+  return searchParams;
+}

--- a/libs/portal-sdk/src/query-utils.ts
+++ b/libs/portal-sdk/src/query-utils.ts
@@ -125,24 +125,13 @@ export type OperationsListParams = OperationsQueryParams;
  * ```
  */
 export function buildOperationsQueryParams(params: OperationsQueryParams): URLSearchParams {
-  const queryParams = serializeQueryParams({
+  const queryString = serializeQueryParams({
     filters: params.filters,
     sorters: params.sorters,
     pagination: params.pagination,
   });
 
-  const searchParams = new URLSearchParams();
-
-  // Add serialized query parameters
-  for (const [key, value] of Object.entries(queryParams)) {
-    if (Array.isArray(value)) {
-      for (const v of value) {
-        searchParams.append(key, v);
-      }
-    } else {
-      searchParams.set(key, value);
-    }
-  }
+  const searchParams = new URLSearchParams(queryString);
 
   // Add search parameter if provided
   if (params.search) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1270,6 +1270,10 @@ importers:
         version: 5.9.3
 
   libs/portal-sdk:
+    dependencies:
+      '@lumeweb/query-builder':
+        specifier: workspace:*
+        version: link:../query-builder
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.0.16


### PR DESCRIPTION
* Integrate `@lumeweb/query-builder` for advanced filtering, sorting, and pagination in `listOperations`
* Add `query-utils.ts` to export query builder helpers and `buildOperationsQueryParams`
* Update `AccountApi.listOperations` to use new query parameter structure
* Refactor tests to use new test helpers (`expectSuccess`, `expectFailure`, `getPrivateProperty`)
* Update `package.json` to include query-builder dependency and switch lint script to `tsc --noEmit`


---

<!-- kody-pr-summary:start -->
This pull request introduces a query builder integration into the Portal SDK, significantly enhancing the `AccountApi.listOperations` method.

Key changes include:

*   **Query Builder Integration**:
    *   A new `query-utils.ts` module is added, wrapping and re-exporting functionalities from the `@lumeweb/query-builder` library. This provides structured methods for creating filters (e.g., `createEqFilter`, `createInFilter`), sorters (`createAscSort`, `createDescSort`), and pagination (`calculatePagination`).
    *   A `buildOperationsQueryParams` function is introduced to serialize these structured query parameters, along with a `search` term, into URL search parameters compatible with the API.
*   **Enhanced `AccountApi.listOperations`**:
    *   The `listOperations` method in `AccountApi` is updated to accept `OperationsListParams`, allowing users to construct complex queries with filters, sorters, pagination, and a search term using the new query builder helpers.
    *   The method now uses `buildOperationsQueryParams` to generate the API request URL, replacing previous manual parameter handling.
*   **Improved Test Suite**:
    *   New test helper functions (`expectSuccess`, `expectFailure`, `expectOperationStatus`, `getPrivateProperty`, `setPrivateProperty`, `asMock`) are added in `test-helpers.ts` to improve test readability and robustness.
    *   Existing tests for `AccountApi` and `http-utils` are refactored to utilize these new helpers.
    *   Dedicated tests for the `query-utils` module are added to ensure the correct functionality of the query builder.
    *   Minor updates to request parameters in `AccountApi` tests (e.g., adding `remember` to login, `email` to password reset/email verification, adjusting OTP parameters) and mock data structures for operations API calls.
*   **Dependency Update**: The `@lumeweb/query-builder` library is added as a dependency to the `portal-sdk`.

This update provides a more robust and flexible way for consumers of the Portal SDK to query and manage operations.
<!-- kody-pr-summary:end -->