### PR TITLE
ci: add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '**'
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
- Enable manual workflow execution from GitHub Actions UI


---

<!-- kody-pr-summary:start -->
This pull request updates the GitHub Actions build workflow configuration to enable manual execution. By adding the `workflow_dispatch` trigger, the workflow can now be initiated manually from the GitHub interface, in addition to the existing automatic trigger that occurs on push events.
<!-- kody-pr-summary:end -->