### PR TITLE
chore(ci): update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ catalogs:
       version: 4.3.5
   framework:
     vite:
-      specifier: 6.4.1
+      specifier: ^6.4.1
       version: 6.4.1
   websites:
     tailwindcss:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `pnpm-lock.yaml` file to modify the version specifier for the Vite framework dependency. The specifier was changed from an exact version (`6.4.1`) to a caret range (`^6.4.1`), allowing for compatible minor and patch updates within the 6.x.x series.
<!-- kody-pr-summary:end -->