### PR TITLE
chore(portal-sdk): exclude test files from build output

### DIFF
--- a/libs/portal-sdk/tsdown.config.ts
+++ b/libs/portal-sdk/tsdown.config.ts
@@ -15,7 +15,13 @@ const configs: UserConfig[] = [
   {
     ...commonOptions,
     clean: true,
-    entry: ["src/**/*", "!src/**/*.yaml"],
+    entry: [
+      "src/**/*",
+      "!**/__tests__/**",
+      "!**/*.test.ts",
+      "!**/*.spec.ts",
+      "!src/**/*.yaml",
+    ],
     format: {
       esm: {
         outputOptions: {


### PR DESCRIPTION
- Exclude `**/__tests__/**`, `**/*.test.ts`, and `**/*.spec.ts` from tsdown build


---

<!-- kody-pr-summary:start -->
Updated the build configuration for the `portal-sdk` library to exclude test files and directories from the build output. The `tsdown.config.ts` file was modified to ignore `__tests__` directories, as well as files ending in `.test.ts` or `.spec.ts`, ensuring that only production code is included in the final build.
<!-- kody-pr-summary:end -->