### PR TITLE
feat(portal-plugin-lbry): add devices management page

### DIFF
--- a/libs/portal-plugin-lbry/src/routes.tsx
+++ b/libs/portal-plugin-lbry/src/routes.tsx
@@ -3,6 +3,16 @@ import { Monitor, Anchor } from "lucide-react";
 
 const routes = [
   {
+    path: "/lbry/devices",
+    component: "devices",
+    id: "lbry_devices",
+    navigation: {
+      label: "Devices",
+      icon: Monitor,
+      order: 3,
+    },
+  },
+  {
     path: "/lbry/streams",
     component: "streams",
     id: "lbry_streams",

--- a/libs/portal-plugin-lbry/src/ui/dialogs/createDevice.tsx
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/createDevice.tsx
@@ -1,0 +1,13 @@
+import { DialogConfig, DialogTypes } from "@lumeweb/portal-framework-ui";
+
+import { createDeviceForm } from "@/ui/forms";
+import { ComponentSize } from "@lumeweb/portal-framework-ui";
+
+export function createDeviceDialogConfig(): DialogConfig {
+  return {
+    formConfig: createDeviceForm(),
+    size: ComponentSize.MD,
+    title: "Add Device",
+    type: DialogTypes.FORM,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/dialogs/deleteDevice.tsx
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/deleteDevice.tsx
@@ -1,0 +1,15 @@
+import { DialogConfig, DialogTypes } from "@lumeweb/portal-framework-ui";
+
+export function deleteDeviceDialogConfig(
+  deviceName: string,
+  onConfirm: () => void,
+): DialogConfig {
+  return {
+    confirmText: "Delete",
+    description: `Are you sure you want to remove "${deviceName}" from your device list? This action cannot be undone.`,
+    onConfirm,
+    title: "Delete Device",
+    type: DialogTypes.CONFIRM,
+    variant: "destructive",
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/dialogs/editDevice.tsx
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/editDevice.tsx
@@ -1,0 +1,16 @@
+import {
+  ComponentSize,
+  DialogConfig,
+  DialogTypes,
+} from "@lumeweb/portal-framework-ui";
+
+import { updateDeviceForm } from "@/ui/forms";
+
+export function editDeviceDialogConfig(deviceId: number): DialogConfig {
+  return {
+    formConfig: updateDeviceForm(deviceId),
+    size: ComponentSize.MD,
+    title: "Edit Device",
+    type: DialogTypes.FORM,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/dialogs/index.ts
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/index.ts
@@ -1,0 +1,3 @@
+export { createDeviceDialogConfig } from "./createDevice";
+export { editDeviceDialogConfig } from "./editDevice";
+export { deleteDeviceDialogConfig } from "./deleteDevice";

--- a/libs/portal-plugin-lbry/src/ui/forms/createDevice.schema.ts
+++ b/libs/portal-plugin-lbry/src/ui/forms/createDevice.schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export default z.object({
+  name: z.string().min(1, "Name is required").max(255, "Name is too long"),
+  ip_address: z.union([z.ipv4(), z.ipv6()]),
+});

--- a/libs/portal-plugin-lbry/src/ui/forms/createDevice.tsx
+++ b/libs/portal-plugin-lbry/src/ui/forms/createDevice.tsx
@@ -1,0 +1,34 @@
+import { type FormConfig, FormFieldType } from "@lumeweb/portal-framework-ui";
+
+import schema from "./createDevice.schema";
+
+export function createDeviceForm(): FormConfig {
+  return {
+    action: "create",
+    actionButtonsLayout: "horizontal",
+    fields: [
+      {
+        label: "Device Name",
+        name: "name",
+        placeholder: "e.g., Home PC, Work Laptop",
+        required: true,
+        type: FormFieldType.TEXT,
+      },
+      {
+        label: "IP Address",
+        name: "ip_address",
+        placeholder: "e.g., 192.168.1.1 or 2001:db8::1",
+        required: true,
+        type: FormFieldType.TEXT,
+      },
+    ],
+    refine: true,
+    resource: "lbry/devices",
+    successNotification: () => ({
+      description: `The device has been added to your device list.`,
+      message: "Device Added",
+      type: "success",
+    }),
+    validationSchema: schema,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/forms/index.ts
+++ b/libs/portal-plugin-lbry/src/ui/forms/index.ts
@@ -1,0 +1,2 @@
+export { createDeviceForm } from "./createDevice";
+export { updateDeviceForm } from "./updateDevice";

--- a/libs/portal-plugin-lbry/src/ui/forms/updateDevice.schema.ts
+++ b/libs/portal-plugin-lbry/src/ui/forms/updateDevice.schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export default z.object({
+  name: z.string().min(1, "Name is required").max(255, "Name is too long"),
+});

--- a/libs/portal-plugin-lbry/src/ui/forms/updateDevice.tsx
+++ b/libs/portal-plugin-lbry/src/ui/forms/updateDevice.tsx
@@ -1,0 +1,27 @@
+import { type FormConfig, FormFieldType } from "@lumeweb/portal-framework-ui";
+
+import schema from "./updateDevice.schema";
+
+export function updateDeviceForm(deviceId: number): FormConfig {
+  return {
+    action: "edit",
+    actionButtonsLayout: "horizontal",
+    fields: [
+      {
+        label: "Device Name",
+        name: "name",
+        required: true,
+        type: FormFieldType.TEXT,
+      },
+    ],
+    id: deviceId,
+    refine: true,
+    resource: "lbry/devices",
+    successNotification: () => ({
+      description: `The device has been updated.`,
+      message: "Device Updated",
+      type: "success",
+    }),
+    validationSchema: schema,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/routes/devices.tsx
+++ b/libs/portal-plugin-lbry/src/ui/routes/devices.tsx
@@ -1,0 +1,109 @@
+import {
+  DataTable,
+  GeneralLayout,
+  PageHeader,
+  useDialog,
+} from "@lumeweb/portal-framework-ui";
+import { Button } from "@lumeweb/portal-framework-ui-core";
+import { Authenticated, useDelete } from "@refinedev/core";
+import { createColumnHelper } from "@tanstack/react-table";
+import { format } from "date-fns";
+import { Edit, Plus, Trash2 } from "lucide-react";
+
+import {
+  createDeviceDialogConfig,
+  deleteDeviceDialogConfig,
+  editDeviceDialogConfig,
+} from "@/ui/dialogs";
+import type { DeviceResponse } from "@/client";
+
+const columnHelper = createColumnHelper<DeviceResponse>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    cell: (info) => <span className="font-medium">{info.getValue()}</span>,
+    header: "Name",
+  }),
+  columnHelper.accessor("ip_address", {
+    cell: (info) => (
+      <span className="font-mono text-sm">{info.getValue()}</span>
+    ),
+    header: "IP Address",
+  }),
+  columnHelper.accessor("created_at", {
+    cell: (info) => (
+      <span className="text-sm text-gray-400">
+        {format(new Date(info.getValue()), "MMM d, yyyy h:mm a")}
+      </span>
+    ),
+    header: "Added",
+  }),
+];
+
+export default function Devices() {
+  const { openDialog } = useDialog();
+  const { mutate: deleteDevice } = useDelete();
+
+  const handleCreateClick = () => {
+    openDialog(createDeviceDialogConfig());
+  };
+
+  const handleEditClick = (device: DeviceResponse) => {
+    openDialog(editDeviceDialogConfig(device.id));
+  };
+
+  const handleDeleteClick = (device: DeviceResponse) => {
+    openDialog(
+      deleteDeviceDialogConfig(device.name, async () => {
+        await deleteDevice({
+          id: device.id,
+          resource: "lbry/devices",
+        });
+      }),
+    );
+  };
+
+  return (
+    <Authenticated key="lbry-devices">
+      <GeneralLayout>
+        <div className="space-y-6">
+          <div className="flex flex-col items-center justify-between sm:flex-row">
+            <PageHeader
+              description="Manage devices in your LBRY device list. Devices in the list can upload content to your account."
+              title="Devices"
+            />
+            <Button className="mt-2 sm:mt-0" onClick={handleCreateClick}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add Device
+            </Button>
+          </div>
+          <DataTable
+            actionMenu={{
+              items: [
+                {
+                  icon: <Edit className="mr-2 h-4 w-4" />,
+                  label: "Edit",
+                  onClick: (row) => {
+                    handleEditClick(row);
+                  },
+                },
+                {
+                  icon: <Trash2 className="mr-2 h-4 w-4" />,
+                  label: "Delete",
+                  onClick: (row) => {
+                    handleDeleteClick(row);
+                  },
+                },
+              ],
+            }}
+            columns={columns}
+            emptyStateMessage="No devices in your device list. Add your first device to allow it to upload content to your account."
+            pagination={true}
+            resource="lbry/devices"
+            responsive={true}
+          />
+        </div>
+      </GeneralLayout>
+    </Authenticated>
+  );
+}


### PR DESCRIPTION
- Add devices route with navigation entry (/lbry/devices)
- Create devices page with DataTable displaying device list (name, IP, added date)
- Implement CRUD operations with dialogs for create, edit, and delete devices
- Add form schemas for device creation (name, IP address) and update (name)
- Configure action menu with Edit and Delete options


---

<!-- kody-pr-summary:start -->
This pull request adds a new Devices management page to the LBRY portal plugin. It introduces a navigation item and route (`/lbry/devices`) that allows users to view and manage devices authorized to upload content to their account.

Key features implemented include:
*   **Device List:** A data table displaying device names, IP addresses, and the date they were added.
*   **Add Device:** A form dialog to register new devices by entering a name and a valid IPv4 or IPv6 address.
*   **Edit Device:** A form dialog to update the name of an existing device.
*   **Delete Device:** A confirmation dialog to remove a device from the list.
<!-- kody-pr-summary:end -->
---
* Testing isnt applicable