### PR TITLE
ci(build): separate config build process and update task dependencies

### DIFF
--- a/libs/portal-sdk/package.json
+++ b/libs/portal-sdk/package.json
@@ -22,7 +22,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "orval && tsdown",
+    "build": "tsdown",
+    "orval": "orval",
     "lint": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",

--- a/libs/portal-sdk/turbo.json
+++ b/libs/portal-sdk/turbo.json
@@ -2,9 +2,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["orval"]
+      "dependsOn": ["$TURBO_EXTENDS$", "orval"]
     },
-    "orval": {
-    }
+    "orval": {}
   }
 }

--- a/libs/tsdown-config/package.json
+++ b/libs/tsdown-config/package.json
@@ -14,7 +14,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsdown"
+    "build:config": "tsdown"
   },
   "peerDependencies": {
     "tsdown": "catalog:"

--- a/turbo.json
+++ b/turbo.json
@@ -1,28 +1,33 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "tasks": {
+    "build:config": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**"]
+    },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", "build/**", "docs/dist/**"]
     },
     "build:dashboard": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/dashboard/**"]
     },
     "build:admin": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/admin/**"]
     },
     "build:lib": {
+      "dependsOn": ["@lumeweb/tsdown-config#build:config"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["lib-dist/**"]
     },
 
     "build-dev": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", "build/**"]
     },
@@ -35,14 +40,14 @@
     },
     "lint": {},
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"]
     },
     "storybook": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"],
       "persistent": true
     },
     "build-storybook": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"]
     }
   }
 }


### PR DESCRIPTION
- Split orval generation from portal-sdk build script
- Rename tsdown-config build script to build:config
- Add build:config task to root turbo.json
- Update all build-related tasks to depend on @lumeweb/tsdown-config#build:config
- Add `$TURBO_EXTENDS$` to portal-sdk build dependencies
