### PR TITLE
chore(ci): update setup all defaults

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -6,11 +6,11 @@ inputs:
   node_version:
     description: Node.js version
     required: false
-    default: '20.10.0'
+    default: '24.12.0'
   go_version:
     description: Go version
     required: false
-    default: '1.23.0'
+    default: '1.25.0'
 
 runs:
   using: composite

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,7 +6,7 @@ inputs:
   go_version:
     description: Go version
     required: false
-    default: '1.23.0'
+    default: '1.25.0'
 
 runs:
   using: composite


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the default tool versions used in the CI pipeline. Specifically, it upgrades the default Node.js version to 24.12.0 and the default Go version to 1.25.0 within the `setup-all` and `setup-go` GitHub Actions.
<!-- kody-pr-summary:end -->