### PR TITLE
chore(portal-framework-ui-core): fix CSS file copy configuration

### DIFF
--- a/libs/portal-framework-ui-core/tsdown.config.ts
+++ b/libs/portal-framework-ui-core/tsdown.config.ts
@@ -29,8 +29,8 @@ export default defineConfig([
       },
     },
     copy: [
-      { to: "dist/esm/tailwind.css", from: "src/tailwind.css" },
-      { to: "dist/esm/tailwind-plugin.css", from: "src/tailwind-plugin.css" },
+      { to: "dist/esm", from: "src/tailwind.css" },
+      { to: "dist/esm", from: "src/tailwind-plugin.css" },
     ],
   },
   {


### PR DESCRIPTION
- Remove explicit destination filenames in copy config
- Copy CSS files to dist/esm directory while preserving original filenames


---

<!-- kody-pr-summary:start -->
This pull request corrects the file copy configuration for the `portal-framework-ui-core` library. The modification updates the destination path for CSS files (`tailwind.css` and `tailwind-plugin.css`) to target the `dist/esm` directory directly, rather than specifying the full file path in the destination. This ensures that the CSS assets are correctly copied to the ESM distribution folder during the build process.
<!-- kody-pr-summary:end -->