### PR TITLE
fix(portal-framework-ui): add default values to required label parameters

### DIFF
--- a/libs/portal-framework-ui/src/components/actions/actionHelpers.ts
+++ b/libs/portal-framework-ui/src/components/actions/actionHelpers.ts
@@ -84,7 +84,7 @@ export function createActionHelpers<T = any>() {
      */
     button: (
       onClick?: () => void,
-      label: string,
+      label = "Button",
       disabled = false,
     ): ActionItemConfig => ({
       disabled,
@@ -108,7 +108,7 @@ export function createActionHelpers<T = any>() {
     custom: (
       type: ActionItemType,
       onClick?: () => void,
-      label: string,
+      label = "Custom",
       options: Partial<ActionItemConfig> = {},
     ): ActionItemConfig => ({
       label,


### PR DESCRIPTION
- Changed `label: string` to `label = "Button"` in the `button` function
- Changed `label: string` to `label = "Custom"` in the `custom` function

This fixes TypeScript build errors where required parameters cannot follow
optional parameters.


---

<!-- kody-pr-summary:start -->
This pull request updates the `createActionHelpers` utility within the `portal-framework-ui` library. It modifies the `button` and `custom` helper methods to provide default values for the `label` parameter. Specifically, the `button` method now defaults to "Button" and the `custom` method defaults to "Custom", making the label argument optional when configuring these actions.
<!-- kody-pr-summary:end -->