### PR TITLE
ci(deps): fix workflow to handle frozen lockfile

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -22,7 +22,11 @@ jobs:
         uses: ./.github/actions/setup-js
 
       - name: Run taze
-        run: pnpm taze major -r -w
+        run: pnpm taze major -r -w --install false
+        shell: bash
+
+      - name: Update lockfile
+        run: pnpm install --no-frozen-lockfile
         shell: bash
 
       - name: Create Pull Request


### PR DESCRIPTION
- Add `--install false` flag to taze command to prevent auto-install
- Add separate step to update lockfile with `--no-frozen-lockfile`
- Resolves catalog mismatch error when dependencies are updated


---

<!-- kody-pr-summary:start -->
This pull request updates the dependency update workflow to correctly handle lockfile generation. It modifies the `taze` command to skip automatic installation and introduces a dedicated step to update the lockfile using `pnpm install` with the `--no-frozen-lockfile` flag. This ensures the workflow can successfully update dependencies and regenerate the lockfile without errors related to frozen lockfile constraints.
<!-- kody-pr-summary:end -->