### PR TITLE
fix(advanced-rest): use type-only import for UserConfig

### DIFF
--- a/libs/advanced-rest/tsdown.config.ts
+++ b/libs/advanced-rest/tsdown.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, UserConfig } from "tsdown";
+import { defineConfig, type UserConfig } from "tsdown";
 
 const commonOptions: UserConfig = {
   external: [/node_modules/],


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the import of `UserConfig` in `libs/advanced-rest/tsdown.config.ts` to use a type-only import. This change ensures that the interface is used strictly for type checking and is removed from the runtime code during the build process.
<!-- kody-pr-summary:end -->