### PR TITLE
fix(portal-framework-ui): correct import paths and remove undefined type

### DIFF
--- a/libs/portal-framework-ui/src/components/shared/environment/builders.ts
+++ b/libs/portal-framework-ui/src/components/shared/environment/builders.ts
@@ -16,7 +16,7 @@ import type {
   HeaderContent,
   HeaderEnvironment,
 } from "../types/header";
-import type { AllowStepNavigation } from "../types/navigation";
+
 import type { ForceRerenderCallback, EnvironmentSyncCallback } from "../types/form";
 
 import { ContainerType } from "../types/container";
@@ -255,7 +255,7 @@ export class HeaderEnvironmentBuilder<
   }
 
   wizardNavigation(options: {
-    allowNavigation?: AllowStepNavigation;
+    allowNavigation?: boolean | (() => boolean);
     current: number;
     descriptionMaxWidth?: string;
     disabledSteps?: number[];

--- a/libs/portal-framework-ui/src/components/shared/types/footer.ts
+++ b/libs/portal-framework-ui/src/components/shared/types/footer.ts
@@ -1,6 +1,6 @@
 import type { BaseRecord } from "@refinedev/core";
 
-import { ActionItemConfig } from "../../../actions";
+import { ActionItemConfig } from "../../actions";
 import {
   AnyContainerEnvironment,
   DialogContainerEnvironment,

--- a/libs/portal-framework-ui/src/components/shared/types/header.ts
+++ b/libs/portal-framework-ui/src/components/shared/types/header.ts
@@ -1,8 +1,8 @@
 import type { BaseRecord } from "@refinedev/core";
 
-import type { WizardStepDefinition } from "../../../form/types";
+import type { WizardStepDefinition } from "../../form/types";
 
-import { ActionItemConfig } from "../../../actions";
+import { ActionItemConfig } from "../../actions";
 import { AnyContainerEnvironment } from "./container";
 
 export enum NavigationType {


### PR DESCRIPTION
- Remove non-existent `AllowStepNavigation` type import from environment/builders.ts
- Use inline type `boolean | (() => boolean)` for wizardNavigation allowNavigation parameter
- Fix relative import paths in shared/types/footer.ts (actions import)
- Fix relative import paths in shared/types/header.ts (form/types and actions imports)

Resolves build errors caused by unresolved imports and undefined type references.


---

<!-- kody-pr-summary:start -->
This pull request addresses import path errors and type definition issues within the `portal-framework-ui` library.

Specifically, it:
*   Corrects relative import paths for `ActionItemConfig` and `WizardStepDefinition` in the footer and header type files to ensure proper module resolution.
*   Removes the usage of the `AllowStepNavigation` type in the environment builders, replacing it with an explicit `boolean | (() => boolean)` type definition to resolve potential undefined type errors.
<!-- kody-pr-summary:end -->