### PR TITLE
feat(portal-plugin-dashboard): add folder upload detection and conditional UI based on service support

### DIFF
--- a/libs/portal-plugin-dashboard/src/features/upload/Feature.ts
+++ b/libs/portal-plugin-dashboard/src/features/upload/Feature.ts
@@ -8,13 +8,14 @@ import {
   getSdk,
   NamespacedId,
 } from "@lumeweb/portal-framework-core";
-import { Meta, UppyEventMap } from "@uppy/core";
+import { Body, Meta, UppyEventMap } from "@uppy/core";
 
 import type { UploadCapability } from "@lib/types/capabilities/upload";
 
 import { Manager, UppyFileDefault } from "@/features/upload/Manager";
 import {
   IUploadManager,
+  PluginConfig,
   ServiceConfig,
   UPLOAD_TYPE_MAIN,
   UploadStatusType,
@@ -99,6 +100,10 @@ export class Feature implements FrameworkFeature, IUploadManager {
     return this.#uploadManager.getServices();
   }
 
+  serviceSupportsFolderUpload(serviceId: string): boolean {
+    return this.#uploadManager.serviceSupportsFolderUpload(serviceId);
+  }
+
   /**
    * Get upload capabilities associated with a specific protocol
    */
@@ -153,27 +158,40 @@ export class Feature implements FrameworkFeature, IUploadManager {
         // Use the first upload capability found
         const uploadCapability = uploadCapabilities[0] as UploadCapability;
 
+        // Get additional plugins and check if there's a folder bundler plugin
+        const additionalPlugins = uploadCapability.getAdditionalPlugins();
+        const folderBundlerPlugin = additionalPlugins.find(
+          (plugin) => plugin.name === "FolderBundler",
+        );
+
         const serviceConfig: ServiceConfig = {
           id: protocol.id,
           largeFilePlugin: createLargeFilePlugin(
             uploadCapability.getLargeFileUploadConfig(),
             protocol.id,
             uploadCapability.getLargeFilePlugin?.(),
-          ),
-          name: protocol.getName(),
+          ) as PluginConfig,
+          name: protocol.id,
           smallFilePlugin: createSmallFilePlugin(
             uploadCapability.getSmallFileUploadConfig(),
             protocol.id,
             uploadCapability.getSmallFilePlugin?.(),
-          ),
+          ) as PluginConfig,
+          ...(folderBundlerPlugin && {
+            folderBundlerPlugin: {
+              module: folderBundlerPlugin.module,
+              options: folderBundlerPlugin.options || {},
+            },
+          }),
         };
 
         this.#uploadManager.registerService(serviceConfig);
 
-        // Register additional plugins from the upload capability
-        const additionalPlugins = uploadCapability.getAdditionalPlugins();
+        // Register additional plugins from the upload capability (excluding folder bundler)
         for (const plugin of additionalPlugins) {
-          this.#uploadManager.registerAdditionalPlugin(plugin);
+          if (plugin.name !== "FolderBundler") {
+            this.#uploadManager.registerAdditionalPlugin(plugin);
+          }
         }
       }
     }

--- a/libs/portal-plugin-dashboard/src/features/upload/Manager.ts
+++ b/libs/portal-plugin-dashboard/src/features/upload/Manager.ts
@@ -209,6 +209,11 @@ export class Manager implements IUploadManager {
     return Array.from(this.#services.values());
   }
 
+  public serviceSupportsFolderUpload(serviceId: string): boolean {
+    const service = this.#services.get(serviceId);
+    return !!service?.folderBundlerPlugin;
+  }
+
   public getStorageInfo(): null | StorageInfo {
     return this.#storageInfo;
   }

--- a/libs/portal-plugin-dashboard/src/types/upload.ts
+++ b/libs/portal-plugin-dashboard/src/types/upload.ts
@@ -46,8 +46,10 @@ export interface IUploadManager {
   cancelAll: () => void;
   clearErrors: () => void;
   getFiles: () => any[] | Promise<any[]>;
+  getServices: () => ServiceConfig[];
   getUploadedFiles: () => UppyFileDefault[];
   getUploadErrors: () => Error[];
+  serviceSupportsFolderUpload: (serviceId: string) => boolean;
   getUploadProgress: () => number;
   getUploadStatus: () => UploadStatusType;
   off: (event: string, callback: (...args: any[]) => void) => void;

--- a/libs/portal-plugin-dashboard/src/ui/forms/uploadWizard.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/uploadWizard.tsx
@@ -586,20 +586,23 @@ export function uploadWizardForm(
               };
             }, [formMethods]);
 
+            const selectedServiceId = formMethods.getValues().storage;
+            const allowFolders = uploadManager?.serviceSupportsFolderUpload(selectedServiceId) ?? false;
+
             return (
               <FileUploadZone
-                allowFolders={true}
+                allowFolders={allowFolders}
                 disabled={false}
                 onFilesChange={async (files) => {
                   // Sync form with uploadManager's complete file list
                   formMethods.setValue("files", files);
                 }}
-                serviceId={formMethods.getValues().storage}
+                serviceId={selectedServiceId}
                 uploadManager={uploadManager}
               />
             );
           },
-          label: "Files or Folders",
+          label: "Files",
           name: "files",
           required: true,
           type: "custom",
@@ -608,7 +611,7 @@ export function uploadWizardForm(
       icon: FileText,
       shortTitle: "Files",
       submitLabel: "Next",
-      title: "Select Files or Folders",
+      title: "Select Files",
       validationSchema: filesSchema,
     },
     {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds folder upload detection capability and conditionally enables folder upload UI based on service support. The changes include:

1. **Folder Upload Support Detection**: Added a new method `serviceSupportsFolderUpload()` that checks whether a storage service has a "FolderBundler" plugin configured, indicating folder upload capability.

2. **Conditional Folder Upload UI**: Modified the upload wizard to dynamically enable or disable folder selection based on the selected service's capabilities. The `FileUploadZone` component now receives a conditional `allowFolders` prop instead of always being set to `true`.

3. **Service Configuration Updates**: Enhanced service registration logic to specifically handle the FolderBundler plugin as part of the service configuration rather than as a general additional plugin.

4. **UI Label Updates**: Changed upload wizard labels from "Files or Folders" to "Files" to reflect the conditional nature of folder upload support.

These changes ensure that users can only upload folders when the selected storage service supports that functionality, providing a more accurate and user-friendly experience.
<!-- kody-pr-summary:end -->