### PR TITLE
chore(ci): use setup defaults

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,5 @@ jobs:
           fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup-all
-        with:
-          node_version: 20.10.0
-          go_version: 1.23.0
       - name: Build
         run: pnpm build


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the CI build workflow to rely on default tooling versions. Explicit version configurations for Node.js and Go were removed from the `setup-all` action step, allowing the workflow to use the default values defined in the action.
<!-- kody-pr-summary:end -->