### PR TITLE
refactor(portal-sdk): remove re-exports of @lumeweb/query-builder utilities

### DIFF
--- a/libs/portal-sdk/src/__tests__/account.test.ts
+++ b/libs/portal-sdk/src/__tests__/account.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { AccountApi, OPERATION_STATUS } from "@/account";
-import { createEqFilter, calculatePagination } from "@/query-utils";
+import { createEqFilter, calculatePagination } from "@lumeweb/query-builder";
 import { expectSuccess, expectFailure, expectOperationStatus, getPrivateProperty, setPrivateProperty } from "./test-helpers";
 
 // Mock types for testing

--- a/libs/portal-sdk/src/__tests__/query-utils.test.ts
+++ b/libs/portal-sdk/src/__tests__/query-utils.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OperationsQueryParams } from "@/query-utils";
-import {
-  buildOperationsQueryParams,
-  createEqFilter,
-  createInFilter,
-  createDescSort,
-  calculatePagination,
-} from "@/query-utils";
+import { buildOperationsQueryParams } from "@/query-utils";
+import { createEqFilter, createInFilter, createDescSort, calculatePagination } from "@lumeweb/query-builder";
 
 describe("buildOperationsQueryParams", () => {
   describe("search parameter", () => {

--- a/libs/portal-sdk/src/query-utils.ts
+++ b/libs/portal-sdk/src/query-utils.ts
@@ -1,74 +1,23 @@
 /**
  * Query utilities for operations API
- * 
+ *
  * Provides types and functions for building query parameters with filters,
  * sorters, and pagination using the @lumeweb/query-builder library.
  */
 
 // Import types and functions from query-builder
-import type {
-  ParsedQuery,
-  QueryParams,
-  SerializeInput,
-} from "@lumeweb/query-builder";
-import {
-  serializeQueryParams,
-  calculatePagination,
-  createEqFilter,
-  createNeFilter,
-  createContainsFilter,
-  createInFilter,
-  createBetweenFilter,
-  createSort,
-  createAscSort,
-  createDescSort,
-  addFilter,
-  addFilters,
-  addSorter,
-  addSorters,
-  setFiltersByField,
-  setSorter,
-  clearFilters,
-  clearSorters,
-  LOGICAL_OPERATORS,
-  COMPARISON_OPERATORS,
-  OPERATORS,
-  ARRAY_OPERATORS,
-} from "@lumeweb/query-builder";
-
-// Re-export types
-export type { ParsedQuery, QueryParams, SerializeInput };
-
-// Re-export functions from query-builder
-export {
-  serializeQueryParams,
-  calculatePagination,
-  createSort,
-  createAscSort,
-  createDescSort,
-  addFilter,
-  addFilters,
-  addSorter,
-  addSorters,
-  setFiltersByField,
-  setSorter,
-  clearFilters,
-  clearSorters,
-  LOGICAL_OPERATORS,
-  COMPARISON_OPERATORS,
-  OPERATORS,
-  ARRAY_OPERATORS,
-} from "@lumeweb/query-builder";
+import type { SerializeInput } from "@lumeweb/query-builder";
+import { serializeQueryParams } from "@lumeweb/query-builder";
 
 /**
  * Operations query parameters for the operations API
- * 
+ *
  * Uses query-builder helpers to construct the API query parameters:
  * - filters: Array of filter objects → serialized to filters[field][operator]=value
  * - sorters: Array of sort objects → serialized to _sort=field&_order=direction
  * - pagination: Object with start/end → serialized to _start=0&_end=20
  * - search: Search term → passed directly as search=value
- * 
+ *
  * @example
  * ```ts
  * const params: OperationsQueryParams = {
@@ -94,16 +43,16 @@ export type OperationsListParams = OperationsQueryParams;
 
 /**
  * Builds URL query parameters for operations API
- * 
+ *
  * Serializes query-builder parameters to the API's expected format:
  * - filters → filters[field][operator]=value
  * - sorters → _sort=field&_order=direction
  * - pagination → _start=0&_end=20
  * - search → search=value
- * 
+ *
  * @param params - Query parameters using query-builder helpers
  * @returns URLSearchParams object ready to use with fetch
- * 
+ *
  * @example
  * ```ts
  * const searchParams = buildOperationsQueryParams({
@@ -115,16 +64,18 @@ export type OperationsListParams = OperationsQueryParams;
  *   pagination: { start: 0, end: 20, page: 1, pageSize: 20 },
  *   search: "myfile"
  * });
- * 
+ *
  * // Result URL: ?filters[status][eq]=completed&filters[operation][in][0]=upload&filters[operation][in][1]=download&_sort=id&_order=desc&_start=0&_end=20&search=myfile
  * ```
  */
-export function buildOperationsQueryParams(params: OperationsQueryParams): URLSearchParams {
+export function buildOperationsQueryParams(
+  params: OperationsQueryParams,
+): URLSearchParams {
   const queryString = serializeQueryParams({
     filters: params.filters,
     sorters: params.sorters,
     pagination: params.pagination,
-  });
+  }) as Record<string, string>;
 
   const searchParams = new URLSearchParams(queryString);
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This refactoring removes the re-export of various utility functions and types from the `@lumeweb/query-builder` library within `libs/portal-sdk/src/query-utils.ts`.

Previously, `query-utils.ts` acted as an intermediary, re-exporting functions such as `createEqFilter`, `createInFilter`, `createDescSort`, and `calculatePagination`, along with several types, from `@lumeweb/query-builder`.

With this change:
- Consumers of these query-builder utilities (including internal test files) will now import them directly from `@lumeweb/query-builder`.
- The `libs/portal-sdk/src/query-utils.ts` module is streamlined to primarily focus on its core function, `buildOperationsQueryParams`, which internally utilizes `serializeQueryParams` from `@lumeweb/query-builder`.
<!-- kody-pr-summary:end -->