### PR TITLE
fix(pinner): make setDriverFactory actually work

### DIFF
--- a/libs/pinner/src/blockstore/__tests__/unstorage.spec.ts
+++ b/libs/pinner/src/blockstore/__tests__/unstorage.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createBlockstore, setDriverFactory } from "@/blockstore";
 import { runCommonBlockstoreTests } from "./shared-blockstore-tests";
+import memoryDriver from "unstorage/drivers/memory";
 
 describe("createBlockstore (factory)", () => {
   const mockDriver = vi.fn() as any;
@@ -90,6 +91,38 @@ describe("createBlockstore (factory)", () => {
       const blockstore = new BlockstoreClass({ storage: mockStorage as any });
 
       expect(blockstore).toBeDefined();
+    });
+
+    it("should bypass driverFactory when storage option is provided", async () => {
+      const factorySpy = vi.fn(() => memoryDriver());
+      setDriverFactory(factorySpy);
+
+      const mockStorage = {
+        hasItem: vi.fn().mockResolvedValue(false),
+        setItemRaw: vi.fn().mockResolvedValue(undefined),
+        getItemRaw: vi.fn().mockResolvedValue(new Uint8Array([])),
+        removeItem: vi.fn().mockResolvedValue(undefined),
+        getKeys: vi.fn().mockResolvedValue([]),
+      };
+
+      const BlockstoreClass = createBlockstore();
+      const blockstore = new BlockstoreClass({ storage: mockStorage as any });
+
+      expect(blockstore).toBeDefined();
+      expect(factorySpy).not.toHaveBeenCalled();
+    });
+
+    it("should bypass driverFactory when driver option is provided", async () => {
+      const factorySpy = vi.fn(() => memoryDriver());
+      setDriverFactory(factorySpy);
+
+      const customDriver = memoryDriver();
+
+      const BlockstoreClass = createBlockstore();
+      const blockstore = new BlockstoreClass({ driver: customDriver });
+
+      expect(blockstore).toBeDefined();
+      expect(factorySpy).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/pinner/src/blockstore/unstorage-base.ts
+++ b/libs/pinner/src/blockstore/unstorage-base.ts
@@ -52,7 +52,7 @@ export interface UnstorageBlockstoreOptions {
 
 type DriverFactory = () => Driver | Promise<Driver>;
 
-let driverFactory: DriverFactory | null = null;
+export let driverFactory: DriverFactory | null = null;
 
 export function setDriverFactory(factory: DriverFactory | null): void {
   driverFactory = factory;

--- a/libs/pinner/src/blockstore/unstorage.ts
+++ b/libs/pinner/src/blockstore/unstorage.ts
@@ -1,6 +1,7 @@
 import {
   createUnstorageBlockstore,
   createUnstorageDatastore,
+  driverFactory,
   setDriverFactory,
   type UnstorageBlockstoreOptions,
 } from "./unstorage-base";
@@ -16,6 +17,11 @@ function isBrowser(): boolean {
 }
 
 async function getDefaultDriver(base?: string) {
+  // Use driverFactory override if set (typically by tests to inject in-memory driver)
+  if (driverFactory) {
+    return await driverFactory();
+  }
+
   if (isBrowser()) {
     return (await import("unstorage/drivers/indexedb")).default({
       base: base ?? DEFAULT_BLOCKSTORE_BASE,


### PR DESCRIPTION
- export driverFactory from unstorage-base.ts so it can be checked
- modify getDefaultDriver to check driverFactory override before defaulting to fs-lite/IndexedDB
- add tests to verify storage/driver options correctly bypass driverFactory


---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where the `setDriverFactory` function, intended to allow overriding the default Unstorage driver, was not being effectively utilized.

The changes ensure that:
*   The `getDefaultDriver` function now correctly checks for and invokes a globally set `driverFactory` to provide the Unstorage driver, enabling custom driver injection (e.g., for in-memory drivers in tests).
*   New test cases confirm that explicitly providing `storage` or `driver` options during blockstore creation correctly bypasses the globally set `driverFactory`, prioritizing the directly supplied options.

This fix makes the `setDriverFactory` mechanism fully functional as intended.
<!-- kody-pr-summary:end -->