### PR TITLE
ci(deps): add workflow to automate dependency updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,43 @@
+name: Update Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 0'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  update-dependencies:
+    name: Update Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout all commits
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
+
+      - name: Run taze
+        run: pnpm taze major -r -w
+        shell: bash
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): update dependencies"
+          title: "chore(deps): update dependencies"
+          body: |
+            ## Dependency Updates
+
+            This PR updates dependencies across all packages using taze.
+          branch: chore/update-dependencies
+          delete-branch: true
+          labels: |
+            dependencies
+            chore
+          draft: false


### PR DESCRIPTION
- Adds scheduled GitHub workflow to run weekly on Sundays
- Runs taze recursively across all packages to update dependencies
- Automatically creates pull requests using peter-evans/create-pull-request
- Supports manual workflow dispatch for on-demand updates


---

<!-- kody-pr-summary:start -->
This pull request introduces a new GitHub Actions workflow designed to automate the process of updating project dependencies.

The workflow is configured to run on a weekly schedule (every Sunday at 09:00) or can be triggered manually. It utilizes the `taze` tool to check for major version updates across the workspace. If updates are found, the workflow automatically commits the changes and creates a pull request labeled as "dependencies" and "chore" to streamline the review and integration process.
<!-- kody-pr-summary:end -->