### PR TITLE
refactor(pinner): remove yieldSafe helper and convert to async generators

### DIFF
--- a/libs/pinner/src/blockstore/unstorage-base.ts
+++ b/libs/pinner/src/blockstore/unstorage-base.ts
@@ -13,26 +13,7 @@ import type { Batch, Datastore, KeyQuery, Query } from "interface-datastore";
 import { Key, Pair } from "interface-datastore";
 import { collectAsyncIterable } from "@/utils/stream";
 
-/**
- * Helper to safely yield a Promise or value from a sync generator.
- * Converts Promise rejection to a thrown error to maintain Await<T> contract.
- *
- * WHY: We use sync generators (* get) instead of async generators (async * get) here.
- * This is because blockstore-core@6.1.1's IdentityBlockstore uses sync generators
- * with yield*, which cannot properly delegate to async generators. This causes:
- * TypeError: yield* (intermediate value) is not iterable
- *
- * TODO: Remove yieldSafe and convert to async generators after
- * https://github.com/ipfs/js-stores/pull/364 is merged and released.
- */
-function yieldSafe<T>(value: Await<T>, errorMessage: string): Await<T> {
-  if (value instanceof Promise) {
-    return value.catch(() => {
-      throw new Error(errorMessage);
-    }) as Await<T>;
-  }
-  return value;
-}
+
 
 export interface UnstorageBlockstoreOptions {
   storage?: Storage;
@@ -175,18 +156,11 @@ export function createUnstorageBlockstore(
       }
     }
 
-    *get(key: CID, _?: AbortOptions): AwaitGenerator<Uint8Array> {
+    async *get(key: CID, _?: AbortOptions): AsyncGenerator<Uint8Array> {
       const storageKey = this.keyToStorageKey(key);
-      const value = this.base.getItem(storageKey);
-
-      if (value === null || value === undefined) {
-        throw new Error(`Block not found: ${key.toString()}`);
-      }
-
-      // @ts-ignore
-      yield yieldSafe(value, `Block not found: ${key.toString()}`);
+      const value = await this.base.getItem(storageKey);
+      yield value;
     }
-    // TODO: Change to async *get after https://github.com/ipfs/js-stores/pull/364 is merged
 
     async *getMany(
       source: AwaitIterable<CID>,
@@ -195,9 +169,9 @@ export function createUnstorageBlockstore(
       for await (const cid of source) {
         yield {
           cid,
-          bytes: async function* () {
+          bytes: (async function* () {
             yield* await this.get(cid, options);
-          }.call(this),
+          }.call(this)),
         };
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1530,6 +1530,66 @@ importers:
         specifier: catalog:framework
         version: 6.4.1(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
 
+  libs/portal-plugin-lbry:
+    dependencies:
+      '@lumeweb/advanced-rest-provider':
+        specifier: workspace:*
+        version: link:../advanced-rest
+      '@lumeweb/portal-framework-auth':
+        specifier: workspace:*
+        version: link:../portal-framework-auth
+      '@lumeweb/portal-framework-core':
+        specifier: workspace:*
+        version: link:../portal-framework-core
+      '@lumeweb/portal-framework-ui':
+        specifier: workspace:*
+        version: link:../portal-framework-ui
+      '@lumeweb/portal-framework-ui-core':
+        specifier: workspace:*
+        version: link:../portal-framework-ui-core
+      '@lumeweb/portal-plugin-dashboard':
+        specifier: workspace:*
+        version: link:../portal-plugin-dashboard
+      '@lumeweb/portal-sdk':
+        specifier: workspace:*
+        version: link:../portal-sdk
+      '@refinedev/core':
+        specifier: 'catalog:'
+        version: 5.0.8(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@refinedev/react-router':
+        specifier: 'catalog:'
+        version: 2.0.3(@refinedev/core@5.0.8(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-query':
+        specifier: 'catalog:'
+        version: 5.90.16(react@19.2.3)
+      '@tanstack/react-table':
+        specifier: 'catalog:'
+        version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@uppy/core':
+        specifier: 'catalog:'
+        version: 5.2.0(patch_hash=8a9c2320245d028b3d5a7d9fabf33e5d501d5c59afc1e03f7576dc9c1cb6a3d8)
+      date-fns:
+        specifier: 'catalog:'
+        version: 4.1.0
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.562.0(react@19.2.3)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.3
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.3(react@19.2.3)
+      react-hook-form:
+        specifier: 'catalog:'
+        version: 7.71.0(react@19.2.3)
+      react-router:
+        specifier: 'catalog:'
+        version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.5
+
   libs/portal-plugin-template:
     dependencies:
       '@lumeweb/portal-framework-core':


### PR DESCRIPTION
- Remove yieldSafe helper function that was a workaround for sync generators
- Convert get() method from sync generator to async generator
- Update getMany() to work with async get()
- Remove TODO comments referencing merged js-stores PR
