### PR TITLE
ci: migrate from changesets to knope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,38 +5,45 @@ on:
     branches:
       - develop
   workflow_dispatch:
+    inputs:
+      knope_version:
+        description: 'Knope version to use (default: latest)'
+        required: false
+        default: ''
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup
-        uses: ./.github/actions/setup-all
+          token: ${{ secrets.PAT }}
+
+      - name: Install Knope
+        uses: knope-dev/action@v2.1.0
         with:
-          node_version: 20.10.0
-          go_version: 1.23.0
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          publish: pnpm changeset:publish
-          createGithubReleases: true
+          version: ${{ inputs.knope_version }}
+
+      - name: Setup Git
+        uses: LumeWeb/workflows/.github/actions/setup-git@develop
+
+      - name: Create Release
+        run: knope release --verbose
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       # Check for portal-frontend changes and notify template repo
-      - if: steps.changesets.outputs.published == 'true'
-        name: Check portal-frontend changes and notify
+      - name: Check portal-frontend changes and notify
         id: check-changes
         run: |
           CHANGES=$(git diff --name-only HEAD^ HEAD apps/portal-frontend)
@@ -48,7 +55,7 @@ jobs:
         name: Trigger portal-frontend template repo update
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.PAT }}
           repository: lumeweb/portal-frontend-template
           event-type: portal-frontend-update
           client-payload: |
@@ -56,10 +63,11 @@ jobs:
               "source_sha": "${{ github.sha }}",
               "source_ref": "${{ github.ref }}"
             }
-        # if a release was published, release the Go modules
-      - if: steps.changesets.outputs.published == 'true'
+
+      # Release the Go modules
+      - name: Trigger Go module release
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.PAT }}
           repository: lumeweb/web
           event-type: release-go

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,71 @@
+[packages."@lumeweb/lumeweb.com"]
+versioned_files = ["apps/lumeweb.com/package.json"]
+changelog = "apps/lumeweb.com/CHANGELOG.md"
+
+[packages."@lumeweb/portal-frontend"]
+versioned_files = ["apps/portal-frontend/package.json"]
+changelog = "apps/portal-frontend/CHANGELOG.md"
+
+[packages."@lumeweb/docs.lumeweb.com"]
+versioned_files = ["apps/docs.lumeweb.com/package.json"]
+changelog = "apps/docs.lumeweb.com/CHANGELOG.md"
+
+[packages."@lumeweb/portal-app-shell"]
+versioned_files = ["apps/portal-app-shell/package.json"]
+changelog = "apps/portal-app-shell/CHANGELOG.md"
+
+[packages."@lumeweb/portal-sdk"]
+versioned_files = ["libs/portal-sdk/package.json"]
+changelog = "libs/portal-sdk/CHANGELOG.md"
+
+[packages."@lumeweb/portal-framework-core"]
+versioned_files = ["libs/portal-framework-core/package.json"]
+changelog = "libs/portal-framework-core/CHANGELOG.md"
+
+[packages."@lumeweb/portal-framework-ui-core"]
+versioned_files = ["libs/portal-framework-ui-core/package.json"]
+changelog = "libs/portal-framework-ui-core/CHANGELOG.md"
+
+[packages."@lumeweb/portal-framework-ui"]
+versioned_files = ["libs/portal-framework-ui/package.json"]
+changelog = "libs/portal-framework-ui/CHANGELOG.md"
+
+[packages."@lumeweb/portal-framework-auth"]
+versioned_files = ["libs/portal-framework-auth/package.json"]
+changelog = "libs/portal-framework-auth/CHANGELOG.md"
+
+[packages."@lumeweb/portal-plugin-dashboard"]
+versioned_files = ["libs/portal-plugin-dashboard/package.json"]
+changelog = "libs/portal-plugin-dashboard/CHANGELOG.md"
+
+[packages."@lumeweb/portal-plugin-admin"]
+versioned_files = ["libs/portal-plugin-admin/package.json"]
+changelog = "libs/portal-plugin-admin/CHANGELOG.md"
+
+[packages."@lumeweb/portal-plugin-core"]
+versioned_files = ["libs/portal-plugin-core/package.json"]
+changelog = "libs/portal-plugin-core/CHANGELOG.md"
+
+[packages."@lumeweb/portal-plugin-ipfs"]
+versioned_files = ["libs/portal-plugin-ipfs/package.json"]
+changelog = "libs/portal-plugin-ipfs/CHANGELOG.md"
+
+[packages."@lumeweb/pinner"]
+versioned_files = ["libs/pinner/package.json"]
+changelog = "libs/pinner/CHANGELOG.md"
+
+[packages."@lumeweb/uppy-post-upload"]
+versioned_files = ["libs/uppy-post-upload/package.json"]
+changelog = "libs/uppy-post-upload/CHANGELOG.md"
+
+[packages."@lumeweb/query-builder"]
+versioned_files = ["libs/query-builder/package.json"]
+changelog = "libs/query-builder/CHANGELOG.md"
+
+[packages."@lumeweb/advanced-rest"]
+versioned_files = ["libs/advanced-rest/package.json"]
+changelog = "libs/advanced-rest/CHANGELOG.md"
+
+[github]
+owner = "LumeWeb"
+repo = "web"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "turbo build",
-    "publish": "changeset publish",
-    "changeset:publish": "pnpm -r publish --publish-branch develop; pnpm changeset tag && git push --follow-tags",
+    "publish": "pnpm -r publish --publish-branch develop; knope release",
     "dev": "turbo dev",
     "lint": "turbo lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",


### PR DESCRIPTION
- Add knope.toml configuration for 17 packages
- Update GitHub Actions release workflow to use knope-dev/action
- Replace changesets publish script with knope release command
- Remove setup-all action, use knope action directly
- Update checkout to use PAT token for write access
- Add NPM_TOKEN environment variable for publishing


---

<!-- kody-pr-summary:start -->
This pull request migrates the project's release automation from Changesets to Knope.

**Key changes:**

*   **Workflow Update:** The GitHub Actions release workflow (`.github/workflows/release.yml`) has been updated to replace the Changesets action with the Knope action. The workflow now installs Knope and executes `knope release` to handle versioning and publishing.
*   **Configuration Addition:** A new `knope.toml` configuration file has been added to define the versioning and changelog settings for all packages within the monorepo (including apps and libraries).
*   **Downstream Triggers:** The steps for notifying the portal-frontend template repository and triggering Go module releases have been updated to run following the Knope release process, removing the previous dependency on Changesets-specific output conditions.
<!-- kody-pr-summary:end -->