### PR TITLE
feat(portal-plugin-lbry): add stream pinning/unpinning functionality

### DIFF
--- a/libs/portal-plugin-lbry/src/ui/components/toolbar/PinItem.tsx
+++ b/libs/portal-plugin-lbry/src/ui/components/toolbar/PinItem.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import { Pin } from "lucide-react";
+import type { BaseRecord } from "@refinedev/core";
+import { useNotification } from "@refinedev/core";
+import {
+  ToolbarCustomItem,
+  ToolbarItemType,
+  useDialog,
+} from "@lumeweb/portal-framework-ui";
+import { Button } from "@lumeweb/portal-framework-ui-core";
+import { createPinDialogConfig } from "@/ui/dialogs/pinDialog";
+import { useLbryPinning } from "@/ui/hooks";
+
+export function PinItem<
+  TData extends BaseRecord = any,
+>(): ToolbarCustomItem<TData> {
+  return {
+    id: "add-pin",
+    type: ToolbarItemType.CUSTOM,
+    component: () => {
+      const { openDialog } = useDialog();
+      const { open } = useNotification();
+      const { pinStreams, isMutating } = useLbryPinning();
+
+      const handleClick = () => {
+        const dialogConfig = createPinDialogConfig(
+          async (sdHashes: string[]) => {
+            await pinStreams(sdHashes);
+          },
+          open,
+        );
+
+        openDialog(dialogConfig);
+      };
+
+      return (
+        <Button
+          onClick={handleClick}
+          title="Add new stream pins to LBRY"
+          size="sm"
+          variant="outline"
+          disabled={isMutating}>
+          <Pin className="mr-2 h-4 w-4" />
+          Add Pin
+        </Button>
+      );
+    },
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/components/toolbar/index.ts
+++ b/libs/portal-plugin-lbry/src/ui/components/toolbar/index.ts
@@ -1,0 +1,1 @@
+export { PinItem } from "./PinItem";

--- a/libs/portal-plugin-lbry/src/ui/dialogs/index.ts
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/index.ts
@@ -1,3 +1,5 @@
+export { createPinDialogConfig } from "./pinDialog";
+export { createUnpinDialogConfig } from "./unpinDialog";
 export { createDeviceDialogConfig } from "./createDevice";
 export { editDeviceDialogConfig } from "./editDevice";
 export { deleteDeviceDialogConfig } from "./deleteDevice";

--- a/libs/portal-plugin-lbry/src/ui/dialogs/pinDialog.tsx
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/pinDialog.tsx
@@ -1,0 +1,340 @@
+import { z } from "zod";
+import {
+  ComponentSize,
+  DialogTypes,
+  FormDialogConfig,
+  FormFieldConfig,
+  useFormContext,
+} from "@lumeweb/portal-framework-ui";
+import { AlertCircle, CheckCircle, Hash, X } from "lucide-react";
+import { forwardRef, useCallback, useMemo, useState } from "react";
+import {
+  Badge,
+  Button,
+  cn,
+  Input,
+  Label,
+  ScrollArea,
+} from "@lumeweb/portal-framework-ui-core";
+
+// Schema for pin dialog
+const pinSchema = z.object({
+  sd_hashes: z.array(z.string()).min(1, "At least one SD hash is required"),
+});
+
+export type PinFormData = z.infer<typeof pinSchema>;
+
+interface SdHashTag {
+  id: string;
+  sd_hash: string;
+  isValid: boolean;
+  isAlreadyPinned: boolean;
+}
+
+// Pre-compile regex for SD hash validation - LBRY SD hashes are 96 hex characters
+const SD_HASH_REGEX = /^[0-9a-fA-F]{96}$/;
+
+const isValidSdHash = (hash: string): boolean => {
+  return SD_HASH_REGEX.test(hash.trim());
+};
+
+// Format SD hash for display
+const formatHashForDisplay = (hash: string): string => {
+  if (hash.length <= 16) return hash;
+  return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+};
+
+// SD hash input component
+const SdHashInputComponent = forwardRef<
+  HTMLDivElement,
+  {
+    existingPinnedHashes?: string[];
+  }
+>(({ existingPinnedHashes = [] }, ref) => {
+  const formContext = useFormContext<PinFormData>();
+  const { formInstance } = formContext;
+  const [inputValue, setInputValue] = useState("");
+  const [hashTags, setHashTags] = useState<SdHashTag[]>([]);
+
+  // Convert existing hashes to Set for O(1) lookup
+  const existingPinnedSet = useMemo(
+    () => new Set(existingPinnedHashes),
+    [existingPinnedHashes],
+  );
+
+  // Add SD hash tag
+  const addHashTag = useCallback(
+    (hash: string) => {
+      const trimmedHash = hash.trim();
+      if (!trimmedHash) return;
+
+      // Check for duplicates
+      if (hashTags.some((tag) => tag.sd_hash === trimmedHash)) return;
+
+      const newTag: SdHashTag = {
+        id: crypto.randomUUID(),
+        sd_hash: trimmedHash,
+        isValid: isValidSdHash(trimmedHash),
+        isAlreadyPinned: existingPinnedSet.has(trimmedHash),
+      };
+
+      setHashTags((prev) => [...prev, newTag]);
+
+      // Update form with valid hashes
+      const validHashes = hashTags
+        .filter((tag) => tag.isValid && !tag.isAlreadyPinned)
+        .map((tag) => tag.sd_hash);
+
+      if (newTag.isValid && !newTag.isAlreadyPinned) {
+        formInstance.setValue("sd_hashes", [...validHashes, newTag.sd_hash]);
+      }
+
+      setInputValue("");
+    },
+    [hashTags, existingPinnedSet, formInstance],
+  );
+
+  // Remove SD hash tag
+  const removeHashTag = useCallback(
+    (tagId: string) => {
+      const updatedTags = hashTags.filter((tag) => tag.id !== tagId);
+      setHashTags(updatedTags);
+
+      // Update form with remaining valid hashes
+      const validHashes = updatedTags
+        .filter((tag) => tag.isValid && !tag.isAlreadyPinned)
+        .map((tag) => tag.sd_hash);
+
+      formInstance.setValue("sd_hashes", validHashes);
+    },
+    [hashTags, formInstance],
+  );
+
+  // Handle input key press
+  const handleKeyPress = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        addHashTag(inputValue);
+      }
+    },
+    [inputValue, addHashTag],
+  );
+
+  // Clear all tags
+  const clearAllTags = useCallback(() => {
+    setHashTags([]);
+    formInstance.setValue("sd_hashes", []);
+  }, [formInstance]);
+
+  // Memoize stats calculation
+  const stats = useMemo(() => {
+    const total = hashTags.length;
+    const valid = hashTags.filter((tag) => tag.isValid).length;
+    const invalid = total - valid;
+    const alreadyPinned = hashTags.filter((tag) => tag.isAlreadyPinned).length;
+    const newToPin = valid - alreadyPinned;
+
+    return { total, valid, invalid, alreadyPinned, newToPin };
+  }, [hashTags]);
+
+  return (
+    <div ref={ref} className="space-y-4">
+      {/* Description */}
+      <div className="text-muted-foreground text-justify text-sm">
+        <p>
+          Pin streams to your account by entering Stream Descriptor (SD) hashes.
+        </p>
+        <p className="mt-1">
+          Pinned streams remain available and accessible through your account on
+          the LBRY network.
+        </p>
+        <p className="mt-1">
+          SD hashes must be exactly 96 hexadecimal characters.
+        </p>
+      </div>
+
+      {/* Input */}
+      <div className="space-y-2">
+        <Label htmlFor="sd-hash-input" className="text-foreground">
+          Enter SD Hash
+        </Label>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <Input
+              id="sd-hash-input"
+              placeholder="96-character hex hash (e.g., 1234567890abcdef...)"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyPress}
+              className="border-border bg-background text-foreground placeholder:text-muted-foreground h-10 w-full"
+            />
+          </div>
+          <Button
+            onClick={() => addHashTag(inputValue)}
+            disabled={!inputValue.trim()}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 h-10">
+            Add
+          </Button>
+        </div>
+      </div>
+
+      {/* Hash Tags */}
+      {hashTags.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label className="text-foreground">
+              SD Hashes to Pin ({hashTags.length})
+            </Label>
+            {hashTags.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={clearAllTags}
+                className="text-muted-foreground hover:text-foreground">
+                Clear All
+              </Button>
+            )}
+          </div>
+
+          <ScrollArea className="max-h-48">
+            <div className="space-y-2">
+              {hashTags.map((tag) => (
+                <div
+                  key={tag.id}
+                  className={cn(
+                    "flex items-center gap-2 rounded-lg border p-2",
+                    tag.isValid
+                      ? tag.isAlreadyPinned
+                        ? "border-yellow-400/20 bg-yellow-400/5"
+                        : "border-green-400/20 bg-green-400/5"
+                      : "border-red-400/20 bg-red-400/5",
+                  )}>
+                  {/* Status Icon */}
+                  {tag.isValid ? (
+                    tag.isAlreadyPinned ? (
+                      <Hash className="h-4 w-4 flex-shrink-0 text-yellow-400" />
+                    ) : (
+                      <CheckCircle className="h-4 w-4 flex-shrink-0 text-green-400" />
+                    )
+                  ) : (
+                    <AlertCircle className="h-4 w-4 flex-shrink-0 text-red-400" />
+                  )}
+
+                  {/* SD Hash */}
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-mono text-sm">
+                      {formatHashForDisplay(tag.sd_hash)}
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                      {!tag.isValid &&
+                        "Invalid SD hash format (must be 96 hex chars)"}
+                      {tag.isValid && tag.isAlreadyPinned && "Already pinned"}
+                      {tag.isValid && !tag.isAlreadyPinned && "Ready to pin"}
+                    </div>
+                  </div>
+
+                  {/* Status Badge */}
+                  <Badge
+                    variant="secondary"
+                    className={cn(
+                      "text-xs",
+                      tag.isValid
+                        ? tag.isAlreadyPinned
+                          ? "bg-warning/10 text-warning"
+                          : "bg-success/10 text-success"
+                        : "bg-destructive/10 text-destructive",
+                    )}>
+                    {!tag.isValid && "Invalid"}
+                    {tag.isValid && tag.isAlreadyPinned && "Pinned"}
+                    {tag.isValid && !tag.isAlreadyPinned && "New"}
+                  </Badge>
+
+                  {/* Remove Button */}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeHashTag(tag.id)}
+                    className="text-muted-foreground hover:text-destructive h-6 w-6 p-0">
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+
+          {/* Summary */}
+          {stats.total > 0 && (
+            <div className="border-border bg-background rounded-lg border p-3">
+              <div className="text-muted-foreground mb-2 text-sm">Summary:</div>
+              <div className="flex flex-wrap gap-3 text-xs">
+                {stats.newToPin > 0 && (
+                  <span className="text-success">
+                    {stats.newToPin} new to pin
+                  </span>
+                )}
+                {stats.alreadyPinned > 0 && (
+                  <span className="text-warning">
+                    {stats.alreadyPinned} already pinned
+                  </span>
+                )}
+                {stats.invalid > 0 && (
+                  <span className="text-destructive">
+                    {stats.invalid} invalid
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export function createPinDialogConfig(
+  onPin: (sdHashes: string[]) => Promise<void>,
+  open?: (options: any) => void,
+): FormDialogConfig<PinFormData> {
+  return {
+    type: DialogTypes.FORM,
+    title: "Pin Streams to Account",
+    description: "Enter SD hashes to pin streams to your account",
+    formConfig: {
+      defaultValues: {
+        sd_hashes: [],
+      },
+      fields: [
+        {
+          name: "sd_hashes",
+          type: "custom",
+          component: SdHashInputComponent,
+          required: true,
+        } as FormFieldConfig<PinFormData>,
+      ],
+      validationSchema: pinSchema,
+      submitLabel: "Pin to Account",
+    },
+    onSubmit: async (data) => {
+      try {
+        await onPin(data.sd_hashes);
+        return { success: true };
+      } catch (error) {
+        open?.({
+          type: "error",
+          message: "Failed to pin streams",
+          description: "An error occurred while pinning the streams",
+        });
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      open?.({
+        type: "success",
+        message: "Stream pinning queued",
+        description: "The streams have been queued for pinning to your account",
+      });
+    },
+    size: ComponentSize.TWO_XL,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/dialogs/unpinDialog.tsx
+++ b/libs/portal-plugin-lbry/src/ui/dialogs/unpinDialog.tsx
@@ -1,0 +1,36 @@
+import {
+  ComponentSize,
+  ConfirmDialogConfig,
+  DialogTypes,
+} from "@lumeweb/portal-framework-ui";
+
+export function createUnpinDialogConfig(
+  sdHash: string,
+  streamName: string,
+  onUnpin: (sdHash: string) => Promise<void>,
+  open?: (options: any) => void,
+): ConfirmDialogConfig {
+  const displayName = streamName || sdHash;
+
+  return {
+    type: DialogTypes.CONFIRM,
+    title: "Unpin Stream",
+    description: `Are you sure you want to unpin "${displayName}"? This action cannot be undone.`,
+    confirmText: "Unpin",
+    cancelText: "Cancel",
+    onConfirm: async () => {
+      try {
+        await onUnpin(sdHash);
+      } catch (error) {
+        open?.({
+          type: "error",
+          message: "Failed to Unpin Stream",
+          description: "An error occurred while unpinning the stream",
+        });
+        throw error;
+      }
+    },
+    variant: "destructive",
+    size: ComponentSize.MD,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/forms/pinStream.schema.ts
+++ b/libs/portal-plugin-lbry/src/ui/forms/pinStream.schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export default z.object({
+  sd_hash: z.string().min(1, "SD hash is required"),
+});

--- a/libs/portal-plugin-lbry/src/ui/forms/pinStream.tsx
+++ b/libs/portal-plugin-lbry/src/ui/forms/pinStream.tsx
@@ -1,0 +1,27 @@
+import { type FormConfig, FormFieldType } from "@lumeweb/portal-framework-ui";
+
+import schema from "./pinStream.schema";
+
+export function pinStreamForm(): FormConfig {
+  return {
+    action: "create",
+    actionButtonsLayout: "horizontal",
+    fields: [
+      {
+        label: "SD Hash",
+        name: "sd_hash",
+        placeholder: "Enter SD hash (e.g., 1234567890abcdef...)",
+        required: true,
+        type: FormFieldType.TEXT,
+      },
+    ],
+    refine: true,
+    resource: "lbry/streams",
+    successNotification: () => ({
+      description: "The stream has been pinned to your account.",
+      message: "Stream Pinned",
+      type: "success",
+    }),
+    validationSchema: schema,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/hooks/index.ts
+++ b/libs/portal-plugin-lbry/src/ui/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useLbryPinning } from "./useLbryPinning";

--- a/libs/portal-plugin-lbry/src/ui/hooks/useLbryPinning.ts
+++ b/libs/portal-plugin-lbry/src/ui/hooks/useLbryPinning.ts
@@ -1,0 +1,103 @@
+import { useCustomMutation, useNotification } from "@refinedev/core";
+import { useCallback } from "react";
+import { DATA_PROVIDER_NAME } from "@/capabilities/refineConfig";
+
+export interface UseLbryPinningReturn {
+  pinStreams: (sdHashes: string[]) => Promise<void>;
+  isMutating: boolean;
+}
+
+export function useLbryPinning(): UseLbryPinningReturn {
+  const { mutateAsync: customMutate, mutation } = useCustomMutation();
+  const { open } = useNotification();
+  const isMutating = mutation.isPending;
+
+  const pinStreams = useCallback(
+    async (sdHashes: string[]) => {
+      if (sdHashes.length === 0) {
+        open?.({
+          type: "error",
+          message: "No Streams to Pin",
+          description: "Please provide at least one SD hash to pin.",
+        });
+        return;
+      }
+
+      try {
+        const success: string[] = [];
+        const failed: string[] = [];
+
+        // Show progress for bulk operations
+        if (sdHashes.length > 1) {
+          open?.({
+            type: "progress",
+            message: "Pinning Streams",
+            description: `Processing ${sdHashes.length} stream(s)...`,
+          });
+        }
+
+        // Pin each SD hash using Refine's custom method with operation to append /pin
+        for (const sdHash of sdHashes) {
+          try {
+            await customMutate({
+              url: "pin",
+              method: "post",
+              values: { sd_hash: sdHash },
+              meta: {
+                resource: "streams",
+              },
+              dataProviderName: DATA_PROVIDER_NAME,
+              successNotification: false,
+              errorNotification: false,
+            });
+            success.push(sdHash);
+
+            // Individual notification for single operations
+            if (sdHashes.length === 1) {
+              open?.({
+                type: "success",
+                message: "Stream Pinned",
+                description: `Stream ${sdHash.slice(0, 8)}...${sdHash.slice(-8)} has been pinned.`,
+              });
+            }
+          } catch (error) {
+            failed.push(sdHash);
+          }
+        }
+
+        // Bulk summary for batch operations
+        if (sdHashes.length > 1) {
+          const failedList = failed
+            .map((h) => `${h.slice(0, 8)}...${h.slice(-8)}`)
+            .join(", ");
+          open?.({
+            type: failed.length === 0 ? "success" : "error",
+            message:
+              failed.length === 0
+                ? "All Streams Pinned"
+                : "Pinning Partially Complete",
+            description:
+              failed.length === 0
+                ? `Successfully pinned ${success.length} streams.`
+                : `Successfully pinned ${success.length} of ${sdHashes.length} streams. Failed: ${failedList}`,
+          });
+        }
+      } catch (error) {
+        // Only show error notification if not already shown by bulk summary
+        if (sdHashes.length === 1) {
+          open?.({
+            type: "error",
+            message: "Pinning Failed",
+            description: "An error occurred while pinning the stream.",
+          });
+        }
+      }
+    },
+    [customMutate, open],
+  );
+
+  return {
+    pinStreams,
+    isMutating,
+  };
+}

--- a/libs/portal-plugin-lbry/src/ui/routes/streams.tsx
+++ b/libs/portal-plugin-lbry/src/ui/routes/streams.tsx
@@ -2,10 +2,17 @@ import {
   DataTable,
   formatFileSize,
   GeneralLayout,
+  ToolbarConfig,
+  ToolbarItemAlignment,
+  useDialog,
 } from "@lumeweb/portal-framework-ui";
 import { format } from "date-fns";
+import { Trash2 } from "lucide-react";
 import { createColumnHelper } from "@tanstack/react-table";
-import { Authenticated } from "@refinedev/core";
+import { Authenticated, useDelete } from "@refinedev/core";
+
+import { createUnpinDialogConfig } from "@/ui/dialogs";
+import { PinItem } from "@/ui/components/toolbar";
 import type { StreamResponse } from "@/client";
 
 const columnHelper = createColumnHelper<StreamResponse>();
@@ -44,7 +51,16 @@ const columns = [
   }),
 ];
 
+const toolbarConfig: ToolbarConfig<StreamResponse> = {
+  defaultAlignment: ToolbarItemAlignment.RIGHT,
+  justifyBetween: true,
+  items: [PinItem()],
+};
+
 export default function StreamsPage() {
+  const { openDialog } = useDialog();
+  const { mutate: deletePin } = useDelete();
+
   return (
     <Authenticated key="lbry-streams">
       <GeneralLayout>
@@ -63,11 +79,42 @@ export default function StreamsPage() {
               {/* Streams Table */}
               <div className="bg-background border-border rounded-lg border">
                 <DataTable
+                  actionMenu={{
+                    items: [
+                      {
+                        icon: <Trash2 className="mr-2 h-4 w-4" />,
+                        label: "Unpin",
+                        onClick: (row) => {
+                          openDialog(
+                            createUnpinDialogConfig(
+                              row.sd_hash,
+                              row.stream_name,
+                              async (sdHash) => {
+                                const displayName =
+                                  row.stream_name || row.sd_hash;
+                                await deletePin({
+                                  id: sdHash,
+                                  resource: "lbry/streams",
+                                  successNotification: () => ({
+                                    description: `The stream "${displayName}" has been unpinned.`,
+                                    message: "Stream Unpinned",
+                                    type: "success",
+                                  }),
+                                });
+                              },
+                              openDialog,
+                            ),
+                          );
+                        },
+                      },
+                    ],
+                  }}
                   columns={columns}
                   emptyStateMessage="No streams found. Pin your first stream to get started."
                   pagination={true}
                   resource="lbry/streams"
                   responsive={true}
+                  toolbar={toolbarConfig}
                 />
               </div>
             </div>


### PR DESCRIPTION
- Add "Add Pin" button to streams page toolbar for bulk pinning
- Create comprehensive pin dialog with SD hash validation (96 hex chars)
- Support bulk pinning with real-time validation and status indicators
- Add unpin action menu item with confirmation dialog
- Implement useLbryPinning hook for managing pin operations with notifications
- Handle duplicate detection and already-pinned hash warnings


---

<!-- kody-pr-summary:start -->
This pull request adds stream pinning and unpinning functionality to the LBRY portal plugin. The implementation includes:

**Pinning Features:**
- A new "Add Pin" button in the streams page toolbar that opens a dialog for entering Stream Descriptor (SD) hashes
- Support for bulk pinning multiple streams at once
- Real-time validation of SD hashes (must be 96 hexadecimal characters)
- Visual feedback indicating valid hashes, invalid formats, and already-pinned streams
- Summary display showing counts of new pins, already pinned, and invalid entries

**Unpinning Features:**
- An "Unpin" action added to each stream row's action menu
- Confirmation dialog before unpinning to prevent accidental removal
- Success/error notifications for unpinning operations

**Technical Implementation:**
- Custom hook (`useLbryPinning`) to handle pinning API calls with support for both single and batch operations
- Form validation using Zod schemas
- Integration with the existing data table and toolbar components
- User notifications for operation status and results
<!-- kody-pr-summary:end -->
---
* Testing not applicable