### PR TITLE
refactor(pinner): add operation polling and waitForOperation support

### DIFF
--- a/libs/pinner/package.json
+++ b/libs/pinner/package.json
@@ -44,6 +44,7 @@
     "@ipfs-shipyard/pinning-service-client": "^3.0.0",
     "@ipld/car": "^5.4.2",
     "@lumeweb/portal-sdk": "workspace:*",
+    "@lumeweb/query-builder": "workspace:*",
     "@lumeweb/uppy-post-upload": "workspace:*",
     "@uppy/core": "^5.2.0",
     "@uppy/tus": "^5.1.0",

--- a/libs/pinner/src/__tests__/msw-handlers.ts
+++ b/libs/pinner/src/__tests__/msw-handlers.ts
@@ -31,6 +31,8 @@ export {
   accountUploadLimitHandler,
   accountInfoHandler,
   accountHandlers,
+  operationHandler,
+  operationHandlers,
   uploadHandlers,
 } from "./msw-upload-handlers";
 

--- a/libs/pinner/src/__tests__/msw-helpers.ts
+++ b/libs/pinner/src/__tests__/msw-helpers.ts
@@ -55,6 +55,7 @@ export async function createMockUploadResult(
     numberOfFiles: overrides.numberOfFiles || 1,
     keyvalues: overrides.keyvalues,
     isDirectory: overrides.isDirectory,
+    operationId: overrides.operationId,
   };
 }
 

--- a/libs/pinner/src/__tests__/msw-upload-handlers.ts
+++ b/libs/pinner/src/__tests__/msw-upload-handlers.ts
@@ -2,6 +2,7 @@
 // This file provides mock handlers for all upload-related API operations
 
 import { http, HttpResponse } from "msw";
+import { OPERATION_STATUS } from "@lumeweb/portal-sdk";
 import {
   createMockCID,
   getAccountApiUrl,
@@ -12,6 +13,9 @@ import { applyMockDelay, createMockUploadResult } from "./msw-helpers";
 
 // Counter for TUS upload IDs
 let tusUploadCounter = 0;
+
+// Counter for operation IDs
+let operationCounter = 0;
 
 export function resetTusUploadCounter(): void {
   tusUploadCounter = 0;
@@ -399,6 +403,7 @@ export const xhrUploadHandler = http.post(
       name: filename,
       cid: await createMockCID(getNextRequestId()),
       size: fileSize,
+      operationId: ++operationCounter,
     });
 
     return HttpResponse.json(result, {
@@ -464,6 +469,110 @@ export const accountInfoHandler = http.get(
 export const accountHandlers = [accountUploadLimitHandler, accountInfoHandler];
 
 // ============================================================================
+// OPERATION HANDLERS
+// ============================================================================
+
+// Helper function to create a mock operation
+async function createMockOperation(
+  operationId: number,
+  overrides: Partial<{
+    status: string;
+    error?: string;
+    cid?: string;
+    operation?: string;
+    operation_display_name?: string;
+  }> = {},
+) {
+  const mockCid = overrides.cid || (await createMockCID(operationId));
+
+  return {
+    id: operationId,
+    operation: overrides.operation || "pin",
+    operation_display_name: overrides.operation_display_name || "Pin Content",
+    cid: mockCid,
+    status: overrides.status || OPERATION_STATUS.COMPLETED,
+    status_display_name:
+      overrides.status === OPERATION_STATUS.FAILED ? "Failed" : "Completed",
+    status_message:
+      overrides.status === OPERATION_STATUS.FAILED
+        ? "Pinning failed"
+        : "Pinning completed successfully",
+    error: overrides.error,
+    progress_percent: overrides.status === OPERATION_STATUS.FAILED ? 0 : 100,
+    protocol: "ipfs",
+    protocol_display_name: "IPFS",
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    current_step: overrides.status === OPERATION_STATUS.FAILED ? 0 : 1,
+    total_steps: 1,
+  };
+}
+
+// List operations
+export const listOperationsHandler = http.get(
+  `${getAccountApiUrl()}/api/operations`,
+  async ({ request }) => {
+    await applyMockDelay();
+
+    const url = new URL(request.url);
+    const cidFilter = url.searchParams.get("filters[cid][eq]");
+
+    const result = await createMockOperation(12345, {
+      operation: "upload",
+      operation_display_name: "Upload",
+      cid: cidFilter || undefined,
+    });
+
+    return HttpResponse.json(
+      { data: result, total: 1 },
+      {
+        status: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  },
+);
+
+// Get operation details
+export const operationHandler = http.get(
+  `${getAccountApiUrl()}/api/operations/:id`,
+  async ({ params }) => {
+    await applyMockDelay();
+
+    const operationId = parseInt(params.id as string, 10);
+
+    // Special case: operation ID 99999 should fail
+    if (operationId === 99999) {
+      const result = await createMockOperation(operationId, {
+        status: OPERATION_STATUS.FAILED,
+        error: "Simulated failure",
+      });
+
+      return HttpResponse.json(result, {
+        status: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
+    const result = await createMockOperation(operationId);
+
+    return HttpResponse.json(result, {
+      status: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  },
+);
+
+// Combined operation handlers
+export const operationHandlers = [listOperationsHandler, operationHandler];
+
+// ============================================================================
 // COMBINED UPLOAD HANDLERS
 // ============================================================================
 
@@ -472,4 +581,5 @@ export const uploadHandlers = [
   ...tusUploadHandlers,
   ...xhrUploadHandlers,
   ...accountHandlers,
+  ...operationHandlers,
 ];

--- a/libs/pinner/src/__tests__/pinner.spec.ts
+++ b/libs/pinner/src/__tests__/pinner.spec.ts
@@ -16,6 +16,7 @@ const mockUploadManagerInstance = {
   upload: vi.fn(),
   uploadDirectory: vi.fn(),
   uploadCar: vi.fn(),
+  waitForOperation: vi.fn(),
   destroy: vi.fn(),
 };
 
@@ -304,6 +305,235 @@ describe("Pinner", () => {
     });
   });
 
+  describe("waitForOperation", () => {
+    describe("with operation ID", () => {
+      it("should wait for operation by ID", async () => {
+        const mockCid = await createMockCID(10);
+        const mockResult: UploadResult = {
+          id: "12345",
+          cid: mockCid,
+          name: "test",
+          size: 0,
+          mimeType: "",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+          operationId: 12345,
+        };
+
+        mockUploadManagerInstance.waitForOperation.mockResolvedValue(
+          mockResult,
+        );
+
+        const result = await pinner.waitForOperation(12345);
+
+        expect(mockUploadManagerInstance.waitForOperation).toHaveBeenCalledWith(
+          12345,
+          undefined,
+        );
+        expect(result).toBe(mockResult);
+      });
+
+      it("should pass polling options", async () => {
+        const mockCid = await createMockCID(11);
+        const mockResult: UploadResult = {
+          id: "12345",
+          cid: mockCid,
+          name: "test",
+          size: 0,
+          mimeType: "",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+          operationId: 12345,
+        };
+
+        mockUploadManagerInstance.waitForOperation.mockResolvedValue(
+          mockResult,
+        );
+
+        const pollingOptions = {
+          interval: 1000,
+          timeout: 60000,
+          settledStates: ["completed"],
+        };
+
+        const result = await pinner.waitForOperation(12345, pollingOptions);
+
+        expect(mockUploadManagerInstance.waitForOperation).toHaveBeenCalledWith(
+          12345,
+          pollingOptions,
+        );
+        expect(result).toBe(mockResult);
+      });
+    });
+
+    describe("with UploadResult", () => {
+      it("should wait for operation using UploadResult", async () => {
+        const mockCid = await createMockCID(12);
+        const uploadResult: UploadResult = {
+          id: "upload-123",
+          cid: mockCid,
+          name: "original.txt",
+          size: 1024,
+          mimeType: "text/plain",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+          operationId: 12345,
+        };
+
+        const finalResult: UploadResult = {
+          id: "upload-123",
+          cid: mockCid,
+          name: "original.txt",
+          size: 1024,
+          mimeType: "text/plain",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+          operationId: 12345,
+        };
+
+        mockUploadManagerInstance.waitForOperation.mockResolvedValue(
+          finalResult,
+        );
+
+        const result = await pinner.waitForOperation(uploadResult);
+
+        expect(mockUploadManagerInstance.waitForOperation).toHaveBeenCalledWith(
+          uploadResult,
+          undefined,
+        );
+        expect(result).toBe(finalResult);
+      });
+
+      it("should pass polling options with UploadResult", async () => {
+        const mockCid = await createMockCID(13);
+        const uploadResult: UploadResult = {
+          id: "upload-123",
+          cid: mockCid,
+          name: "original.txt",
+          size: 1024,
+          mimeType: "text/plain",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+          operationId: 12345,
+        };
+
+        const finalResult: UploadResult = {
+          id: "upload-123",
+          cid: mockCid,
+          name: "original.txt",
+          size: 1024,
+          mimeType: "text/plain",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+          operationId: 12345,
+        };
+
+        mockUploadManagerInstance.waitForOperation.mockResolvedValue(
+          finalResult,
+        );
+
+        const pollingOptions = { interval: 2000 };
+
+        const result = await pinner.waitForOperation(
+          uploadResult,
+          pollingOptions,
+        );
+
+        expect(mockUploadManagerInstance.waitForOperation).toHaveBeenCalledWith(
+          uploadResult,
+          pollingOptions,
+        );
+        expect(result).toBe(finalResult);
+      });
+    });
+  });
+
+  describe("upload with waitForOperation option", () => {
+    const mockFile = new File(["test content"], "test.txt", {
+      type: "text/plain",
+    });
+    let mockUploadResult: UploadResult;
+    let mockOperation: UploadOperation;
+
+    beforeEach(async () => {
+      const mockCid = await createMockCID(14);
+      mockUploadResult = createMockUploadResult(
+        "upload-123",
+        mockCid,
+        "test.txt",
+        12,
+        "text/plain",
+      );
+      mockUploadResult.operationId = 12345;
+      mockOperation = await createMockOperation(mockUploadResult);
+      mockUploadManagerInstance.upload.mockResolvedValue(mockOperation);
+    });
+
+    it("should pass waitForOperation option to UploadManager", async () => {
+      const options: UploadOptions = {
+        waitForOperation: true,
+      };
+
+      const operation = await pinner.upload(mockFile, options);
+
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(
+        mockFile,
+        options,
+      );
+      expect(operation).toBe(mockOperation);
+    });
+
+    it("should pass operationPollingOptions to UploadManager", async () => {
+      const options: UploadOptions = {
+        waitForOperation: true,
+        operationPollingOptions: {
+          interval: 1000,
+          timeout: 60000,
+          settledStates: ["completed"],
+        },
+      };
+
+      const operation = await pinner.upload(mockFile, options);
+
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(
+        mockFile,
+        options,
+      );
+      expect(operation).toBe(mockOperation);
+    });
+
+    it("should work with upload builder", async () => {
+      const operation = await pinner.upload
+        .file(mockFile)
+        .waitForOperation(true)
+        .pin();
+
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(mockFile, {
+        waitForOperation: true,
+      });
+      expect(operation).toBe(mockOperation);
+    });
+
+    it("should work with upload builder and polling options", async () => {
+      const pollingOptions = {
+        interval: 2000,
+        timeout: 120000,
+      };
+
+      const operation = await pinner.upload
+        .file(mockFile)
+        .waitForOperation(true)
+        .operationPollingOptions(pollingOptions)
+        .pin();
+
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(mockFile, {
+        waitForOperation: true,
+        operationPollingOptions: pollingOptions,
+      });
+      expect(operation).toBe(mockOperation);
+    });
+  });
+
   describe("uploadDirectory", () => {
     const mockFiles = [
       new File(["file1"], "file1.txt"),
@@ -391,32 +621,33 @@ describe("Pinner", () => {
         keyvalues: { type: "file" },
       });
 
-      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(
-        mockFile,
-        {
-          name: "custom.txt",
-          keyvalues: { type: "file" },
-        },
-      );
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(mockFile, {
+        name: "custom.txt",
+        keyvalues: { type: "file" },
+      });
       expect(operation).toBe(mockOperation);
     });
 
     it("should support upload.file() builder", async () => {
-      const operation = await pinner.upload.file(mockFile).name("custom.txt").keyvalues({ type: "file" }).pin();
+      const operation = await pinner.upload
+        .file(mockFile)
+        .name("custom.txt")
+        .keyvalues({ type: "file" })
+        .pin();
 
-      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(
-        mockFile,
-        {
-          name: "custom.txt",
-          keyvalues: { type: "file" },
-        },
-      );
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(mockFile, {
+        name: "custom.txt",
+        keyvalues: { type: "file" },
+      });
       expect(operation).toBe(mockOperation);
     });
 
     it("should support upload.json() builder", async () => {
       const jsonData = { foo: "bar", nested: { value: 123 } };
-      const operation = await pinner.upload.json(jsonData).name("data.json").pin();
+      const operation = await pinner.upload
+        .json(jsonData)
+        .name("data.json")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -432,7 +663,10 @@ describe("Pinner", () => {
 
     it("should support upload.base64() builder", async () => {
       const base64Data = "SGVsbG8gV29ybGQ=";
-      const operation = await pinner.upload.base64(base64Data).name("hello.txt").pin();
+      const operation = await pinner.upload
+        .base64(base64Data)
+        .name("hello.txt")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -447,7 +681,10 @@ describe("Pinner", () => {
 
     it("should support upload.url() builder", async () => {
       const url = "https://httpbin.org/robots.txt";
-      const operation = await pinner.upload.url(url).name("remote-file.txt").pin();
+      const operation = await pinner.upload
+        .url(url)
+        .name("remote-file.txt")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -462,7 +699,10 @@ describe("Pinner", () => {
 
     it("should support upload.csv() builder with string", async () => {
       const csvData = "name,age\nJohn,30\nJane,25";
-      const operation = await pinner.upload.csv(csvData).name("users.csv").pin();
+      const operation = await pinner.upload
+        .csv(csvData)
+        .name("users.csv")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -481,7 +721,10 @@ describe("Pinner", () => {
         { name: "John", age: 30 },
         { name: "Jane", age: 25 },
       ];
-      const operation = await pinner.upload.csv(csvData).name("users.csv").pin();
+      const operation = await pinner.upload
+        .csv(csvData)
+        .name("users.csv")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -497,7 +740,10 @@ describe("Pinner", () => {
         ["John", 30],
         ["Jane", 25],
       ];
-      const operation = await pinner.upload.csv(csvData).name("users.csv").pin();
+      const operation = await pinner.upload
+        .csv(csvData)
+        .name("users.csv")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -509,7 +755,10 @@ describe("Pinner", () => {
 
     it("should support upload.text() builder", async () => {
       const textData = "Hello, World!";
-      const operation = await pinner.upload.text(textData).name("hello.txt").pin();
+      const operation = await pinner.upload
+        .text(textData)
+        .name("hello.txt")
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -525,7 +774,11 @@ describe("Pinner", () => {
 
     it("should support upload.content() as alias for text()", async () => {
       const textData = "Sample content";
-      const operation = await pinner.upload.content(textData).name("sample.txt").keyvalues({ type: "text" }).pin();
+      const operation = await pinner.upload
+        .content(textData)
+        .name("sample.txt")
+        .keyvalues({ type: "text" })
+        .pin();
 
       expect(mockUploadManagerInstance.upload).toHaveBeenCalled();
       const uploadCall = mockUploadManagerInstance.upload.mock.calls[0];
@@ -544,7 +797,10 @@ describe("Pinner", () => {
         type: "application/vnd.ipld.car",
       });
 
-      const operation = await pinner.upload.raw(mockCarFile).name("my-data.car").pin();
+      const operation = await pinner.upload
+        .raw(mockCarFile)
+        .name("my-data.car")
+        .pin();
 
       expect(mockUploadManagerInstance.uploadCar).toHaveBeenCalledWith(
         mockCarFile,
@@ -564,7 +820,11 @@ describe("Pinner", () => {
         },
       });
 
-      const operation = await pinner.upload.raw(carStream).name("stream-data.car").keyvalues({ source: "stream" }).pin();
+      const operation = await pinner.upload
+        .raw(carStream)
+        .name("stream-data.car")
+        .keyvalues({ source: "stream" })
+        .pin();
 
       expect(mockUploadManagerInstance.uploadCar).toHaveBeenCalledWith(
         carStream,
@@ -604,13 +864,10 @@ describe("Pinner", () => {
         .keyvalues({ key1: "value1", key2: "value2" })
         .pin();
 
-      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(
-        mockFile,
-        {
-          name: "my-file.txt",
-          keyvalues: { key1: "value1", key2: "value2" },
-        },
-      );
+      expect(mockUploadManagerInstance.upload).toHaveBeenCalledWith(mockFile, {
+        name: "my-file.txt",
+        keyvalues: { key1: "value1", key2: "value2" },
+      });
       expect(operation).toBe(mockOperation);
     });
 

--- a/libs/pinner/src/adapters/pinata/list-builder.ts
+++ b/libs/pinner/src/adapters/pinata/list-builder.ts
@@ -4,7 +4,7 @@ import type { RemoteLsOptions } from "@/types/pin";
 
 /**
  * List builder for listing pins.
- * 
+ *
  * Note: .pageToken() provides Pinata SDK API compatibility for easier migration.
  * The token is passed through to the underlying IPFS Pinning Service cursor parameter.
  * The server handles the actual pagination logic according to the IPFS Pinning Service spec.

--- a/libs/pinner/src/blockstore/__tests__/setup.ts
+++ b/libs/pinner/src/blockstore/__tests__/setup.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { setDriverFactory } from "../unstorage-base";
 import memoryDriver from "unstorage/drivers/memory";
 

--- a/libs/pinner/src/blockstore/__tests__/unstorage-factory.spec.ts
+++ b/libs/pinner/src/blockstore/__tests__/unstorage-factory.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createBlockstore, createDatastore } from "../unstorage";
 import { Key } from "interface-datastore";
 import { collectAsyncIterable } from "@/utils/stream";
@@ -27,8 +27,12 @@ describe("Unstorage Factory", () => {
       await blockstore2.put(testData2.cid, testData2.block);
 
       // Verify each blockstore has its own data
-      const result1 = await collectAsyncIterable(blockstore1.get(testData1.cid));
-      const result2 = await collectAsyncIterable(blockstore2.get(testData2.cid));
+      const result1 = await collectAsyncIterable(
+        blockstore1.get(testData1.cid),
+      );
+      const result2 = await collectAsyncIterable(
+        blockstore2.get(testData2.cid),
+      );
 
       expect(Array.from(result1)).toEqual(Array.from(testData1.block));
       expect(Array.from(result2)).toEqual(Array.from(testData2.block));
@@ -36,7 +40,9 @@ describe("Unstorage Factory", () => {
       // Verify they don't share data
       let result1From2: Uint8Array | null = null;
       try {
-        result1From2 = await collectAsyncIterable(blockstore2.get(testData1.cid));
+        result1From2 = await collectAsyncIterable(
+          blockstore2.get(testData1.cid),
+        );
       } catch {}
       expect(result1From2).toBeNull();
     });
@@ -56,8 +62,12 @@ describe("Unstorage Factory", () => {
       await blockstore1.put(testData1.cid, testData1.block);
       await blockstore2.put(testData2.cid, testData2.block);
 
-      const result1 = await collectAsyncIterable(blockstore1.get(testData1.cid));
-      const result2 = await collectAsyncIterable(blockstore2.get(testData2.cid));
+      const result1 = await collectAsyncIterable(
+        blockstore1.get(testData1.cid),
+      );
+      const result2 = await collectAsyncIterable(
+        blockstore2.get(testData2.cid),
+      );
 
       expect(Array.from(result1)).toEqual(Array.from(testData1.block));
       expect(Array.from(result2)).toEqual(Array.from(testData2.block));

--- a/libs/pinner/src/encoder/__tests__/csv.spec.ts
+++ b/libs/pinner/src/encoder/__tests__/csv.spec.ts
@@ -112,9 +112,7 @@ describe("CsvEncoder", () => {
     });
 
     it("should handle newlines in values", async () => {
-      const data = [
-        { name: "John", description: "Line 1\nLine 2" },
-      ];
+      const data = [{ name: "John", description: "Line 1\nLine 2" }];
       const result = await csvToFile(data);
 
       const content = await result.file.text();

--- a/libs/pinner/src/encoder/csv.ts
+++ b/libs/pinner/src/encoder/csv.ts
@@ -1,11 +1,14 @@
 import type { Encoder, EncoderResult, UploadOptions } from "./types";
 import { EncoderError } from "./error";
-import { createCsvFormatter, type CsvFormatterOptions } from "./csv/csv-formatter";
+import {
+  createCsvFormatter,
+  type CsvFormatterOptions,
+} from "./csv/csv-formatter";
 
 /**
  * CSV encoder - converts CSV strings, arrays of objects, or arrays of arrays to File objects.
  * Uses a simplified CSV formatter without streaming support.
- * 
+ *
  * This implementation is derived from @fast-csv/format (https://github.com/C2FO/fast-csv)
  * Copyright (c) 2011 C2FO Labs, LLC
  * Licensed under the MIT License

--- a/libs/pinner/src/encoder/csv/__tests__/csv-formatter.spec.ts
+++ b/libs/pinner/src/encoder/csv/__tests__/csv-formatter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CsvFormatter } from "../csv-formatter";
-import type { CsvFormatterOptions, HeadersConfig } from "../csv-options";
+import type { HeadersConfig } from "../csv-options";
 
 export const objectRows = [
   { a: "a1", b: "b1" },
@@ -34,7 +34,8 @@ describe("CsvFormatter", () => {
     it("should support transforming an array of arrays", () => {
       const formatter = new CsvFormatter({
         headers: true as HeadersConfig,
-        transform: (row) => (row as string[]).map((entry) => entry.toUpperCase()),
+        transform: (row) =>
+          (row as string[]).map((entry) => entry.toUpperCase()),
       });
       expect(formatter.format(arrayRows)).toBe("A,B\nA1,B1\nA2,B2");
     });
@@ -96,13 +97,18 @@ describe("CsvFormatter", () => {
 
       it("should write an array of multi-dimensional arrays with headers", () => {
         const formatter = new CsvFormatter({ headers: true as HeadersConfig });
-        expect(formatter.format(multiDimensionalRows)).toBe("a,b\na1,b1\na2,b2");
+        expect(formatter.format(multiDimensionalRows)).toBe(
+          "a,b\na1,b1\na2,b2",
+        );
       });
     });
 
     describe("rowDelimiter option", () => {
       it("should support specifying an alternate row delimiter", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, rowDelimiter: "\r\n" });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          rowDelimiter: "\r\n",
+        });
         expect(formatter.format(objectRows)).toBe("a,b\r\na1,b1\r\na2,b2");
       });
 
@@ -111,91 +117,140 @@ describe("CsvFormatter", () => {
           { a: "a\t1", b: "b1" },
           { a: "a\t2", b: "b2" },
         ];
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, rowDelimiter: "\t" });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          rowDelimiter: "\t",
+        });
         expect(formatter.format(rows)).toBe('a,b\t"a\t1",b1\t"a\t2",b2');
       });
     });
 
     describe("includeEndRowDelimiter option", () => {
       it("should add a final rowDelimiter if includeEndRowDelimiter is true", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, includeEndRowDelimiter: true });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          includeEndRowDelimiter: true,
+        });
         expect(formatter.format(objectRows)).toBe("a,b\na1,b1\na2,b2\n");
       });
     });
 
     describe("writeBOM option", () => {
       it("should write BOM at the beginning if writeBOM is true", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, writeBOM: true });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          writeBOM: true,
+        });
         expect(formatter.format(objectRows)).toBe("\ufeffa,b\na1,b1\na2,b2");
       });
 
       it("should not write BOM if writeBOM is false", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, writeBOM: false });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          writeBOM: false,
+        });
         expect(formatter.format(objectRows)).toBe("a,b\na1,b1\na2,b2");
       });
     });
 
     describe("alwaysWriteHeaders option", () => {
       it("should write headers even if no rows were written", () => {
-        const formatter = new CsvFormatter({ headers: ["h1", "h2"], alwaysWriteHeaders: true });
+        const formatter = new CsvFormatter({
+          headers: ["h1", "h2"],
+          alwaysWriteHeaders: true,
+        });
         expect(formatter.format([])).toBe("h1,h2");
       });
 
       it("should not write headers twice if rows were written", () => {
-        const formatter = new CsvFormatter({ headers: ["h1", "h2"], alwaysWriteHeaders: true });
+        const formatter = new CsvFormatter({
+          headers: ["h1", "h2"],
+          alwaysWriteHeaders: true,
+        });
         expect(formatter.format([{ h1: "v1", h2: "v2" }])).toBe("h1,h2\nv1,v2");
       });
     });
 
     describe("delimiter option", () => {
       it("should support specifying an alternate delimiter", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, delimiter: ";" });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          delimiter: ";",
+        });
         expect(formatter.format(objectRows)).toBe("a;b\na1;b1\na2;b2");
       });
     });
 
     describe("quote option", () => {
       it("should support specifying an alternate quote character", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quote: "$" });
-        expect(formatter.format([{ a: 'a"1', b: "b1" }])).toBe('a,b\n$a""1$,b1');
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quote: "$",
+        });
+        expect(formatter.format([{ a: 'a"1', b: "b1" }])).toBe(
+          'a,b\n$a""1$,b1',
+        );
       });
 
       it("should disable quoting if quote is false", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quote: false });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quote: false,
+        });
         expect(formatter.format([{ a: "a,1", b: "b1" }])).toBe("a,b\na,1,b1");
       });
     });
 
     describe("quoteColumns option", () => {
       it("should quote all columns if quoteColumns is true", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quoteColumns: true });
-        expect(formatter.format(objectRows)).toBe('"a","b"\n"a1","b1"\n"a2","b2"');
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quoteColumns: true,
+        });
+        expect(formatter.format(objectRows)).toBe(
+          '"a","b"\n"a1","b1"\n"a2","b2"',
+        );
       });
 
       it("should quote specific columns if quoteColumns is an array", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quoteColumns: [true, false] });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quoteColumns: [true, false],
+        });
         expect(formatter.format(objectRows)).toBe('"a",b\n"a1",b1\n"a2",b2');
       });
 
       it("should quote specific columns if quoteColumns is an object", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quoteColumns: { a: true, b: false } });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quoteColumns: { a: true, b: false },
+        });
         expect(formatter.format(objectRows)).toBe('"a",b\n"a1",b1\n"a2",b2');
       });
     });
 
     describe("quoteHeaders option", () => {
       it("should quote all headers if quoteHeaders is true", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quoteHeaders: true });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quoteHeaders: true,
+        });
         expect(formatter.format(objectRows)).toBe('"a","b"\na1,b1\na2,b2');
       });
 
       it("should quote specific headers if quoteHeaders is an array", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quoteHeaders: [true, false] });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quoteHeaders: [true, false],
+        });
         expect(formatter.format(objectRows)).toBe('"a",b\na1,b1\na2,b2');
       });
 
       it("should quote specific headers if quoteHeaders is an object", () => {
-        const formatter = new CsvFormatter({ headers: true as HeadersConfig, quoteHeaders: { a: true, b: false } });
+        const formatter = new CsvFormatter({
+          headers: true as HeadersConfig,
+          quoteHeaders: { a: true, b: false },
+        });
         expect(formatter.format(objectRows)).toBe('"a",b\na1,b1\na2,b2');
       });
     });

--- a/libs/pinner/src/encoder/csv/__tests__/field-formatter.spec.ts
+++ b/libs/pinner/src/encoder/csv/__tests__/field-formatter.spec.ts
@@ -58,17 +58,26 @@ describe("FieldFormatter", () => {
       });
 
       it("should quote the header if quoteHeaders is an object and quoteHeaders object has true for the column name", () => {
-        const formatter = createFormatter({ quoteHeaders: { header: true }, headers: ["header"] });
+        const formatter = createFormatter({
+          quoteHeaders: { header: true },
+          headers: ["header"],
+        });
         expect(formatter.format("header", 0, true)).toBe('"header"');
       });
 
       it("should not quote the header if quoteHeaders is an object and quoteHeaders object has false for the column name", () => {
-        const formatter = createFormatter({ quoteHeaders: { header: false }, headers: ["header"] });
+        const formatter = createFormatter({
+          quoteHeaders: { header: false },
+          headers: ["header"],
+        });
         expect(formatter.format("header", 0, true)).toBe("header");
       });
 
       it("should not quote the header if quoteHeaders is an object and quoteHeaders object does not contain the header", () => {
-        const formatter = createFormatter({ quoteHeaders: { header2: true }, headers: ["header"] });
+        const formatter = createFormatter({
+          quoteHeaders: { header2: true },
+          headers: ["header"],
+        });
         expect(formatter.format("header", 0, true)).toBe("header");
       });
     });
@@ -105,17 +114,26 @@ describe("FieldFormatter", () => {
       });
 
       it("should quote the header if quoteColumns is an object and quoteColumns object has true for the column name", () => {
-        const formatter = createFormatter({ quoteColumns: { header: true }, headers: ["header"] });
+        const formatter = createFormatter({
+          quoteColumns: { header: true },
+          headers: ["header"],
+        });
         expect(formatter.format("col", 0, false)).toBe('"col"');
       });
 
       it("should not quote the header if quoteColumns is an object and quoteColumns object has false for the column name", () => {
-        const formatter = createFormatter({ quoteColumns: { header: false }, headers: ["header"] });
+        const formatter = createFormatter({
+          quoteColumns: { header: false },
+          headers: ["header"],
+        });
         expect(formatter.format("col", 0, false)).toBe("col");
       });
 
       it("should not quote the header if quoteColumns is an object and quoteColumns object does not contain the header", () => {
-        const formatter = createFormatter({ quoteColumns: { header2: true }, headers: ["header"] });
+        const formatter = createFormatter({
+          quoteColumns: { header2: true },
+          headers: ["header"],
+        });
         expect(formatter.format("col", 0, false)).toBe("col");
       });
     });

--- a/libs/pinner/src/encoder/csv/__tests__/row-formatter.spec.ts
+++ b/libs/pinner/src/encoder/csv/__tests__/row-formatter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { RowFormatter } from "../row-formatter";
-import type { CsvFormatterOptions, HeadersConfig, RowTransform } from "../csv-options";
+import type { CsvFormatterOptions, HeadersConfig } from "../csv-options";
 
 describe("RowFormatter", () => {
   const createFormatter = (options: CsvFormatterOptions = {}) => {
@@ -19,12 +19,21 @@ describe("RowFormatter", () => {
       const syncError = () => {
         throw new Error("Expected Error");
       };
-      const asyncTransform = (row: string[], cb: (err: Error | null, row?: string[]) => void) => {
+      const asyncTransform = (
+        row: string[],
+        cb: (err: Error | null, row?: string[]) => void,
+      ) => {
         setTimeout(() => {
-          cb(null, row.map((col) => col.toUpperCase()));
+          cb(
+            null,
+            row.map((col) => col.toUpperCase()),
+          );
         }, 0);
       };
-      const asyncErrorTransform = (_row: unknown, cb: (err: Error | null, row?: unknown) => void) => {
+      const asyncErrorTransform = (
+        _row: unknown,
+        cb: (err: Error | null, row?: unknown) => void,
+      ) => {
         setTimeout(() => {
           cb(new Error("Expected Error"));
         }, 0);
@@ -42,17 +51,26 @@ describe("RowFormatter", () => {
       });
 
       it("should support a sync transform", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: syncTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: syncTransform,
+        });
         expect(formatter.format(headerRow)).toEqual(["A,B"]);
       });
 
       it("should catch a sync transform thrown error", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: syncError });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: syncError,
+        });
         expect(() => formatter.format(headerRow)).toThrow("Expected Error");
       });
 
       it("should support an async transform", async () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: asyncTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: asyncTransform,
+        });
         const result = formatter.format(headerRow);
         // Note: Our implementation uses Promise.all internally for async transforms
         // The result may be empty if the transform hasn't completed yet
@@ -61,7 +79,10 @@ describe("RowFormatter", () => {
       });
 
       it("should support an async transform with error", async () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: asyncErrorTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: asyncErrorTransform,
+        });
         expect(() => formatter.format(headerRow)).toThrow();
       });
 
@@ -75,13 +96,17 @@ describe("RowFormatter", () => {
           it("should still format all rows without headers", () => {
             const formatter = createFormatter({ headers: false });
             expect(formatter.format([])).toEqual([""]);
-            expect(formatter.format(headerRow)).toEqual([`\n${headerRow.join(",")}`]);
+            expect(formatter.format(headerRow)).toEqual([
+              `\n${headerRow.join(",")}`,
+            ]);
           });
         });
 
         describe("with headers=true", () => {
           it("should only write the first row", () => {
-            const formatter = createFormatter({ headers: true as HeadersConfig });
+            const formatter = createFormatter({
+              headers: true as HeadersConfig,
+            });
             expect(formatter.format(headerRow)).toEqual([headerRow.join(",")]);
           });
         });
@@ -96,8 +121,13 @@ describe("RowFormatter", () => {
           });
 
           it("should append an additional column for new fields", () => {
-            const formatter = createFormatter({ headers: ["A", "B", "no_field"] });
-            expect(formatter.format(columnsRow)).toEqual(["A,B,no_field", "\na1,b1,"]);
+            const formatter = createFormatter({
+              headers: ["A", "B", "no_field"],
+            });
+            expect(formatter.format(columnsRow)).toEqual([
+              "A,B,no_field",
+              "\na1,b1,",
+            ]);
           });
 
           it("should exclude columns that do not have a header", () => {
@@ -109,7 +139,10 @@ describe("RowFormatter", () => {
 
       describe("rowDelimiter option", () => {
         it("should support specifying an alternate row delimiter", () => {
-          const formatter = createFormatter({ headers: true as HeadersConfig, rowDelimiter: "\r\n" });
+          const formatter = createFormatter({
+            headers: true as HeadersConfig,
+            rowDelimiter: "\r\n",
+          });
           expect(formatter.format(headerRow)).toEqual(["a,b"]);
           expect(formatter.format(columnsRow)).toEqual(["\r\na1,b1"]);
         });
@@ -123,18 +156,30 @@ describe("RowFormatter", () => {
       ];
 
       const syncTransform = (rowToTransform: string[][]) => {
-        return rowToTransform.map(([header, col]) => [header, col.toUpperCase()]);
+        return rowToTransform.map(([header, col]) => [
+          header,
+          col.toUpperCase(),
+        ]);
       };
       const syncError = () => {
         throw new Error("Expected Error");
       };
-      const asyncTransform = (rowToTransform: string[][], cb: (err: Error | null, row?: string[][]) => void) => {
-        const transformed = rowToTransform.map(([header, col]) => [header, col.toUpperCase()]);
+      const asyncTransform = (
+        rowToTransform: string[][],
+        cb: (err: Error | null, row?: string[][]) => void,
+      ) => {
+        const transformed = rowToTransform.map(([header, col]) => [
+          header,
+          col.toUpperCase(),
+        ]);
         setTimeout(() => {
           cb(null, transformed);
         }, 0);
       };
-      const asyncErrorTransform = (rowToTransform: unknown, cb: (err: Error | null, row?: unknown) => void) => {
+      const asyncErrorTransform = (
+        rowToTransform: unknown,
+        cb: (err: Error | null, row?: unknown) => void,
+      ) => {
         return setTimeout(() => {
           cb(new Error("Expected Error"));
         }, 0);
@@ -151,23 +196,35 @@ describe("RowFormatter", () => {
       });
 
       it("should support a sync transform", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: syncTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: syncTransform,
+        });
         expect(formatter.format(row)).toEqual(["a,b", "\nA1,B1"]);
       });
 
       it("should catch a sync transform thrown error", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: syncError });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: syncError,
+        });
         expect(() => formatter.format(row)).toThrow("Expected Error");
       });
 
       it("should support an async transform", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: asyncTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: asyncTransform,
+        });
         const result = formatter.format(row);
         expect(Array.isArray(result)).toBe(true);
       });
 
       it("should support an async transform with error", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: asyncErrorTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: asyncErrorTransform,
+        });
         expect(() => formatter.format(row)).toThrow();
       });
 
@@ -181,7 +238,9 @@ describe("RowFormatter", () => {
 
         describe("with headers=true", () => {
           it("should only write the first row", () => {
-            const formatter = createFormatter({ headers: true as HeadersConfig });
+            const formatter = createFormatter({
+              headers: true as HeadersConfig,
+            });
             expect(formatter.format(row)).toEqual(["a,b", "\na1,b1"]);
           });
         });
@@ -193,7 +252,9 @@ describe("RowFormatter", () => {
           });
 
           it("should append an additional column for new fields", () => {
-            const formatter = createFormatter({ headers: ["A", "B", "no_field"] });
+            const formatter = createFormatter({
+              headers: ["A", "B", "no_field"],
+            });
             expect(formatter.format(row)).toEqual(["A,B,no_field", "\na1,b1,"]);
           });
 
@@ -206,7 +267,10 @@ describe("RowFormatter", () => {
 
       describe("rowDelimiter option", () => {
         it("should support specifying an alternate row delimiter", () => {
-          const formatter = createFormatter({ headers: true as HeadersConfig, rowDelimiter: "\r\n" });
+          const formatter = createFormatter({
+            headers: true as HeadersConfig,
+            rowDelimiter: "\r\n",
+          });
           expect(formatter.format(row)).toEqual(["a,b", "\r\na1,b1"]);
         });
       });
@@ -224,12 +288,18 @@ describe("RowFormatter", () => {
       const syncError = () => {
         throw new Error("Expected Error");
       };
-      const asyncTransform = (rowToTransform: Record<string, string>, cb: (err: Error | null, row?: Record<string, string>) => void) => {
+      const asyncTransform = (
+        rowToTransform: Record<string, string>,
+        cb: (err: Error | null, row?: Record<string, string>) => void,
+      ) => {
         return setTimeout(() => {
           cb(null, syncTransform(rowToTransform));
         }, 0);
       };
-      const asyncErrorTransform = (rowToTransform: unknown, cb: (err: Error | null, row?: unknown) => void) => {
+      const asyncErrorTransform = (
+        rowToTransform: unknown,
+        cb: (err: Error | null, row?: unknown) => void,
+      ) => {
         return setTimeout(() => {
           cb(new Error("Expected Error"));
         }, 0);
@@ -246,23 +316,35 @@ describe("RowFormatter", () => {
       });
 
       it("should support a sync transform", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: syncTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: syncTransform,
+        });
         expect(formatter.format(row)).toEqual(["a,b", "\nA1,B1"]);
       });
 
       it("should catch a sync transform thrown error", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: syncError });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: syncError,
+        });
         expect(() => formatter.format(row)).toThrow("Expected Error");
       });
 
       it("should support an async transform", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: asyncTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: asyncTransform,
+        });
         const result = formatter.format(row);
         expect(Array.isArray(result)).toBe(true);
       });
 
       it("should support an async transform with error", () => {
-        const formatter = createFormatter({ headers: true as HeadersConfig, transform: asyncErrorTransform });
+        const formatter = createFormatter({
+          headers: true as HeadersConfig,
+          transform: asyncErrorTransform,
+        });
         expect(() => formatter.format(row)).toThrow();
       });
 
@@ -276,12 +358,17 @@ describe("RowFormatter", () => {
 
         describe("with headers=true", () => {
           it("should only write the first row", () => {
-            const formatter = createFormatter({ headers: true as HeadersConfig });
+            const formatter = createFormatter({
+              headers: true as HeadersConfig,
+            });
             expect(formatter.format(row)).toEqual(["a,b", "\na1,b1"]);
           });
 
           it("should not write the first row if writeHeaders is false", () => {
-            const formatter = createFormatter({ headers: true as HeadersConfig, writeHeaders: false });
+            const formatter = createFormatter({
+              headers: true as HeadersConfig,
+              writeHeaders: false,
+            });
             expect(formatter.format(row)).toEqual(["a1,b1"]);
           });
         });
@@ -293,7 +380,10 @@ describe("RowFormatter", () => {
           });
 
           it("should not write the header row if writeHeaders is false", () => {
-            const formatter = createFormatter({ headers: ["a", "b"], writeHeaders: false });
+            const formatter = createFormatter({
+              headers: ["a", "b"],
+              writeHeaders: false,
+            });
             expect(formatter.format(row)).toEqual(["a1,b1"]);
           });
 
@@ -303,12 +393,17 @@ describe("RowFormatter", () => {
           });
 
           it("should append an additional column for new fields", () => {
-            const formatter = createFormatter({ headers: ["a", "b", "no_field"] });
+            const formatter = createFormatter({
+              headers: ["a", "b", "no_field"],
+            });
             expect(formatter.format(row)).toEqual(["a,b,no_field", "\na1,b1,"]);
           });
 
           it("should respect the order of the columns and not write the headers if writeHeaders is false", () => {
-            const formatter = createFormatter({ headers: ["b", "a"], writeHeaders: false });
+            const formatter = createFormatter({
+              headers: ["b", "a"],
+              writeHeaders: false,
+            });
             expect(formatter.format(row)).toEqual(["b1,a1"]);
           });
         });
@@ -316,7 +411,10 @@ describe("RowFormatter", () => {
 
       describe("rowDelimiter option", () => {
         it("should support specifying an alternate row delimiter", () => {
-          const formatter = createFormatter({ headers: true as HeadersConfig, rowDelimiter: "\r\n" });
+          const formatter = createFormatter({
+            headers: true as HeadersConfig,
+            rowDelimiter: "\r\n",
+          });
           expect(formatter.format(row)).toEqual(["a,b", "\r\na1,b1"]);
         });
       });
@@ -327,13 +425,19 @@ describe("RowFormatter", () => {
     describe("alwaysWriteHeaders option", () => {
       it("should return a headers row if no rows have been written", () => {
         const headers = ["h1", "h2"];
-        const formatter = createFormatter({ headers, alwaysWriteHeaders: true });
+        const formatter = createFormatter({
+          headers,
+          alwaysWriteHeaders: true,
+        });
         expect(formatter.finish()).toEqual([headers.join(",")]);
       });
 
       it("should not return a headers row if rows have been written", () => {
         const headers = ["h1", "h2"];
-        const formatter = createFormatter({ headers, alwaysWriteHeaders: true });
+        const formatter = createFormatter({
+          headers,
+          alwaysWriteHeaders: true,
+        });
         formatter.format(["c1", "c2"]);
         expect(formatter.finish()).toEqual([]);
       });

--- a/libs/pinner/src/encoder/csv/csv-formatter.ts
+++ b/libs/pinner/src/encoder/csv/csv-formatter.ts
@@ -6,7 +6,7 @@ export type { CsvFormatterOptions };
 /**
  * Simple CSV formatter without streaming support.
  * Converts arrays of objects or arrays to CSV strings.
- * 
+ *
  * This implementation is derived from @fast-csv/format (https://github.com/C2FO/fast-csv)
  * Copyright (c) 2011 C2FO Labs, LLC
  * Licensed under the MIT License
@@ -19,8 +19,8 @@ export class CsvFormatter {
   constructor(options: CsvFormatterOptions = {}) {
     this.options = {
       objectMode: true,
-      delimiter: ',',
-      rowDelimiter: '\n',
+      delimiter: ",",
+      rowDelimiter: "\n",
       quote: '"',
       escape: undefined,
       quoteColumns: false,
@@ -30,18 +30,19 @@ export class CsvFormatter {
       includeEndRowDelimiter: false,
       transform: undefined,
       writeBOM: false,
-      BOM: '\ufeff',
+      BOM: "\ufeff",
       alwaysWriteHeaders: false,
       ...options,
     };
 
     // Set escape to quote if not provided
-    if (typeof this.options.escape !== 'string') {
-      this.options.escape = this.options.quote === true ? '"' : (this.options.quote as string);
+    if (typeof this.options.escape !== "string") {
+      this.options.escape =
+        this.options.quote === true ? '"' : (this.options.quote as string);
     }
 
     // Set quoteHeaders to quoteColumns if not provided
-    if (typeof this.options.quoteHeaders === 'undefined') {
+    if (typeof this.options.quoteHeaders === "undefined") {
       this.options.quoteHeaders = this.options.quoteColumns;
     }
 
@@ -49,7 +50,7 @@ export class CsvFormatter {
     if (this.options.quote === true) {
       this.options.quote = '"';
     } else if (this.options.quote === false) {
-      this.options.quote = '';
+      this.options.quote = "";
     }
 
     this.rowFormatter = new RowFormatter(this.options);
@@ -64,7 +65,7 @@ export class CsvFormatter {
 
     // Write BOM if configured
     if (!this.hasWrittenBOM) {
-      chunks.push(this.options.BOM || '\ufeff');
+      chunks.push(this.options.BOM || "\ufeff");
       this.hasWrittenBOM = true;
     }
 
@@ -78,7 +79,7 @@ export class CsvFormatter {
     const finishRows = this.rowFormatter.finish();
     chunks.push(...finishRows);
 
-    return chunks.join('');
+    return chunks.join("");
   }
 
   /**
@@ -89,20 +90,22 @@ export class CsvFormatter {
 
     // Write BOM if configured
     if (!this.hasWrittenBOM) {
-      chunks.push(this.options.BOM || '\ufeff');
+      chunks.push(this.options.BOM || "\ufeff");
       this.hasWrittenBOM = true;
     }
 
     const formattedRows = this.rowFormatter.format(row);
     chunks.push(...formattedRows);
 
-    return chunks.join('');
+    return chunks.join("");
   }
 }
 
 /**
  * Create a CSV formatter with the given options.
  */
-export function createCsvFormatter(options?: CsvFormatterOptions): CsvFormatter {
+export function createCsvFormatter(
+  options?: CsvFormatterOptions,
+): CsvFormatter {
   return new CsvFormatter(options);
 }

--- a/libs/pinner/src/encoder/csv/field-formatter.ts
+++ b/libs/pinner/src/encoder/csv/field-formatter.ts
@@ -4,12 +4,15 @@ import type { CsvFormatterOptions } from "./csv-options";
  * Escape special regex characters in a string.
  */
 function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\import type { CsvFormatterOptions } from "./csv-options";');
+  return str.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    '\\import type { CsvFormatterOptions } from "./csv-options";',
+  );
 }
 
 /**
  * Handles formatting of individual CSV fields including quoting and escaping.
- * 
+ *
  * This implementation is derived from @fast-csv/format (https://github.com/C2FO/fast-csv)
  * Copyright (c) 2011 C2FO Labs, LLC
  * Licensed under the MIT License
@@ -29,11 +32,16 @@ export class FieldFormatter {
       this._headers = null;
     }
 
-    const quote = options.quote === true ? '"' : (options.quote === false ? '' : options.quote ?? '"');
-    this.quoteReplaceRegExp = new RegExp(quote, 'g');
+    const quote =
+      options.quote === true
+        ? '"'
+        : options.quote === false
+          ? ""
+          : (options.quote ?? '"');
+    this.quoteReplaceRegExp = new RegExp(quote, "g");
 
     // Use lodash.escapeRegExp pattern for delimiter and row delimiter
-    const escapePattern = `[${escapeRegExp(options.delimiter ?? ',')}${escapeRegExp(options.rowDelimiter ?? '\n')}|\r|\n]`;
+    const escapePattern = `[${escapeRegExp(options.delimiter ?? ",")}${escapeRegExp(options.rowDelimiter ?? "\n")}|\r|\n]`;
     this.escapePatternRegExp = new RegExp(escapePattern);
   }
 
@@ -49,18 +57,18 @@ export class FieldFormatter {
    * Escape special regex characters in a string.
    */
   #escapeRegExpString(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
 
   /**
    * Determine if a field should be quoted.
    */
   private shouldQuote(fieldIndex: number, isHeader: boolean): boolean {
-    const quoteConfig = isHeader 
-      ? this.options.quoteHeaders 
+    const quoteConfig = isHeader
+      ? this.options.quoteHeaders
       : this.options.quoteColumns;
 
-    if (typeof quoteConfig === 'boolean') {
+    if (typeof quoteConfig === "boolean") {
       return quoteConfig;
     }
 
@@ -68,7 +76,7 @@ export class FieldFormatter {
       return quoteConfig[fieldIndex] === true;
     }
 
-    if (this._headers !== null && typeof quoteConfig === 'object') {
+    if (this._headers !== null && typeof quoteConfig === "object") {
       return quoteConfig[this._headers[fieldIndex]] === true;
     }
 
@@ -79,22 +87,30 @@ export class FieldFormatter {
    * Format a single field value.
    */
   format(field: unknown, fieldIndex: number, isHeader: boolean): string {
-    const quote = this.options.quote === true ? '"' : (this.options.quote === false ? '' : this.options.quote ?? '"');
+    const quote =
+      this.options.quote === true
+        ? '"'
+        : this.options.quote === false
+          ? ""
+          : (this.options.quote ?? '"');
     const escape = this.options.escape ?? quote;
 
     // Convert to string, handle null/undefined
-    const preparedField = `${field == null ? '' : field}`.replace(/\0/g, '');
+    const preparedField = `${field == null ? "" : field}`.replace(/\0/g, "");
 
     // Handle quote escaping
-    if (quote !== '') {
+    if (quote !== "") {
       const shouldEscape = preparedField.indexOf(quote) !== -1;
       if (shouldEscape) {
-        return this.quoteField(preparedField.replace(this.quoteReplaceRegExp, `${escape}${quote}`));
+        return this.quoteField(
+          preparedField.replace(this.quoteReplaceRegExp, `${escape}${quote}`),
+        );
       }
     }
 
     // Check if field needs quoting (contains delimiter, row delimiter, etc.)
-    const hasEscapeCharacters = preparedField.search(this.escapePatternRegExp) !== -1;
+    const hasEscapeCharacters =
+      preparedField.search(this.escapePatternRegExp) !== -1;
     if (hasEscapeCharacters || this.shouldQuote(fieldIndex, isHeader)) {
       return this.quoteField(preparedField);
     }
@@ -106,7 +122,12 @@ export class FieldFormatter {
    * Quote a field value.
    */
   private quoteField(field: string): string {
-    const quote = this.options.quote === true ? '"' : (this.options.quote === false ? '' : this.options.quote ?? '"');
+    const quote =
+      this.options.quote === true
+        ? '"'
+        : this.options.quote === false
+          ? ""
+          : (this.options.quote ?? '"');
     return `${quote}${field}${quote}`;
   }
 }

--- a/libs/pinner/src/encoder/csv/field-formatter.ts
+++ b/libs/pinner/src/encoder/csv/field-formatter.ts
@@ -4,10 +4,7 @@ import type { CsvFormatterOptions } from "./csv-options";
  * Escape special regex characters in a string.
  */
 function escapeRegExp(str: string): string {
-  return str.replace(
-    /[.*+?^${}()|[\]\\]/g,
-    '\\import type { CsvFormatterOptions } from "./csv-options";',
-  );
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/libs/pinner/src/encoder/csv/row-formatter.ts
+++ b/libs/pinner/src/encoder/csv/row-formatter.ts
@@ -1,13 +1,13 @@
 import type {
   CsvFormatterOptions,
-  RowTransformCallback,
   RowTransform,
+  RowTransformCallback,
 } from "./csv-options";
 import { FieldFormatter } from "./field-formatter";
 
 /**
  * Handles formatting of CSV rows including headers and column extraction.
- * 
+ *
  * This implementation is derived from @fast-csv/format (https://github.com/C2FO/fast-csv)
  * Copyright (c) 2011 C2FO Labs, LLC
  * Licensed under the MIT License
@@ -25,7 +25,9 @@ export class RowFormatter {
     this.options = options;
     this.fieldFormatter = new FieldFormatter(options);
     this.headers = Array.isArray(options.headers) ? options.headers : null;
-    this.shouldWriteHeaders = options.writeHeaders ?? (Array.isArray(options.headers) || options.headers === true);
+    this.shouldWriteHeaders =
+      options.writeHeaders ??
+      (Array.isArray(options.headers) || options.headers === true);
 
     if (this.headers !== null) {
       this.fieldFormatter.headers = this.headers;
@@ -44,7 +46,9 @@ export class RowFormatter {
     if (transformFn.length === 1) {
       return (row: unknown, cb: RowTransformCallback) => {
         try {
-          const transformedRow = (transformFn as (row: unknown) => unknown)(row);
+          const transformedRow = (transformFn as (row: unknown) => unknown)(
+            row,
+          );
           cb(null, transformedRow);
         } catch (e) {
           cb(e instanceof Error ? e : new Error(String(e)));
@@ -121,7 +125,9 @@ export class RowFormatter {
       }
     }
 
-    throw new Error('Async transforms are not supported in synchronous CSV formatting');
+    throw new Error(
+      "Async transforms are not supported in synchronous CSV formatting",
+    );
   }
 
   /**
@@ -133,14 +139,16 @@ export class RowFormatter {
     // Write headers if alwaysWriteHeaders is true and no rows were written
     if (this.options.alwaysWriteHeaders && this.rowCount === 0) {
       if (!this.headers) {
-        throw new Error('`alwaysWriteHeaders` option is set to true but `headers` option not provided.');
+        throw new Error(
+          "`alwaysWriteHeaders` option is set to true but `headers` option not provided.",
+        );
       }
       rows.push(this.formatColumns(this.headers, true));
     }
 
     // Add end row delimiter if configured
     if (this.options.includeEndRowDelimiter) {
-      rows.push(this.options.rowDelimiter || '\n');
+      rows.push(this.options.rowDelimiter || "\n");
     }
 
     return rows;
@@ -149,7 +157,10 @@ export class RowFormatter {
   /**
    * Check if headers need to be written.
    */
-  private checkHeaders(row: unknown): { shouldFormatColumns: boolean; headers: string[] | null } {
+  private checkHeaders(row: unknown): {
+    shouldFormatColumns: boolean;
+    headers: string[] | null;
+  } {
     if (this.headers) {
       return { shouldFormatColumns: true, headers: this.headers };
     }
@@ -163,8 +174,7 @@ export class RowFormatter {
     }
 
     // If the row is equal to headers, don't format (it's the header row itself)
-    if (Array.isArray(row) &&
-        headers.every((header, i) => header === row[i])) {
+    if (Array.isArray(row) && headers.every((header, i) => header === row[i])) {
       return { shouldFormatColumns: false, headers };
     }
 
@@ -202,19 +212,21 @@ export class RowFormatter {
    */
   private gatherColumns(row: unknown): unknown[] {
     if (this.headers === null) {
-      throw new Error('Headers is currently null');
+      throw new Error("Headers is currently null");
     }
 
     if (!Array.isArray(row)) {
       // Object: use headers to get values
-      return this.headers.map((header) => (row as Record<string, unknown>)[header]);
+      return this.headers.map(
+        (header) => (row as Record<string, unknown>)[header],
+      );
     }
 
     if (this.isRowHashArray(row)) {
       // Hash array: extract values
       return this.headers.map((header, i) => {
         const col = (row as unknown[][])[i];
-        return col ? col[1] : '';
+        return col ? col[1] : "";
       });
     }
 
@@ -234,14 +246,14 @@ export class RowFormatter {
   private formatColumns(columns: unknown[], isHeadersRow: boolean): string {
     const formattedCols = columns
       .map((field, i) => this.fieldFormatter.format(field, i, isHeadersRow))
-      .join(this.options.delimiter || ',');
+      .join(this.options.delimiter || ",");
 
     const { rowCount } = this;
     this.rowCount += 1;
 
     // Add row delimiter before all rows except the first
     if (rowCount > 0) {
-      return [this.options.rowDelimiter || '\n', formattedCols].join('');
+      return [this.options.rowDelimiter || "\n", formattedCols].join("");
     }
 
     return formattedCols;

--- a/libs/pinner/src/pinner.ts
+++ b/libs/pinner/src/pinner.ts
@@ -1,12 +1,14 @@
 import type { PinnerConfig } from "./config";
 import { UploadManager } from "./upload";
 import { PinClient } from "./pin";
+import type { UploadMethodAndBuilder } from "@/upload/builder";
 import { createUploadBuilderNamespace } from "@/upload/builder";
 import type {
   UploadOperation,
   UploadOptions,
   UploadResult,
 } from "@/types/upload";
+import type { OperationPollingOptions } from "@lumeweb/portal-sdk";
 import type {
   AbortOptions,
   RemoteAddOptions,
@@ -15,7 +17,6 @@ import type {
   RemotePins,
 } from "@/types/pin";
 import { CID } from "multiformats/cid";
-import type { UploadMethodAndBuilder } from "@/upload/builder";
 
 export class Pinner {
   private uploadManager: UploadManager;
@@ -72,6 +73,19 @@ export class Pinner {
   ): Promise<UploadResult> {
     const operation = await this.upload(file, options);
     return operation.result;
+  }
+
+  /**
+   * Wait for an operation to complete or reach a settled state.
+   * @param input Either an operation ID (number) or an UploadResult
+   * @param options Polling options (interval, timeout, settledStates)
+   * @returns UploadResult with operation status merged in
+   */
+  async waitForOperation(
+    input: number | UploadResult,
+    options?: OperationPollingOptions,
+  ): Promise<UploadResult> {
+    return this.uploadManager.waitForOperation(input, options);
   }
 
   /**

--- a/libs/pinner/src/types/upload.ts
+++ b/libs/pinner/src/types/upload.ts
@@ -1,3 +1,10 @@
+import type { OperationPollingOptions } from "@lumeweb/portal-sdk";
+
+/**
+ * Symbol used to brand UploadResult for type checking
+ */
+export const UploadResultSymbol = Symbol("UploadResult");
+
 export interface UploadResult {
   /**
    * Unique identifier for this upload operation.
@@ -50,9 +57,33 @@ export interface UploadResult {
    * Useful for passthrough of pre-generated CAR files.
    */
   isCarFile?: boolean;
+
+  /**
+   * Portal operation ID for tracking the pinning operation.
+   * Can be used with waitForOperation() to wait for the operation to complete.
+   */
+  operationId?: number;
+
+  /**
+   * Symbol brand for type checking - used to identify UploadResult objects
+   */
+  [UploadResultSymbol]?: true;
 }
 
 export type UploadInput = File | ReadableStream<Uint8Array>;
+
+/**
+ * Type guard to check if a value is an UploadResult
+ * Uses the UploadResultSymbol for reliable type checking
+ */
+export function isUploadResult(value: unknown): value is UploadResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    UploadResultSymbol in value &&
+    value[UploadResultSymbol] === true
+  );
+}
 
 export interface UploadOptions {
   /**
@@ -102,6 +133,19 @@ export interface UploadOptions {
    * Useful for passthrough of pre-generated CAR files.
    */
   isCarFile?: boolean;
+
+  /**
+   * Whether to wait for the pinning operation to complete/fail.
+   * When true, the upload will block until the operation reaches a settled state
+   * (completed, failed, or error). Default is false (upload only).
+   */
+  waitForOperation?: boolean;
+
+  /**
+   * Polling options for waiting on operation completion.
+   * Only used when waitForOperation is true.
+   */
+  operationPollingOptions?: OperationPollingOptions;
 }
 
 export interface UploadProgress {
@@ -172,6 +216,18 @@ export interface PinnerUploadBuilder {
    * Set custom key-value metadata.
    */
   keyvalues(kv: Record<string, string>): this;
+
+  /**
+   * Whether to wait for the pinning operation to complete/fail.
+   * When true, the upload will block until the operation reaches a settled state.
+   */
+  waitForOperation(wait: boolean): this;
+
+  /**
+   * Set polling options for waiting on operation completion.
+   * Only used when waitForOperation is true.
+   */
+  operationPollingOptions(options: OperationPollingOptions): this;
 
   /**
    * Start the upload and return UploadOperation with controls.

--- a/libs/pinner/src/upload/__tests__/manager.integration.spec.ts
+++ b/libs/pinner/src/upload/__tests__/manager.integration.spec.ts
@@ -381,4 +381,133 @@ describe("UploadManager Integration Tests", () => {
       expect(result).toBeDefined();
     });
   });
+
+  describe("waitForOperation", () => {
+    it("should wait for operation by ID and return result", async () => {
+      const operationId = 12345;
+      const result = await manager.waitForOperation(operationId);
+
+      expect(result).toBeDefined();
+      expect(result.operationId).toBe(operationId);
+      expect(result.cid).toBeDefined();
+      expect(result.id).toBe(String(operationId));
+    });
+
+    it("should wait for operation with UploadResult and preserve metadata", async () => {
+      const stream = createReadableStream("test content");
+      const file = await streamToFile(stream, "test.car");
+
+      // First upload to get a result with operationId
+      const operation = await manager.upload(file);
+      const uploadResult = await operation.result;
+
+      expect(uploadResult.operationId).toBeDefined();
+      expect(uploadResult.size).toBeGreaterThan(0);
+      expect(uploadResult.name).toBe("test.car");
+
+      // Wait for operation using the upload result
+      const finalResult = await manager.waitForOperation(uploadResult);
+
+      // Verify original metadata is preserved
+      expect(finalResult.size).toBe(uploadResult.size);
+      expect(finalResult.name).toBe(uploadResult.name);
+      expect(finalResult.mimeType).toBe(uploadResult.mimeType);
+      expect(finalResult.numberOfFiles).toBe(uploadResult.numberOfFiles);
+      expect(finalResult.operationId).toBe(uploadResult.operationId);
+    });
+
+    it("should support custom polling options", async () => {
+      const operationId = 12346;
+      const pollingOptions = {
+        interval: 1000,
+        timeout: 60000,
+        settledStates: ["completed"] as string[],
+      };
+
+      const result = await manager.waitForOperation(
+        operationId,
+        pollingOptions,
+      );
+
+      expect(result).toBeDefined();
+      expect(result.operationId).toBe(operationId);
+    });
+
+    it("should throw error when operation fails", async () => {
+      const operationId = 99999;
+
+      await expect(manager.waitForOperation(operationId)).rejects.toThrow();
+    });
+  });
+
+  describe("upload with waitForOperation option", () => {
+    it("should wait for operation when waitForOperation is true", async () => {
+      const stream = createReadableStream("test content");
+      const file = await streamToFile(stream, "test.car");
+
+      const operation = await manager.upload(file, {
+        waitForOperation: true,
+      });
+
+      const result = await operation.result;
+
+      expect(result).toBeDefined();
+      expect(result.operationId).toBeDefined();
+      expect(result.cid).toBeDefined();
+    });
+
+    it("should pass custom polling options", async () => {
+      const stream = createReadableStream("test content");
+      const file = await streamToFile(stream, "test.car");
+
+      const operation = await manager.upload(file, {
+        waitForOperation: true,
+        operationPollingOptions: {
+          interval: 1000,
+          timeout: 60000,
+        },
+      });
+
+      const result = await operation.result;
+
+      expect(result).toBeDefined();
+      expect(result.operationId).toBeDefined();
+    });
+
+    it("should preserve upload metadata after waiting for operation", async () => {
+      const stream = createReadableStream("test content for metadata");
+      const file = await streamToFile(stream, "metadata-test.car");
+
+      const operation = await manager.upload(file, {
+        name: "custom-name.car",
+        waitForOperation: true,
+      });
+
+      const result = await operation.result;
+
+      expect(result).toBeDefined();
+      expect(result.operationId).toBeDefined();
+      expect(result.size).toBeGreaterThan(0);
+      expect(result.name).toBe("metadata-test.car");
+      expect(result.mimeType).toBe("application/vnd.ipld.car");
+    });
+
+    it("should work with directory upload", async () => {
+      const file1 = new File(["content1"], "file1.txt");
+      const file2 = new File(["content2"], "file2.txt");
+
+      const operation = await manager.uploadDirectory([file1, file2], {
+        name: "test-dir",
+        waitForOperation: true,
+      });
+
+      const result = await operation.result;
+
+      expect(result).toBeDefined();
+      expect(result.operationId).toBeDefined();
+      expect(result.cid).toBeDefined();
+      expect(result.isDirectory).toBe(true);
+      expect(result.numberOfFiles).toBe(2);
+    });
+  });
 });

--- a/libs/pinner/src/upload/__tests__/test-constants.ts
+++ b/libs/pinner/src/upload/__tests__/test-constants.ts
@@ -25,4 +25,5 @@ export const MOCK_UPLOAD_RESULT: UploadResult = {
   mimeType: "application/vnd.ipld.car",
   createdAt: new Date(),
   numberOfFiles: 1,
+  operationId: 12345,
 };

--- a/libs/pinner/src/upload/__tests__/unit-mocks.ts
+++ b/libs/pinner/src/upload/__tests__/unit-mocks.ts
@@ -8,6 +8,7 @@ import { getMockCID } from "./test-helpers";
 const { mockSdkInstance, mockXhrHandler, mockTusHandler, mockUploadResult } =
   await vi.hoisted(async () => {
     const getMockCID = (await import("./test-helpers")).getMockCID;
+    const { OPERATION_STATUS } = await import("@lumeweb/portal-sdk");
     const mockCid = getMockCID(0);
     const mockUploadResult: UploadResult = {
       id: "test-id",
@@ -17,6 +18,7 @@ const { mockSdkInstance, mockXhrHandler, mockTusHandler, mockUploadResult } =
       mimeType: "application/vnd.ipld.car",
       createdAt: new Date(),
       numberOfFiles: 1,
+      operationId: 12345,
     };
     const sdkInstance = {
       account: vi.fn().mockReturnValue({
@@ -25,6 +27,39 @@ const { mockSdkInstance, mockXhrHandler, mockTusHandler, mockUploadResult } =
             success: true,
             data: { limit: 104857600 }, // 100 MB in bytes
           });
+        }),
+        listOperations: vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            data: {
+              id: 12345,
+              cid: mockCid,
+              status: OPERATION_STATUS.COMPLETED,
+              operation: "upload",
+              operation_display_name: "Upload",
+              protocol: "ipfs",
+              protocol_display_name: "IPFS",
+              progress_percent: 100,
+              started_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            },
+            total: 1,
+          },
+        }),
+        waitForOperation: vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            id: 12345,
+            cid: mockCid,
+            status: OPERATION_STATUS.COMPLETED,
+            operation: "upload",
+            operation_display_name: "Upload",
+            protocol: "ipfs",
+            protocol_display_name: "IPFS",
+            progress_percent: 100,
+            started_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
         }),
       }),
     };
@@ -136,6 +171,7 @@ export function setupUppyMocks() {
             mimeType: "application/vnd.ipld.car",
             createdAt: new Date().toISOString(),
             numberOfFiles: 1,
+            operationId: 12345,
           },
         };
 
@@ -235,6 +271,8 @@ export function setupMockSdkInstance(
     success: true,
     data: { limit: uploadLimit },
   });
+  mockSdkInstance.account().listOperations.mockClear();
+  mockSdkInstance.account().waitForOperation.mockClear();
   return mockSdkInstance;
 }
 

--- a/libs/pinner/src/upload/builder.ts
+++ b/libs/pinner/src/upload/builder.ts
@@ -1,7 +1,17 @@
 import type { Pinner } from "@/pinner";
-import type { PinnerUploadBuilder } from "@/types/upload";
-import type { UploadOptions, UploadOperation } from "@/types/upload";
-import { jsonToFile, base64ToFile, urlToFile, csvToFile, textToFile } from "@/encoder";
+import type {
+  PinnerUploadBuilder,
+  UploadOperation,
+  UploadOptions,
+} from "@/types/upload";
+import type { OperationPollingOptions } from "@lumeweb/portal-sdk";
+import {
+  base64ToFile,
+  csvToFile,
+  jsonToFile,
+  textToFile,
+  urlToFile,
+} from "@/encoder";
 import { validateUrl } from "@/utils/validation";
 
 /**
@@ -10,6 +20,8 @@ import { validateUrl } from "@/utils/validation";
 abstract class BaseUploadBuilder implements PinnerUploadBuilder {
   protected _name?: string;
   protected _keyvalues?: Record<string, string>;
+  protected _waitForOperation?: boolean;
+  protected _operationPollingOptions?: OperationPollingOptions;
 
   constructor(protected pinner: Pinner) {}
 
@@ -23,6 +35,16 @@ abstract class BaseUploadBuilder implements PinnerUploadBuilder {
     return this;
   }
 
+  waitForOperation(wait: boolean = true): this {
+    this._waitForOperation = wait;
+    return this;
+  }
+
+  operationPollingOptions(options: OperationPollingOptions): this {
+    this._operationPollingOptions = options;
+    return this;
+  }
+
   abstract pin(): Promise<UploadOperation>;
 
   protected buildOptions(): UploadOptions {
@@ -32,6 +54,12 @@ abstract class BaseUploadBuilder implements PinnerUploadBuilder {
     }
     if (this._keyvalues !== undefined) {
       options.keyvalues = this._keyvalues;
+    }
+    if (this._waitForOperation !== undefined) {
+      options.waitForOperation = this._waitForOperation;
+    }
+    if (this._operationPollingOptions !== undefined) {
+      options.operationPollingOptions = this._operationPollingOptions;
     }
     return options;
   }
@@ -186,9 +214,11 @@ export function createUploadBuilderNamespace(
 /**
  * Combined interface for upload that works as both a method and a builder namespace.
  */
-export type UploadMethodAndBuilder =
-  & ((file: File, options?: UploadOptions) => Promise<UploadOperation>)
-  & UploadBuilderNamespace;
+export type UploadMethodAndBuilder = ((
+  file: File,
+  options?: UploadOptions,
+) => Promise<UploadOperation>) &
+  UploadBuilderNamespace;
 
 /**
  * Export PinnerUploadBuilder for external use.

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -1,11 +1,19 @@
-import { Sdk } from "@lumeweb/portal-sdk";
+import type { OperationPollingOptions } from "@lumeweb/portal-sdk";
+import {
+  OPERATION_STATUS,
+  type OperationsQueryParams,
+  Sdk,
+} from "@lumeweb/portal-sdk";
+import { createEqFilter } from "@lumeweb/query-builder";
 
 import type { PinnerConfig } from "../config";
 import type {
   UploadInput,
   UploadOperation,
   UploadOptions,
+  UploadResult,
 } from "@/types/upload";
+import { isUploadResult } from "@/types/upload";
 import { XHRUploadHandler } from "./xhr-upload";
 import { TUSUploadHandler } from "./tus-upload";
 import { DEFAULT_ENDPOINT, TUS_SIZE_THRESHOLD } from "@/types/constants";
@@ -81,6 +89,167 @@ export class UploadManager {
     return this.#uploadCarFile(input, options);
   }
 
+  /**
+   * Wait for an operation to complete or reach a settled state.
+   *
+   * Handles two scenarios:
+   * 1. If an operationId is provided (in UploadResult), uses it directly
+   * 2. If only CID is available, lists operations filtered by CID and polls the first result
+   *
+   * @param input Either an operation ID (number) or an UploadResult
+   * @param options Polling options (interval, timeout, settledStates)
+   * @returns UploadResult with operation status merged in
+   */
+  async waitForOperation(
+    input: number | UploadResult,
+    options?: OperationPollingOptions,
+  ): Promise<UploadResult> {
+    // Scenario 1: UploadResult with operationId - use it directly
+    if (isUploadResult(input) && input.operationId) {
+      const result = await this.portalSdk
+        .account()
+        .waitForOperation(input.operationId, options);
+
+      if (!result.success) {
+        throw new Error(
+          result.error?.message || `Operation ${input.operationId} failed`,
+        );
+      }
+
+      const operation = result.data;
+      if (!operation.cid) {
+        throw new Error(`Operation ${input.operationId} completed without CID`);
+      }
+
+      if (
+        operation.status?.toLowerCase() === OPERATION_STATUS.FAILED ||
+        operation.status?.toLowerCase() === OPERATION_STATUS.ERROR
+      ) {
+        throw new Error(
+          `Operation ${input.operationId} failed: ${operation.error || operation.status_message || "Unknown error"}`,
+        );
+      }
+
+      // Merge operation data into the original upload result
+      return {
+        ...input,
+        cid: operation.cid,
+        operationId: operation.id,
+      };
+    }
+
+    // Scenario 2: UploadResult with CID but no operationId - find by CID
+    if (isUploadResult(input) && input.cid) {
+      return await this.#waitForOperationByCid(input, options);
+    }
+
+    // Scenario 3: Only operation ID provided
+    const operationId = typeof input === "number" ? input : undefined;
+    if (operationId) {
+      const result = await this.portalSdk
+        .account()
+        .waitForOperation(operationId, options);
+
+      if (!result.success) {
+        throw new Error(
+          result.error?.message || `Operation ${operationId} failed`,
+        );
+      }
+
+      const operation = result.data;
+      if (!operation.cid) {
+        throw new Error(`Operation ${operationId} completed without CID`);
+      }
+
+      if (
+        operation.status?.toLowerCase() === OPERATION_STATUS.FAILED ||
+        operation.status?.toLowerCase() === OPERATION_STATUS.ERROR
+      ) {
+        throw new Error(
+          `Operation ${operationId} failed: ${operation.error || operation.status_message || "Unknown error"}`,
+        );
+      }
+
+      return {
+        id: operationId.toString(),
+        cid: operation.cid,
+        name: operation.operation_display_name || "Unknown",
+        size: 0,
+        mimeType: "",
+        createdAt: new Date(operation.started_at),
+        numberOfFiles: 1,
+        operationId: operation.id,
+      };
+    }
+
+    throw new Error(
+      "No operation ID or CID provided, cannot wait for operation",
+    );
+  }
+
+  /**
+   * Wait for an operation by CID.
+   *
+   * This is used when we have a CID from an upload but no operation ID.
+   * We list operations filtered by CID to find the operation ID,
+   * then use the SDK's waitForOperation for polling.
+   *
+   * @param uploadResult UploadResult with CID
+   * @param options Polling options (interval, timeout, settledStates)
+   * @returns UploadResult with operation status merged in
+   */
+  async #waitForOperationByCid(
+    uploadResult: UploadResult,
+    options?: OperationPollingOptions,
+  ): Promise<UploadResult> {
+    // List operations filtered by CID
+    const params: OperationsQueryParams = {
+      filters: [createEqFilter("cid", uploadResult.cid)],
+      pagination: { start: 0, end: 1 },
+    };
+
+    const result = await this.portalSdk.account().listOperations(params);
+
+    if (!result.success || !result.data || !result.data.data) {
+      throw new Error(`Failed to find operation with CID ${uploadResult.cid}`);
+    }
+
+    const operation = result.data.data;
+    const operationId = operation.id;
+
+    // Use SDK's waitForOperation for polling
+    const waitResult = await this.portalSdk
+      .account()
+      .waitForOperation(operationId, options);
+
+    if (!waitResult.success) {
+      throw new Error(
+        waitResult.error?.message || `Operation ${operationId} failed`,
+      );
+    }
+
+    const finalOperation = waitResult.data;
+    if (!finalOperation.cid) {
+      throw new Error(`Operation ${operationId} completed without CID`);
+    }
+
+    if (
+      finalOperation.status?.toLowerCase() === OPERATION_STATUS.FAILED ||
+      finalOperation.status?.toLowerCase() === OPERATION_STATUS.ERROR
+    ) {
+      throw new Error(
+        `Operation ${operationId} failed: ${finalOperation.error || finalOperation.status_message || "Unknown error"}`,
+      );
+    }
+
+    // Return merged result
+    return {
+      ...uploadResult,
+      cid: finalOperation.cid,
+      operationId: finalOperation.id,
+    };
+  }
+
   #validateInput(input: UploadInput, options?: UploadOptions): void {
     if (input instanceof File) {
       if (input.size === 0) {
@@ -111,11 +280,21 @@ export class UploadManager {
       signal: options?.signal,
     });
 
-    return this.#uploadCarResult(
+    const operation = await this.#uploadCarResult(
       carResult,
       options?.name || "directory",
       options,
     );
+
+    if (options?.waitForOperation && operation.result) {
+      const uploadResult = await operation.result;
+      operation.result = this.waitForOperation(
+        { ...uploadResult, isDirectory: true, numberOfFiles: files.length },
+        options.operationPollingOptions,
+      );
+    }
+
+    return operation;
   }
 
   async #uploadInput(
@@ -193,7 +372,10 @@ export class UploadManager {
     }
 
     // For ReadableStream, rely on explicit isCarFile option or name extension
-    if (input instanceof ReadableStream && options?.name?.endsWith(FILE_EXTENSION_CAR)) {
+    if (
+      input instanceof ReadableStream &&
+      options?.name?.endsWith(FILE_EXTENSION_CAR)
+    ) {
       // We can't verify stream content without consuming it,
       // so we trust the explicit isCarFile option or extension
       return options?.isCarFile !== false;
@@ -288,11 +470,19 @@ export class UploadManager {
       isLargeFile = true;
     }
 
-    if (isLargeFile) {
-      return this.tusHandler.upload(input, options);
+    const operation = await (isLargeFile
+      ? this.tusHandler.upload(input, options)
+      : this.xhrHandler.upload(input, options));
+
+    if (options?.waitForOperation && operation.result) {
+      const uploadResult = await operation.result;
+      operation.result = this.waitForOperation(
+        uploadResult,
+        options.operationPollingOptions,
+      );
     }
 
-    return this.xhrHandler.upload(input, options);
+    return operation;
   }
 
   destroy(): void {

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -210,11 +210,15 @@ export class UploadManager {
 
     const result = await this.portalSdk.account().listOperations(params);
 
-    if (!result.success || !result.data || !result.data.data) {
+    if (!result.success) {
       throw new Error(`Failed to find operation with CID ${uploadResult.cid}`);
     }
 
-    const operation = result.data.data;
+    const operation = result.data.data?.[0];
+    if (!operation) {
+      throw new Error(`Failed to find operation with CID ${uploadResult.cid}`);
+    }
+
     const operationId = operation.id;
 
     // Use SDK's waitForOperation for polling

--- a/libs/pinner/src/upload/tus-upload.ts
+++ b/libs/pinner/src/upload/tus-upload.ts
@@ -1,6 +1,7 @@
 import Uppy from "@uppy/core";
 import TusPlugin from "@uppy/tus";
 import type { UploadResult } from "@/types/upload";
+import { UploadResultSymbol } from "@/types/upload";
 import { BaseUploadHandler } from "./base-upload";
 import { patchTusNodeHttpStack } from "@/utils/tus-patch";
 import type { PinnerConfig } from "@/config";
@@ -41,6 +42,7 @@ export class TUSUploadHandler extends BaseUploadHandler {
         createdAt: new Date(),
         numberOfFiles: 1,
         isDirectory: false,
+        [UploadResultSymbol]: true,
       };
     }
 
@@ -57,6 +59,8 @@ export class TUSUploadHandler extends BaseUploadHandler {
         numberOfFiles: response.numberOfFiles,
         isDirectory: response.isDirectory ?? false,
         keyvalues: response.keyvalues,
+        operationId: response.operationId,
+        [UploadResultSymbol]: true,
       };
     }
 
@@ -71,6 +75,7 @@ export class TUSUploadHandler extends BaseUploadHandler {
       createdAt: new Date(),
       numberOfFiles: 1,
       isDirectory: false,
+      [UploadResultSymbol]: true,
     };
   }
 

--- a/libs/pinner/src/upload/xhr-upload.ts
+++ b/libs/pinner/src/upload/xhr-upload.ts
@@ -1,6 +1,7 @@
 import Uppy from "@uppy/core";
 import XHRUpload from "@lumeweb/uppy-post-upload";
 import type { UploadResult } from "@/types/upload";
+import { UploadResultSymbol } from "@/types/upload";
 import { BaseUploadHandler } from "./base-upload";
 import { UPLOAD_SOURCE_XHR } from "./constants";
 
@@ -28,6 +29,7 @@ export class XHRUploadHandler extends BaseUploadHandler {
         createdAt: string;
         numberOfFiles: number;
         keyvalues?: Record<string, string>;
+        operationId?: number;
       };
     };
 
@@ -42,6 +44,8 @@ export class XHRUploadHandler extends BaseUploadHandler {
       createdAt: new Date(response.createdAt),
       numberOfFiles: response.numberOfFiles,
       keyvalues: response.keyvalues,
+      operationId: response.operationId,
+      [UploadResultSymbol]: true,
     };
   }
 

--- a/libs/pinner/src/utils/__tests__/validation.spec.ts
+++ b/libs/pinner/src/utils/__tests__/validation.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { validateUrl, ValidationError } from "../validation";
 
 describe("validateUrl", () => {
@@ -6,13 +6,17 @@ describe("validateUrl", () => {
     it("should allow valid HTTP URLs", () => {
       expect(() => validateUrl("http://example.com")).not.toThrow();
       expect(() => validateUrl("http://example.com/path")).not.toThrow();
-      expect(() => validateUrl("http://example.com/path?query=value")).not.toThrow();
+      expect(() =>
+        validateUrl("http://example.com/path?query=value"),
+      ).not.toThrow();
     });
 
     it("should allow valid HTTPS URLs", () => {
       expect(() => validateUrl("https://example.com")).not.toThrow();
       expect(() => validateUrl("https://example.com/path")).not.toThrow();
-      expect(() => validateUrl("https://example.com/path?query=value")).not.toThrow();
+      expect(() =>
+        validateUrl("https://example.com/path?query=value"),
+      ).not.toThrow();
     });
 
     it("should allow URLs with subdomains", () => {
@@ -36,7 +40,9 @@ describe("validateUrl", () => {
     });
 
     it("should reject data: URLs", () => {
-      expect(() => validateUrl("data:text/plain,hello")).toThrow(ValidationError);
+      expect(() => validateUrl("data:text/plain,hello")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject javascript: URLs", () => {
@@ -44,7 +50,9 @@ describe("validateUrl", () => {
     });
 
     it("should reject mailto: URLs", () => {
-      expect(() => validateUrl("mailto:test@example.com")).toThrow(ValidationError);
+      expect(() => validateUrl("mailto:test@example.com")).toThrow(
+        ValidationError,
+      );
     });
   });
 
@@ -64,7 +72,9 @@ describe("validateUrl", () => {
     it("should reject 127.x.x.x addresses", () => {
       expect(() => validateUrl("http://127.0.0.2")).toThrow(ValidationError);
       expect(() => validateUrl("http://127.1.1.1")).toThrow(ValidationError);
-      expect(() => validateUrl("http://127.255.255.255")).toThrow(ValidationError);
+      expect(() => validateUrl("http://127.255.255.255")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject IPv6 localhost", () => {
@@ -75,17 +85,23 @@ describe("validateUrl", () => {
   describe("SSRF protection - private IP ranges (IPv4)", () => {
     it("should reject 10.0.0.0/8 range", () => {
       expect(() => validateUrl("http://10.0.0.1")).toThrow(ValidationError);
-      expect(() => validateUrl("http://10.255.255.255")).toThrow(ValidationError);
+      expect(() => validateUrl("http://10.255.255.255")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject 172.16.0.0/12 range", () => {
       expect(() => validateUrl("http://172.16.0.1")).toThrow(ValidationError);
-      expect(() => validateUrl("http://172.31.255.255")).toThrow(ValidationError);
+      expect(() => validateUrl("http://172.31.255.255")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject 192.168.0.0/16 range", () => {
       expect(() => validateUrl("http://192.168.0.1")).toThrow(ValidationError);
-      expect(() => validateUrl("http://192.168.255.255")).toThrow(ValidationError);
+      expect(() => validateUrl("http://192.168.255.255")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject link-local 169.254.0.0/16 range", () => {
@@ -110,14 +126,18 @@ describe("validateUrl", () => {
       // 0177.0.0.1 = 127.0.0.1 in octal
       expect(() => validateUrl("http://0177.0.0.1")).toThrow(ValidationError);
       // 0300.0250.0.1 = 192.168.0.1 in octal
-      expect(() => validateUrl("http://0300.0250.0.1")).toThrow(ValidationError);
+      expect(() => validateUrl("http://0300.0250.0.1")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject hexadecimal notation", () => {
       // 0x7f.0.0.1 = 127.0.0.1 in hex
       expect(() => validateUrl("http://0x7f.0.0.1")).toThrow(ValidationError);
       // 0xc0.0xa8.0.0.1 = 192.168.0.1 in hex
-      expect(() => validateUrl("http://0xc0.0xa8.0.0.1")).toThrow(ValidationError);
+      expect(() => validateUrl("http://0xc0.0xa8.0.0.1")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject mixed notation", () => {
@@ -138,12 +158,16 @@ describe("validateUrl", () => {
     it("should reject IPv6 unique local addresses (fc00::/7)", () => {
       expect(() => validateUrl("http://[fc00::1]")).toThrow(ValidationError);
       expect(() => validateUrl("http://[fd00::1]")).toThrow(ValidationError);
-      expect(() => validateUrl("http://[fde4:8dba:82e1::1]")).toThrow(ValidationError);
+      expect(() => validateUrl("http://[fde4:8dba:82e1::1]")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject IPv6 link-local addresses (fe80::/10)", () => {
       expect(() => validateUrl("http://[fe80::1]")).toThrow(ValidationError);
-      expect(() => validateUrl("http://[fe80::1%eth0]")).toThrow(ValidationError);
+      expect(() => validateUrl("http://[fe80::1%eth0]")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should reject IPv6 multicast addresses (ff00::/8)", () => {
@@ -151,8 +175,12 @@ describe("validateUrl", () => {
     });
 
     it("should reject IPv4-mapped IPv6 addresses", () => {
-      expect(() => validateUrl("http://[::ffff:127.0.0.1]")).toThrow(ValidationError);
-      expect(() => validateUrl("http://[::ffff:192.168.1.1]")).toThrow(ValidationError);
+      expect(() => validateUrl("http://[::ffff:127.0.0.1]")).toThrow(
+        ValidationError,
+      );
+      expect(() => validateUrl("http://[::ffff:192.168.1.1]")).toThrow(
+        ValidationError,
+      );
     });
   });
 

--- a/libs/portal-sdk/src/account/generated/accountAPI.schemas.ts
+++ b/libs/portal-sdk/src/account/generated/accountAPI.schemas.ts
@@ -169,7 +169,7 @@ export interface OperationListItem {
 }
 
 export interface OperationListItemResponse {
-  data: OperationListItem;
+  data: OperationListItem[];
   total: number;
 }
 

--- a/libs/portal-sdk/src/account/swagger.yaml
+++ b/libs/portal-sdk/src/account/swagger.yaml
@@ -387,7 +387,9 @@ components:
       additionalProperties: false
       properties:
         data:
-          $ref: '#/components/schemas/OperationListItem'
+          type: array
+          items:
+            $ref: '#/components/schemas/OperationListItem'
         total:
           type: integer
       required:

--- a/libs/portal-sdk/src/index.ts
+++ b/libs/portal-sdk/src/index.ts
@@ -5,5 +5,6 @@ export { DEFAULT_SETTLED_STATES, OPERATION_STATUS } from "@/account";
 export * from "@/account/generated/accountAPI.schemas";
 export * from '@/account/generated/default';
 export * from '@/query-utils';
+export { type OperationsQueryParams } from '@/query-utils';
 export * from './account/generated/default';
 export * from './account/generated/accountAPI.schemas';

--- a/libs/portal-sdk/src/query-utils.ts
+++ b/libs/portal-sdk/src/query-utils.ts
@@ -39,15 +39,10 @@ import {
 // Re-export types
 export type { ParsedQuery, QueryParams, SerializeInput };
 
-// Re-export functions
+// Re-export functions from query-builder
 export {
   serializeQueryParams,
   calculatePagination,
-  createEqFilter,
-  createNeFilter,
-  createContainsFilter,
-  createInFilter,
-  createBetweenFilter,
   createSort,
   createAscSort,
   createDescSort,
@@ -63,7 +58,7 @@ export {
   COMPARISON_OPERATORS,
   OPERATORS,
   ARRAY_OPERATORS,
-};
+} from "@lumeweb/query-builder";
 
 /**
  * Operations query parameters for the operations API

--- a/libs/portal-sdk/tsdown.config.ts
+++ b/libs/portal-sdk/tsdown.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, UserConfig } from "tsdown";
+import { defineConfig, type UserConfig } from "tsdown";
 
 const commonOptions: UserConfig = {
   external: [/node_modules/],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@lumeweb/portal-sdk':
         specifier: workspace:*
         version: link:../portal-sdk
+      '@lumeweb/query-builder':
+        specifier: workspace:*
+        version: link:../query-builder
       '@lumeweb/uppy-post-upload':
         specifier: workspace:*
         version: link:../uppy-post-upload


### PR DESCRIPTION
- Add `waitForOperation` method to `Pinner` and `UploadManager` to poll for operation completion
- Add `operationId` to `UploadResult` and `isUploadResult` type guard
- Add `waitForOperation` and `operationPollingOptions` to `UploadOptions` and `PinnerUploadBuilder`
- Integrate automatic operation waiting into upload and uploadDirectory flows
- Add MSW handlers for operation list and get endpoints in tests
- Add `@lumeweb/query-builder` dependency to `pinner`


---

<!-- kody-pr-summary:start -->
This pull request introduces operation polling and a `waitForOperation` feature to the Pinner library.

Key changes include:

*   **`waitForOperation` Method**: A new public method `pinner.waitForOperation` has been added, allowing users to explicitly wait for a backend operation to complete. This method accepts either an operation ID (number) or an `UploadResult` object as input, and can be configured with custom polling options (interval, timeout, settled states).
*   **Integrated Operation Waiting in Uploads**: The `pinner.upload` and `pinner.uploadDirectory` methods now support a `waitForOperation` option. When set to `true`, these methods will automatically poll the associated backend operation until it reaches a settled state (completed, failed, or error) before resolving the upload promise. Custom `operationPollingOptions` can also be provided.
*   **`operationId` in `UploadResult`**: The `UploadResult` interface has been extended to include an `operationId`, which is populated by the underlying upload handlers (TUS and XHR) to link an upload to its corresponding backend operation.
*   **Operation Lookup by CID**: The `UploadManager` can now find an operation ID by listing operations filtered by CID, enabling `waitForOperation` even when only a CID is initially available.
*   **Mock API Support**: New mock API handlers for `/api/operations` and `/api/operations/:id` have been added to facilitate testing of the new polling and operation tracking functionality.
*   **Dependency**: The `@lumeweb/query-builder` library has been added as a dependency to `libs/pinner` for constructing API queries related to operations.
<!-- kody-pr-summary:end -->