### PR TITLE
build(portal-test-util): add tsdown and update build configuration

### DIFF
--- a/libs/portal-test-util/package.json
+++ b/libs/portal-test-util/package.json
@@ -24,5 +24,7 @@
   "dependencies": {
     "@lumeweb/portal-framework-core": "workspace:*"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "tsdown": "0.19.0-beta.5"
+  }
 }

--- a/libs/portal-test-util/tsdown.config.ts
+++ b/libs/portal-test-util/tsdown.config.ts
@@ -3,11 +3,20 @@ export default defineConfig({
   clean: true,
   dts: true,
   entry: ["src/**/*"],
-  format: ["cjs", "esm"],
-  hash: false,
-  outputOptions(options, format) {
-    options.dir = format === "es" ? "dist/esm" : "dist/cjs";
+  format: {
+    esm: {
+      outputOptions: {
+        dir: "dist/esm",
+        entryFileNames: "[name].js",
+      },
+    },
+    cjs: {
+      outputOptions: {
+        dir: "dist/cjs",
+      },
+    },
   },
+  hash: false,
   sourcemap: true,
   target: "esnext",
   tsconfig: "./tsconfig.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1348,6 +1348,10 @@ importers:
       '@lumeweb/portal-framework-core':
         specifier: workspace:*
         version: link:../portal-framework-core
+    devDependencies:
+      tsdown:
+        specifier: 0.19.0-beta.5
+        version: 0.19.0-beta.5(typescript@5.9.3)
 
   libs/query-builder:
     dependencies:


### PR DESCRIPTION
- Add tsdown@0.19.0-beta.5 to devDependencies
- Update tsdown.config.ts to use new format configuration API
- Configure separate output directories for esm and cjs formats


---

<!-- kody-pr-summary:start -->
This pull request updates the build configuration for the `portal-test-util` library. It modifies the `tsdown.config.ts` file to change how the CommonJS (CJS) and ECMAScript Module (ESM) output formats are defined. The configuration structure is updated from using a function to determine output directories to an explicit object-based approach that defines the output directory for each format directly within the configuration.
<!-- kody-pr-summary:end -->