### PR TITLE
feat(portal-plugin-lbry): add streams page and route

### DIFF
--- a/libs/portal-plugin-lbry/src/index.ts
+++ b/libs/portal-plugin-lbry/src/index.ts
@@ -7,14 +7,11 @@ import {
 import { LbryProtocol } from "./capabilities/lbryProtocol";
 import { LbryUpload } from "./capabilities/lbryUpload";
 import { RefineConfig as LbryRefineConfig } from "./capabilities/refineConfig";
+import routes from "./routes";
 
 export default function (): Plugin {
   return {
-    capabilities: [
-      new LbryProtocol(),
-      new LbryUpload(),
-      new LbryRefineConfig(),
-    ],
+    capabilities: [new LbryProtocol(), new LbryUpload(), new LbryRefineConfig()],
     capabilityAssociations: [
       {
         associated: ["lbry:upload"],
@@ -28,9 +25,11 @@ export default function (): Plugin {
     async initialize(_framework: Framework) {
       console.log("Plugin LBRY initialized");
     },
+    routes,
   } satisfies Plugin;
 }
 
-export * from "./client/default";
-export * from "./client/lBRYStreamAPI.schemas";
-export * from "./client/tus";
+export * from "./types";
+export * from './client/default';
+export * from './client/lBRYStreamAPI.schemas';
+export * from './client/tus';

--- a/libs/portal-plugin-lbry/src/routes.tsx
+++ b/libs/portal-plugin-lbry/src/routes.tsx
@@ -1,0 +1,17 @@
+import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import { Monitor, Anchor } from "lucide-react";
+
+const routes = [
+  {
+    path: "/lbry/streams",
+    component: "streams",
+    id: "lbry_streams",
+    navigation: {
+      label: "Streams",
+      icon: Anchor,
+      order: 4,
+    },
+  },
+] satisfies RouteDefinition[];
+
+export default routes;

--- a/libs/portal-plugin-lbry/src/types.ts
+++ b/libs/portal-plugin-lbry/src/types.ts
@@ -1,0 +1,12 @@
+export interface LbryUploadResponse {
+  upload_hash: string;
+}
+
+export interface LbryError {
+  success: false;
+  error: string;
+}
+
+export interface LbryServiceConfig {
+  authToken?: string;
+}

--- a/libs/portal-plugin-lbry/src/ui/components/LbryIcon.tsx
+++ b/libs/portal-plugin-lbry/src/ui/components/LbryIcon.tsx
@@ -6,7 +6,7 @@ const LbryIcon: React.FC<{ className?: string }> = ({ className }) => {
       className={className}
       viewBox="0 0 320 250"
       xmlns="http://www.w3.org/2000/svg"
-      fill="#ffffff">
+      fill="white">
       <path d="M296.05, 85.9l0, 14.1l-138.8, 85.3l-104.6, -51.3l0.2, -7.9l104, 51.2l132.2, -81.2l0, -5.8l-124.8, -60.2l-139.2, 86.1l0, 38.5l131.8, 65.2l137.6, -84.4l3.9, 6l-141.1, 86.4l-139.2, -68.8l0, -46.8l145.8, -90.2l132.2, 63.8Z" />
       <path d="M294.25, 150.9l2, -12.6l-12.2, -2.1l0.8, -4.9l17.1, 2.9l-2.8, 17.5l-4.9, -0.8Z" />
     </svg>

--- a/libs/portal-plugin-lbry/src/ui/routes/streams.tsx
+++ b/libs/portal-plugin-lbry/src/ui/routes/streams.tsx
@@ -1,0 +1,79 @@
+import {
+  DataTable,
+  formatFileSize,
+  GeneralLayout,
+} from "@lumeweb/portal-framework-ui";
+import { format } from "date-fns";
+import { createColumnHelper } from "@tanstack/react-table";
+import { Authenticated } from "@refinedev/core";
+import type { StreamResponse } from "@/client";
+
+const columnHelper = createColumnHelper<StreamResponse>();
+
+const columns = [
+  columnHelper.accessor("sd_hash", {
+    cell: (info) => (
+      <span className="text-muted-foreground font-mono text-xs">
+        {info.getValue()}
+      </span>
+    ),
+    header: "SD Hash",
+  }),
+  columnHelper.accessor("suggested_file_name", {
+    cell: (info) => (
+      <span className="font-medium text-white">
+        {info.getValue() || "Unnamed"}
+      </span>
+    ),
+    header: "Name",
+  }),
+  columnHelper.accessor("created_at", {
+    cell: (info) => (
+      <span className="text-sm text-gray-400">
+        {format(new Date(info.getValue()), "MMM d, yyyy h:mm a")}
+      </span>
+    ),
+    header: "Created",
+  }),
+  columnHelper.accessor("size", {
+    cell: (info) => {
+      const size = info.getValue();
+      return size != null ? formatFileSize(size) : "—";
+    },
+    header: "Size",
+  }),
+];
+
+export default function StreamsPage() {
+  return (
+    <Authenticated key="lbry-streams">
+      <GeneralLayout>
+        <div className="space-y-6">
+          <div className="flex-1 p-6">
+            <div className="space-y-4">
+              <div>
+                <h1 className="text-foreground text-2xl font-semibold">
+                  LBRY Streams
+                </h1>
+                <p className="text-muted-foreground mt-1">
+                  Manage your LBRY streams
+                </p>
+              </div>
+
+              {/* Streams Table */}
+              <div className="bg-background border-border rounded-lg border">
+                <DataTable
+                  columns={columns}
+                  emptyStateMessage="No streams found. Pin your first stream to get started."
+                  pagination={true}
+                  resource="lbry/streams"
+                  responsive={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </GeneralLayout>
+    </Authenticated>
+  );
+}


### PR DESCRIPTION
- Add new streams route with navigation entry (/lbry/streams)
- Create streams page component with DataTable for displaying streams
- Add TypeScript type definitions (LbryUploadResponse, LbryError, LbryServiceConfig)
- Integrate routes into LBRY plugin configuration
- Minor style cleanup in LbryIcon component
---

<!-- kody-pr-summary:start -->
This pull request adds a new Streams page and route to the LBRY portal plugin, enabling users to view and manage their LBRY streams.

**Key Changes:**

1. **New Streams Route** (`routes.tsx`):
   - Added a route at `/lbry/streams` with navigation label "Streams" and an Anchor icon
   - Integrated into the plugin's routing system

2. **New Streams Page Component** (`ui/routes/streams.tsx`):
   - Created a data table interface displaying LBRY streams with columns for:
     - SD Hash
     - Name (suggested file name)
     - Creation date (formatted)
     - File size
   - Includes authentication requirement via the `Authenticated` component
   - Features pagination, responsive design, and an empty state message
   - Uses the "lbry/streams" resource for data fetching

3. **Type Definitions** (`types.ts`):
   - Added TypeScript interfaces for `LbryUploadResponse`, `LbryError`, and `LbryServiceConfig`

4. **Plugin Integration** (`index.ts`):
   - Registered the new routes in the plugin configuration
   - Updated exports to include the new types module

The changes provide users with a dedicated interface to browse and manage their LBRY streams within the portal.
<!-- kody-pr-summary:end -->

---
* Testing is not applicable