### PR TITLE
chore(query-builder): exclude test files from build output

### DIFF
--- a/libs/query-builder/tsdown.config.ts
+++ b/libs/query-builder/tsdown.config.ts
@@ -15,7 +15,7 @@ const configs: UserConfig[] = [
   {
     ...commonOptions,
     clean: true,
-    entry: ["src/**/*"],
+    entry: ["src/**/*", "!**/__tests__/**", "!**/*.test.ts", "!**/*.spec.ts"],
     format: {
       esm: {
         outputOptions: {


### PR DESCRIPTION
- Add negation patterns to entry array to exclude test files
- Exclude `**/__tests__/**`, `**/*.test.ts`, and `**/*.spec.ts` from tsdown build


---

<!-- kody-pr-summary:start -->
This pull request updates the build configuration for the `query-builder` library to exclude test files and directories from the build output. Specifically, it modifies the entry paths to ignore files within `__tests__` directories and files ending in `.test.ts` or `.spec.ts`.
<!-- kody-pr-summary:end -->