### PR TITLE
ci: add orval task dependency to portal-plugin-ipfs

### DIFF
--- a/libs/portal-plugin-ipfs/turbo.json
+++ b/libs/portal-plugin-ipfs/turbo.json
@@ -1,8 +1,15 @@
 {
   "extends": ["//"],
   "tasks": {
+    "orval": {
+      "outputs": ["src/client/generated/**"]
+    },
     "build": {
-      "dependsOn": ["$TURBO_EXTENDS$", "@lumeweb/portal-plugin-dashboard#build:lib"]
+      "dependsOn": [
+        "$TURBO_EXTENDS$",
+        "@lumeweb/portal-plugin-dashboard#build:lib",
+        "orval"
+      ]
     }
   }
 }


### PR DESCRIPTION
- Configure orval task with output caching for generated client files
- Make build task depend on orval to ensure API client generation
