### PR TITLE
refactor(portal-framework-ui): extract AllowStepNavigation type and fix import paths

### DIFF
--- a/libs/portal-framework-ui/src/components/form/types.ts
+++ b/libs/portal-framework-ui/src/components/form/types.ts
@@ -23,6 +23,7 @@ import type {
   ForceRerenderCallback,
   EnvironmentSyncCallback,
 } from "../shared/types/form";
+import type { AllowStepNavigation } from "../shared/types/navigation";
 
 /**
  * Enum defining the adapter types for form handling
@@ -321,7 +322,7 @@ export interface StepDefinition<TRequest extends BaseRecord = any> {
    * Whether to allow navigation to this step by clicking on progress indicator
    * Takes precedence over the wizard-level allowStepNavigation config
    */
-  allowStepNavigation?: boolean | (() => boolean);
+  allowStepNavigation?: AllowStepNavigation;
   /**
    * Description for the step
    */
@@ -550,7 +551,7 @@ export interface WizardStepDefinition<TRequest extends BaseRecord = any>
    * Whether to allow navigation to this step by clicking on progress indicator
    * Takes precedence over the wizard-level allowStepNavigation config
    */
-  allowStepNavigation?: boolean | (() => boolean);
+  allowStepNavigation?: AllowStepNavigation;
   /**
    * Description for the step
    * Required for wizard steps

--- a/libs/portal-framework-ui/src/components/shared/types/footer.ts
+++ b/libs/portal-framework-ui/src/components/shared/types/footer.ts
@@ -1,6 +1,6 @@
 import type { BaseRecord } from "@refinedev/core";
 
-import { ActionItemConfig } from "../../../actions";
+import { ActionItemConfig } from "../../actions";
 import {
   AnyContainerEnvironment,
   DialogContainerEnvironment,

--- a/libs/portal-framework-ui/src/components/shared/types/header.ts
+++ b/libs/portal-framework-ui/src/components/shared/types/header.ts
@@ -1,9 +1,10 @@
 import type { BaseRecord } from "@refinedev/core";
 
-import type { WizardStepDefinition } from "../../../form/types";
+import type { WizardStepDefinition } from "../../form/types";
 
-import { ActionItemConfig } from "../../../actions";
+import { ActionItemConfig } from "../../actions";
 import { AnyContainerEnvironment } from "./container";
+import type { AllowStepNavigation } from "./navigation";
 
 export enum NavigationType {
   NONE = "none",
@@ -64,7 +65,7 @@ export interface StepNavigationEnvironment extends NavigationEnvironment {
 // createHeaderContext function is now in context/builders.ts
 
 export interface WizardNavigationEnvironment extends NavigationEnvironment {
-  allowNavigation?: boolean | (() => boolean);
+  allowNavigation?: AllowStepNavigation;
   current: number;
   descriptionMaxWidth?: string;
   disabledSteps?: number[];

--- a/libs/portal-framework-ui/src/components/shared/types/index.ts
+++ b/libs/portal-framework-ui/src/components/shared/types/index.ts
@@ -3,4 +3,5 @@ export * from "./environment";
 export * from "./footer";
 export * from "./form";
 export * from "./header";
+export * from "./navigation";
 export * from "./step";

--- a/libs/portal-framework-ui/src/components/shared/types/navigation.ts
+++ b/libs/portal-framework-ui/src/components/shared/types/navigation.ts
@@ -1,0 +1,7 @@
+import type { BaseRecord } from "@refinedev/core";
+
+/**
+ * Type for controlling step navigation in wizards
+ * Can be a boolean value or a function that returns a boolean
+ */
+export type AllowStepNavigation = boolean | (() => boolean);


### PR DESCRIPTION
- Create navigation.ts with AllowStepNavigation type definition
- Export navigation types from shared/types/index.ts
- Replace inline `boolean | (() => boolean)` with AllowStepNavigation in form/types.ts
- Replace inline `boolean | (() => boolean)` with AllowStepNavigation in shared/types/header.ts
- Fix incorrect relative import paths in footer.ts and header.ts


---

<!-- kody-pr-summary:start -->
This pull request refactors the portal-framework-ui library by extracting a shared type definition and fixing import path issues.

**Key Changes:**

1. **Extracted `AllowStepNavigation` type**: Created a new dedicated type file (`navigation.ts`) to define the `AllowStepNavigation` type (boolean or function returning boolean), which controls step navigation in wizards. This replaces inline type definitions across multiple interfaces.

2. **Updated type references**: Applied the new `AllowStepNavigation` type to:
   - `StepDefinition.allowStepNavigation` in form types
   - `WizardStepDefinition.allowStepNavigation` in form types
   - `WizardNavigationEnvironment.allowNavigation` in header types

3. **Fixed import paths**: Corrected relative import paths in `footer.ts` and `header.ts` from `../../../` to `../../` for `ActionItemConfig` and `WizardStepDefinition` imports.

4. **Exported new type**: Added the navigation type to the shared types index for proper module exports.

These changes improve code maintainability by centralizing the navigation control type definition and resolving import path inconsistencies.
<!-- kody-pr-summary:end -->