### PR TITLE
build(portal-plugin-dashboard): add tsdown configuration and build:lib task

### DIFF
--- a/libs/portal-plugin-dashboard/package.json
+++ b/libs/portal-plugin-dashboard/package.json
@@ -49,5 +49,8 @@
     "react-hook-form": "^7.70.0",
     "react-router": "^7.12.0",
     "zod": "4.3.5"
+  },
+  "devDependencies": {
+    "tsdown": "0.19.0-beta.5"
   }
 }

--- a/libs/portal-plugin-dashboard/src-lib/types/capabilities/upload.ts
+++ b/libs/portal-plugin-dashboard/src-lib/types/capabilities/upload.ts
@@ -1,7 +1,6 @@
 import type { BaseCapability } from "@lumeweb/portal-framework-core";
 
-import type { UploadConfig } from "../upload";
-import type { UppyPlugin } from "../uppy";
+import type { UploadConfig, UppyPlugin } from "../upload";
 import type { BasePlugin } from "@uppy/core";
 
 export interface UploadCapability extends BaseCapability<"core:upload"> {

--- a/libs/portal-plugin-dashboard/tsdown.config.ts
+++ b/libs/portal-plugin-dashboard/tsdown.config.ts
@@ -5,10 +5,19 @@ export default defineConfig({
   dts: true,
   entry: ["./src-lib/index.ts"],
   external: [/node_modules/],
-  format: ["esm", "cjs"],
   minify: false,
-  outputOptions(options, format) {
-    options.dir = format === "es" ? "lib-dist/esm" : "lib-dist/cjs";
+  format: {
+    esm: {
+      outputOptions: {
+        dir: "lib-dist/esm",
+        entryFileNames: "[name].js",
+      },
+    },
+    cjs: {
+      outputOptions: {
+        dir: "lib-dist/cjs",
+      },
+    },
   },
   platform: "node",
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1141,6 +1141,10 @@ importers:
       zod:
         specifier: 4.3.5
         version: 4.3.5
+    devDependencies:
+      tsdown:
+        specifier: 0.19.0-beta.5
+        version: 0.19.0-beta.5(typescript@5.9.3)
 
   libs/portal-plugin-ipfs:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -4,12 +4,19 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**","build/**"]
+      "outputs": ["dist/**", "build/**"]
+    },
+    "build:lib": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["lib-dist/**"]
+    },
+    "@lumeweb/portal-plugin-ipfs#build": {
+      "dependsOn": ["@lumeweb/portal-plugin-dashboard#build:lib"]
     },
     "build-dev": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**","build/**"]
+      "outputs": ["dist/**", "build/**"]
     },
     "check-types": {
       "dependsOn": ["^check-types"]


### PR DESCRIPTION
- Add tsdown@0.19.0-beta.5 as devDependency
- Update tsdown.config.ts to use new format syntax for ESM/CJS output
- Add build:lib task to turbo.json with lib-dist outputs
- Configure @lumeweb/portal-plugin-ipfs build to depend on dashboard build:lib
- Consolidate import statements in upload.ts


---

<!-- kody-pr-summary:start -->
This pull request establishes the build configuration for the `portal-plugin-dashboard` library using `tsdown`. It adds `tsdown` as a development dependency and updates the configuration to define specific output directories for ESM and CJS module formats. Additionally, it refactors import statements within the types module to consolidate type definitions.
<!-- kody-pr-summary:end -->