### PR TITLE
fix(portal-framework-core): configure tsconfig-paths to use project's tsconfig.json

### DIFF
--- a/libs/portal-framework-core/src/vite/plugin.ts
+++ b/libs/portal-framework-core/src/vite/plugin.ts
@@ -245,7 +245,7 @@ export function Config(opts: ConfigOptions) {
           reactRefreshHost: `http://localhost:${normalizedOpts.appPort}`,
         })
       : react(),
-    tsconfigPaths(),
+    tsconfigPaths({ projects: [resolve(opts.dir, "./tsconfig.json")] }),
     createHostFederationConfig(normalizedOpts, resolvedRuntimePlugins),
     opts.type === "host" ? localhostAccessPlugin() : undefined,
     ...(opts.plugins?.map((plugin) =>


### PR DESCRIPTION
- Pass explicit tsconfig.json path from opts.dir to vite-tsconfig-paths plugin
- Ensures TypeScript path aliases are resolved correctly during build


---

<!-- kody-pr-summary:start -->
This pull request updates the Vite plugin configuration within `portal-framework-core` to explicitly specify the location of the `tsconfig.json` file for the `tsconfig-paths` plugin. By passing the project's directory path to the plugin configuration, the change ensures that TypeScript path resolution correctly utilizes the specific configuration file associated with the project, rather than relying on default lookup behavior.
<!-- kody-pr-summary:end -->