### PR TITLE
ci: skip builds for select packages and update turbo config

### DIFF
--- a/apps/portal-storybook/package.json
+++ b/apps/portal-storybook/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "build": "storybook build"
+    "build": "echo 'Build skipped' && exit 0"
   },
   "dependencies": {},
   "devDependencies": {}

--- a/libs/portal-plugin-abuse-common/package.json
+++ b/libs/portal-plugin-abuse-common/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsdown",
+    "build": "echo 'Build skipped' && exit 0",
     "lint": "eslint .",
     "orval": "orval"
   },

--- a/libs/portal-plugin-abuse-report/package.json
+++ b/libs/portal-plugin-abuse-report/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "echo 'Build skipped' && exit 0",
     "serve": "vite preview",
     "lint": "eslint ."
   },

--- a/libs/portal-plugin-abuse/package.json
+++ b/libs/portal-plugin-abuse/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "echo 'Build skipped' && exit 0",
     "serve": "vite preview",
     "lint": "eslint ."
   },

--- a/libs/portal-plugin-ipfs/turbo.json
+++ b/libs/portal-plugin-ipfs/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["$TURBO_EXTENDS$", "@lumeweb/portal-plugin-dashboard#build:lib"]
+    }
+  }
+}

--- a/libs/portal-plugin-template/package.json
+++ b/libs/portal-plugin-template/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "echo 'Build skipped' && exit 0",
     "build:lib": "tsdown",
     "e2e": "dotenv -- run-s build e2e:playwright",
     "e2e:playwright": "playwright test",

--- a/libs/portal-storybook-config/package.json
+++ b/libs/portal-storybook-config/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsup"
+    "build": "echo 'Build skipped' && exit 0"
   },
   "dependencies": {
     "@lumeweb/portal-framework-core": "workspace:*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.org/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**", "build/**"]
+      "outputs": ["dist/**", "build/**", "docs/dist/**"]
     },
     "build:dashboard": {
       "dependsOn": ["^build"],
@@ -20,9 +20,7 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["lib-dist/**"]
     },
-    "@lumeweb/portal-plugin-ipfs#build": {
-      "dependsOn": ["@lumeweb/portal-plugin-dashboard#build:lib"]
-    },
+
     "build-dev": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
@@ -35,19 +33,16 @@
       "persistent": true,
       "cache": false
     },
-    "lint": {
-      // Assuming linting should run independently per package
-    },
+    "lint": {},
     "test": {
       "dependsOn": ["^build"]
     },
     "storybook": {
-      "dependsOn": ["^build"], // Ensure dependencies are built before running storybook
-      "cache": false, // Storybook dev server is not cacheable
+      "dependsOn": ["^build"],
       "persistent": true
     },
     "build-storybook": {
-      "dependsOn": ["^build"] // Ensure dependencies are built before building storybook
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
- Set build scripts to skip in portal-storybook, portal-plugin-abuse packages, portal-plugin-template, and portal-storybook-config
- Add turbo.json for portal-plugin-ipfs with dashboard build dependency
- Update turbo.json schema URL and add docs/dist to outputs
- Remove redundant ipfs build config from root turbo.json
