### PR TITLE
refactor(portal-frontend): migrate from tailwind v3 to v4

### DIFF
--- a/apps/lumeweb.com/package.json
+++ b/apps/lumeweb.com/package.json
@@ -20,7 +20,7 @@
     "typewriter-effect": "^2.22.0"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.18",
+    "@tailwindcss/vite": "catalog:",
     "tailwindcss": "catalog:"
   }
 }

--- a/apps/portal-frontend/astro.config.mjs
+++ b/apps/portal-frontend/astro.config.mjs
@@ -1,18 +1,18 @@
 // @ts-check
-import { defineConfig } from "astro/config";
-
 import react from "@astrojs/react";
-import tailwind from "@astrojs/tailwind";
+import { defineConfig } from "astro/config";
+import tailwindcss from "@tailwindcss/vite";
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [react(), tailwind({ applyBaseStyles: false })],
-	vite: {
-		optimizeDeps: {
-			include: ["swiper"],
-		},
-		ssr: {
-			noExternal: ["swiper"], // Add this line
-		},
-	},
+  integrations: [react()],
+  vite: {
+    optimizeDeps: {
+      include: ["swiper"],
+    },
+    ssr: {
+      noExternal: ["swiper"], // Add this line
+    },
+    plugins: [tailwindcss()],
+  },
 });

--- a/apps/portal-frontend/package.json
+++ b/apps/portal-frontend/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@astrojs/react": "catalog:",
-    "@astrojs/tailwind": "^6.0.2",
     "@radix-ui/react-navigation-menu": "catalog:",
     "@radix-ui/react-progress": "catalog:",
     "@radix-ui/react-slot": "catalog:",
@@ -20,7 +19,6 @@
     "astro": "catalog:",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
-    "i": "^0.3.7",
     "lucide-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
@@ -29,6 +27,7 @@
     "tailwindcss": "catalog:",
     "tailwindcss-animate": "catalog:"
   },
-  "devDependencies": {},
-  "peerDependencies": {}
+  "devDependencies": {
+    "@tailwindcss/vite": "catalog:"
+  }
 }

--- a/apps/portal-frontend/src/components/AboutSection.jsx
+++ b/apps/portal-frontend/src/components/AboutSection.jsx
@@ -62,7 +62,7 @@ const AboutSection = ({
               )}
 
               {description && (
-                <p className="text-[#485453] text-[13px] md:text-base lg:text-lg !leading-[21px] lg:!leading-[35px] md:!leading-[26px] lg:text-xl mb-6 lg:mb-[26px] max-w-[600px]">
+                <p className="text-[#485453] text-[13px] md:text-base lg:text-lg leading-[21px]! lg:leading-[35px]! md:leading-[26px]! lg:text-xl mb-6 lg:mb-[26px] max-w-[600px]">
                   {description}
                 </p>
               )}

--- a/apps/portal-frontend/src/components/BrandLogos.jsx
+++ b/apps/portal-frontend/src/components/BrandLogos.jsx
@@ -6,7 +6,7 @@ const BrandLogos = ({ logos, title, logoType = "dark" }) => {
       }`}>
       <div className="xl:container px-6">
         <div className="lg:flex items-start md:items-center justify-between gap-[150px]">
-          <div className="basis-80 md:basis-[17rem] mb-[30px] lg:mb-0">
+          <div className="basis-80 md:basis-68 mb-[30px] lg:mb-0">
             <h2
               className={`text-[31px] font-medium ${
                 logoType === "light" ? "text-[#0D1D1C]" : "text-[#F8F8F8]"
@@ -15,7 +15,7 @@ const BrandLogos = ({ logos, title, logoType = "dark" }) => {
             </h2>
           </div>
 
-          <div className="flex-grow">
+          <div className="grow">
             <div className="flex-wrap grid grid-cols-4 lg:grid-cols-6 gap-7 md:gap-10 flex-2 items-center justify-start md:justify-between">
               {logoType === "light"
                 ? logos.logoLight.map((logo) => (

--- a/apps/portal-frontend/src/components/Button.jsx
+++ b/apps/portal-frontend/src/components/Button.jsx
@@ -5,13 +5,13 @@ const Button = ({ label, url, style, size = "md" }) => {
 			className={`inline-flex rounded-full border border-transparent  text-[13px] lg:text-lg font-medium transition ease-in-out duration-300 
                 ${
 					style === "outline"
-						? "border !border-[#F8F8F8] text-[#f8f8f8] bg-transparent hover:!bg-[#0D2D2A] hover:text-[#F8F8F8] hover:!border-[#0D2D2A]"
+						? "border border-[#F8F8F8]! text-[#f8f8f8] bg-transparent hover:bg-[#0D2D2A]! hover:text-[#F8F8F8] hover:border-[#0D2D2A]!"
 						: style === "outline-dark"
-						? "border !border-[#0D1D1C] !text-[#0D1D1C] bg-transparent hover:!bg-[#0D1D1C] hover:!text-white hover:!border-[#0D1D1C]"
+						? "border border-[#0D1D1C]! text-[#0D1D1C]! bg-transparent hover:bg-[#0D1D1C]! hover:text-white! hover:border-[#0D1D1C]!"
 						: style === "btn-light"
-						? "!bg-white !text-[#0D1D1C] hover:!bg-transparent hover:!text-white !border-white"
+						? "bg-white! text-[#0D1D1C]! hover:bg-transparent! hover:text-white! border-white!"
 						: style === "gray"
-						? "bg-[#E4E0D4] !text-[#0D1D1C] hover:!bg-[#0D2D2A] hover:!text-white"
+						? "bg-[#E4E0D4] text-[#0D1D1C]! hover:bg-[#0D2D2A]! hover:text-white!"
 						: style === "light"
 						? "bg-white text-[#0D1D1C] hover:bg-[#0D2D2A] hover:text-white"
 						: "text-[#F8F8F8] bg-[#0D2D2A] hover:bg-white hover:text-[#0D1D1C]"

--- a/apps/portal-frontend/src/components/Home/Hero.jsx
+++ b/apps/portal-frontend/src/components/Home/Hero.jsx
@@ -35,7 +35,7 @@ const Hero = () => {
             </div>
           </div>
 
-          <div className="lg:w-[480px] !translate-y-11 lg:translate-y-0">
+          <div className="lg:w-[480px] translate-y-11! lg:translate-y-0">
             <div className="hidden lg:block">
               <ProgressCard
                 value="25"
@@ -74,7 +74,7 @@ const Hero = () => {
                 title="project-backup"
                 description="1 file (1.2 MB)"
                 day="7 days ago"
-                style="bg-[#0D2D2A] border-none mb-8 opacity-100 max-w-[342px] !mb-[-60px]"
+                style="bg-[#0D2D2A] border-none mb-8 opacity-100 max-w-[342px] mb-[-60px]!"
               />
             </div>
           </div>

--- a/apps/portal-frontend/src/components/ui/button.tsx
+++ b/apps/portal-frontend/src/components/ui/button.tsx
@@ -9,10 +9,10 @@ const buttonVariants = cva(
     variants: {
       style: {
         default: "text-[#F8F8F8] bg-[#0D2D2A] hover:bg-white hover:text-[#0D1D1C]",
-        outline: "border !border-[#F8F8F8] text-[#f8f8f8] bg-transparent hover:!bg-[#0D2D2A] hover:text-[#F8F8F8] hover:!border-[#0D2D2A]",
-        "outline-dark": "border !border-[#0D1D1C] !text-[#0D1D1C] bg-transparent hover:!bg-[#0D1D1C] hover:!text-white hover:!border-[#0D1D1C]",
-        "btn-light": "!bg-white !text-[#0D1D1C] hover:!bg-transparent hover:!text-white !border-white",
-        gray: "bg-[#E4E0D4] !text-[#0D1D1C] hover:!bg-[#0D2D2A] hover:!text-white",
+        outline: "border border-[#F8F8F8]! text-[#f8f8f8] bg-transparent hover:bg-[#0D2D2A]! hover:text-[#F8F8F8] hover:border-[#0D2D2A]!",
+        "outline-dark": "border border-[#0D1D1C]! text-[#0D1D1C]! bg-transparent hover:bg-[#0D1D1C]! hover:text-white! hover:border-[#0D1D1C]!",
+        "btn-light": "bg-white! text-[#0D1D1C]! hover:bg-transparent! hover:text-white! border-white!",
+        gray: "bg-[#E4E0D4] text-[#0D1D1C]! hover:bg-[#0D2D2A]! hover:text-white!",
         light: "bg-white text-[#0D1D1C] hover:bg-[#0D2D2A] hover:text-white",
       },
       size: {

--- a/apps/portal-frontend/src/components/ui/navigation-menu.tsx
+++ b/apps/portal-frontend/src/components/ui/navigation-menu.tsx
@@ -41,7 +41,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 const NavigationMenuItem = NavigationMenuPrimitive.Item
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-100 hover:text-neutral-900 focus:bg-neutral-100 focus:text-neutral-900 focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-neutral-100/50 data-[state=open]:bg-neutral-100/50 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50 dark:data-[active]:bg-neutral-800/50 dark:data-[state=open]:bg-neutral-800/50"
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-100 hover:text-neutral-900 focus:bg-neutral-100 focus:text-neutral-900 focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-active:bg-neutral-100/50 data-[state=open]:bg-neutral-100/50 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50 dark:data-active:bg-neutral-800/50 dark:data-[state=open]:bg-neutral-800/50"
 )
 
 const NavigationMenuTrigger = React.forwardRef<
@@ -55,7 +55,7 @@ const NavigationMenuTrigger = React.forwardRef<
   >
     {children}{""}
     <ChevronDown
-      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+      className="relative top-px ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
       aria-hidden="true"
     />
   </NavigationMenuPrimitive.Trigger>
@@ -86,7 +86,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-neutral-200 bg-white text-neutral-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)] dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+        "origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border border-neutral-200 bg-white text-neutral-950 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-(--radix-navigation-menu-viewport-width) dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
         className
       )}
       ref={ref}
@@ -104,7 +104,7 @@ const NavigationMenuIndicator = React.forwardRef<
   <NavigationMenuPrimitive.Indicator
     ref={ref}
     className={cn(
-      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
+      "top-full z-1 flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
       className
     )}
     {...props}

--- a/apps/portal-frontend/src/components/ui/progress.tsx
+++ b/apps/portal-frontend/src/components/ui/progress.tsx
@@ -16,7 +16,7 @@ const Progress = React.forwardRef<
 		{...props}
 	>
 		<ProgressPrimitive.Indicator
-			className="h-full w-full rounded-full flex-1 bg-gradient-to-r from-[#ADF0DD] via-[#97D1C1] vai-[#89F8D8] to-[#887E62] transition-all"
+			className="h-full w-full rounded-full flex-1 bg-linear-to-r from-[#ADF0DD] via-[#97D1C1] via-[#89F8D8] to-[#887E62] transition-all"
 			style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
 		/>
 	</ProgressPrimitive.Root>

--- a/apps/portal-frontend/src/styles/globals.css
+++ b/apps/portal-frontend/src/styles/globals.css
@@ -1,20 +1,25 @@
 @import url("https://fonts.cdnfonts.com/css/euclid-circular-a");
+@import "tailwindcss";
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-@layer base {
-	:root {
-		--radius: 0.5rem;
-		--color-primary: #f3c614;
-		--color-primary-light: #f7d94c;
-	}
+@theme {
+  /* Define custom variables */
+  --radius-custom: 0.5rem;
+
+  /* Map theme colors */
+  --color-primary: #f3c614;
+  --color-primary-light: #f7d94c;
+
+  /* Define font family */
+  --font-sans: "Euclid Circular A", ui-sans-serif, system-ui, sans-serif;
 }
 
-@layer components {
-	body {
-		font-family: "Euclid Circular A", sans-serif;
-		background-color: #f9f9f9;
-		color: #333;
-	}
+@utility container {
+  @apply mx-auto px-4 sm:px-8 lg:px-16;
+}
+
+/* Base styles are applied directly to elements */
+@layer base {
+  body {
+    @apply bg-[#f9f9f9] text-[#333] font-sans;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@t3-oss/env-core':
       specifier: ^0.13.10
       version: 0.13.10
+    '@tailwindcss/vite':
+      specifier: ^4.1.18
+      version: 4.1.18
     '@tanstack/react-query':
       specifier: ^5.90.16
       version: 5.90.16
@@ -387,7 +390,7 @@ importers:
   apps/lumeweb.com:
     dependencies:
       '@tailwindcss/vite':
-        specifier: ^4.1.18
+        specifier: 'catalog:'
         version: 4.1.18(vite@7.1.11(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2))
       tailwindcss:
         specifier: 'catalog:'
@@ -487,9 +490,6 @@ importers:
       '@astrojs/react':
         specifier: 'catalog:'
         version: 4.4.2(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
-      '@astrojs/tailwind':
-        specifier: ^6.0.2
-        version: 6.0.2(astro@5.16.7(@types/node@25.0.3)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(tailwindcss@4.1.18)
       '@radix-ui/react-navigation-menu':
         specifier: 'catalog:'
         version: 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -514,9 +514,6 @@ importers:
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
-      i:
-        specifier: ^0.3.7
-        version: 0.3.7
       lucide-react:
         specifier: 'catalog:'
         version: 0.562.0(react@19.2.3)
@@ -538,6 +535,10 @@ importers:
       tailwindcss-animate:
         specifier: 'catalog:'
         version: 1.0.7(tailwindcss@4.1.18)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.1.18(vite@7.1.11(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2))
 
   apps/portal-storybook: {}
 
@@ -1732,12 +1733,6 @@ packages:
 
   '@astrojs/sitemap@3.6.1':
     resolution: {integrity: sha512-+o+TbxXqQJAOd+HxCjz/5RdAMrRFGjeuO+U6zddUuTO59WqMqXnsc8uveRiEr2Ff+3McZiEne7iG4J5cnuI6kA==}
-
-  '@astrojs/tailwind@6.0.2':
-    resolution: {integrity: sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg==}
-    peerDependencies:
-      astro: ^3.0.0 || ^4.0.0 || ^5.0.0
-      tailwindcss: ^3.0.24
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -7920,10 +7915,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  i@0.3.7:
-    resolution: {integrity: sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==}
-    engines: {node: '>=0.4'}
-
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -8731,10 +8722,6 @@ packages:
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
-
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
@@ -9873,18 +9860,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -12476,16 +12451,6 @@ snapshots:
       sitemap: 8.0.2
       stream-replace-string: 2.0.0
       zod: 3.25.76
-
-  '@astrojs/tailwind@6.0.2(astro@5.16.7(@types/node@25.0.3)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2))(tailwindcss@4.1.18)':
-    dependencies:
-      astro: 5.16.7(@types/node@25.0.3)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3)(yaml@2.8.2)
-      autoprefixer: 10.4.23(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      tailwindcss: 4.1.18
-    transitivePeerDependencies:
-      - ts-node
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -20581,8 +20546,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  i@0.3.7: {}
-
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -21508,8 +21471,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
-
-  lilconfig@3.1.3: {}
 
   linkify-it@5.0.0:
     dependencies:
@@ -23069,13 +23030,6 @@ snapshots:
   pony-cause@1.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss-load-config@4.0.2(postcss@8.5.6):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.2
-    optionalDependencies:
-      postcss: 8.5.6
 
   postcss-value-parser@4.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
-  - apps/*
-  - libs/*
+- apps/*
+- libs/*
 catalog:
   '@astrojs/react': ^4.4.2
   '@conform-to/react': ^1.15.1
@@ -23,6 +23,7 @@ catalog:
   '@refinedev/react-router': ^2.0.3
   '@refinedev/react-table': ^6.0.1
   '@t3-oss/env-core': ^0.13.10
+  '@tailwindcss/vite': ^4.1.18
   '@tanstack/react-query': ^5.90.16
   '@tanstack/react-table': ^8.21.3
   '@types/react': ^19.2.7


### PR DESCRIPTION
- Replace @astrojs/tailwind integration with @tailwindcss/vite plugin
- Update CSS imports from @tailwind directives to @import "tailwindcss"
- Migrate theme configuration from @layer base to @theme block
- Update class name syntax for important modifiers and data attributes
- Add container utility with responsive padding using @apply
- Fix typo in progress component (vai → via)
- Remove invalid "i" dependency from package.json
- Update workspace catalog with @tailwindcss/vite


---

<!-- kody-pr-summary:start -->
This pull request migrates the `portal-frontend` application from Tailwind CSS v3 to v4.

**Key changes include:**

*   **Configuration Update**: Replaced the `@astrojs/tailwind` integration with the `@tailwindcss/vite` plugin in `astro.config.mjs`.
*   **Global Styles Refactoring**: Updated `src/styles/globals.css` to use the new v4 `@import "tailwindcss"` directive and the `@theme` block for defining custom variables (colors, fonts, radius) instead of the previous `@tailwind` directives and `@layer base`.
*   **Component Syntax Updates**: Modified class names across multiple components (e.g., `Button`, `Hero`, `NavigationMenu`) to comply with Tailwind v4 syntax requirements. These updates include:
    *   Switching important modifiers from a prefix (e.g., `!text-`) to a suffix (e.g., `text-!`).
    *   Simplifying arbitrary values (e.g., `top-[1px]` to `top-px`).
    *   Updating CSS variable usage (e.g., `h-[var(--name)]` to `h-(--name)`).
    *   Modifying attribute selectors (e.g., `data-[active]` to `data-active`).
    *   Updating gradient syntax (e.g., `bg-gradient-to-r` to `bg-linear-to-r`).
*   **Dependencies**: Updated `pnpm-workspace.yaml` and `pnpm-lock.yaml` to add `@tailwindcss/vite` and remove `@astrojs/tailwind`.
<!-- kody-pr-summary:end -->