### PR TITLE
chore(ci): update node

### DIFF
--- a/.github/actions/setup-js/action.yml
+++ b/.github/actions/setup-js/action.yml
@@ -6,7 +6,7 @@ inputs:
   node_version:
     description: Node.js version
     required: false
-    default: '20.10.0'
+    default: '24.12.0'
 
 runs:
   using: composite


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the default Node.js version used in the CI setup action from 20.10.0 to 24.12.0.
<!-- kody-pr-summary:end -->