### PR TITLE
feat(rego): add React-to-Go Template DSL for email generation

### DIFF
--- a/libs/rego/README.md
+++ b/libs/rego/README.md
@@ -1,0 +1,942 @@
+# @lumeweb/rego
+
+React-to-Go Template DSL for Email Generation
+
+## Overview
+
+`@lumeweb/rego` provides a thin React DSL layer that wraps React Email components and outputs Go template syntax. The generated HTML contains Go template tags that can be executed by Go at runtime.
+
+### What it is NOT
+
+- ❌ NOT runtime execution of Go in JavaScript
+- ❌ NOT a complex transpilation system
+
+### What it IS
+
+- ✅ A React-based DSL that generates Go templates
+- ✅ React generates HTML with embedded Go template syntax
+- ✅ Go executes the templates with runtime data
+- ✅ Clean separation: React for design, Go for runtime parameterization
+
+## Architecture
+
+This library is middleware that sits between React Email and Go templates:
+
+```
+React Email Components
+    ↓ (styled with Tailwind)
+    @lumeweb/rego (adds Go template syntax)
+    ↓ (renders to)
+HTML + Go Template Syntax
+    ↓ (executed by)
+Go Templates with Data (Runtime)
+    ↓ (outputs)
+Final Email HTML
+```
+
+## Installation
+
+```bash
+npm install @lumeweb/rego
+```
+
+## Quick Start
+
+```tsx
+import React from 'react'
+import {
+  Head,
+  Body,
+  Container,
+  Text,
+  Heading,
+  Html,
+  Button,
+  Link,
+} from '@react-email/components'
+import {
+  GoVar,
+  GoIf,
+  GoElse,
+  GoRange,
+  goVar,
+  goUrl,
+} from '@lumeweb/rego'
+
+const WelcomeEmail = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Container>
+          <Heading>Hello, <GoVar name="UserName" />!</Heading>
+          <Text>Welcome to our app!</Text>
+
+          <GoIf condition="IsPremium">
+            <Text>You're a premium member!</Text>
+          </GoIf>
+
+          <GoRange items="RecentItems" empty={<Text>No recent items</Text>}>
+            <Text>• <GoVar name="Title" /></Text>
+          </GoRange>
+
+          {/* Helper functions for JSX attributes */}
+          <Button href={goVar("DashboardURL")}>
+            Go to Dashboard
+          </Button>
+
+          <Link href={goUrl({ path: "/settings", params: ["tab"] })}>
+            Settings
+          </Link>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+```
+
+## Core Components
+
+### GoVar - Variable Interpolation
+
+Outputs Go template variable syntax. Supports both field access and local variables:
+
+- Field access: `{{.VarName}}`
+- Local variables: `{{$VarName}}` (e.g., from GoRange)
+
+```tsx
+// Field access
+<GoVar name="userName" />
+// Outputs: {{.userName}}
+
+// Local variable (from GoRange)
+<GoRange items="items" elementName="item">
+  <GoVar name="$item.Name" />
+</GoRange>
+// Outputs: {{range $item := .items}}{{$item.Name}}{{end}}
+```
+
+**Note:** For default values, use `GoIf` component instead:
+```tsx
+<GoIf condition="userName">
+  <GoVar name="userName" />
+  <GoElse>
+    <Text>Guest</Text>
+  </GoElse>
+</GoIf>
+```
+
+### Helper Functions for JSX Attributes
+
+When you need to use Go template syntax in JSX attributes (like `href`, `src`, etc.), you can use helper functions instead of components:
+
+#### goVar(), goLocalVar(), goFieldVar()
+
+```tsx
+// In JSX attributes - use helper function
+<Button href={goVar("DashboardURL")}>Go to Dashboard</Button>
+// Outputs: href="{{.DashboardURL}}"
+
+// With local variable
+<GoRange items="items" elementName="item">
+  <Link href={goLocalVar("item.url")}>View</Link>
+</GoRange>
+// Outputs: href="{{$item.Url}}"
+
+// Always field access
+<Link href={goFieldVar("settingsUrl")}>Settings</Link>
+// Outputs: href="{{.SettingsUrl}}"
+```
+
+#### goUrl()
+
+```tsx
+// Simple path
+<Button href={goUrl("/dashboard")}>Dashboard</Button>
+// Outputs: href="{{"/dashboard"}}"
+
+// With variable
+<Button href={goUrl({ var: "dashboardUrl" })}>Dashboard</Button>
+// Outputs: href="{{.DashboardUrl}}"
+
+// With query parameters
+<Link href={goUrl({ path: "/verify", params: ["token", "email"] })}>
+  Verify Email
+</Link>
+// Outputs: href="{{"/verify" | addQueryParams .Token .Email}}"
+```
+
+#### goDate()
+
+```tsx
+<Text>Due: {goDate("dueDate", "Jan 2, 2006")}</Text>
+// Outputs: Due: {{.DueDate | formatDate "Jan 2, 2006"}}
+```
+
+#### goCurrency()
+
+```tsx
+<Text>Total: {goCurrency("total", "USD")}</Text>
+// Outputs: Total: {{.Total | formatCurrency "USD"}}
+```
+
+#### goFunc()
+
+```tsx
+<Text>{goFunc("pluralize", { var: "itemCount", args: ["item", "items"] })}</Text>
+// Outputs: {{pluralize .ItemCount "item" "items"}}
+```
+
+### GoIf - Conditional Rendering
+
+Outputs Go template conditional syntax: `{{if .Condition}}...{{end}}`
+
+```tsx
+<GoIf condition="isLoggedIn">
+  <Text>Welcome back!</Text>
+  <GoElse>
+    <Text>Please log in</Text>
+  </GoElse>
+</GoIf>
+
+// Outputs:
+// {{if .isLoggedIn}}
+// <Text>Welcome back!</Text>
+// {{else}}
+// <Text>Please log in</Text>
+// {{end}}
+```
+
+### GoRange - Loop Iteration
+
+Outputs Go template range syntax with variable assignment support:
+
+- `{{range .Items}}` - dot (.) becomes the element
+- `{{$item := range .Items}}` - element assigned to local variable
+- `{{$i, $item := range .Items}}` - index and element assigned
+
+```tsx
+// Basic: dot becomes element
+<GoRange items="cartItems">
+  <div>Item: <GoVar name="Name" /></div>
+</GoRange>
+// Outputs: {{range .cartItems}}<div>Item: {{.Name}}</div>{{end}}
+
+// With element name
+<GoRange items="items" elementName="item">
+  <div>{{$item.Name}}</div>
+</GoRange>
+// Outputs: {{range $item := .items}}<div>{{$item.Name}}</div>{{end}}
+
+// With index and element
+<GoRange items="items" indexName="i" elementName="item">
+  <div>{{$i}}: {{$item.Name}}</div>
+</GoRange>
+// Outputs: {{range $i, $item := .items}}<div>{{$i}}: {{$item.Name}}</div>{{end}}
+
+// With empty state
+<GoRange items="cartItems" empty={<Text>Your cart is empty</Text>}>
+  <div>Item: <GoVar name="Name" /></div>
+</GoRange>
+// Outputs:
+// {{range .cartItems}}
+// <div>Item: {{.Name}}</div>
+// {{else}}
+// <Text>Your cart is empty</Text>
+// {{end}}
+```
+
+### GoWith - Context Switching
+
+Outputs Go template with syntax: `{{with .Value}}...{{end}}`
+
+Changes the dot (.) to the specified value within the block.
+
+```tsx
+<GoWith value="user" fallback="No user found">
+  <div>Name: <GoVar name="Name" /></div>
+  <div>Email: <GoVar name="Email" /></div>
+</GoWith>
+
+// Outputs:
+// {{with .user}}
+// <div>Name: {{.Name}}</div>
+// <div>Email: {{.Email}}</div>
+// {{else}}
+// No user found
+// {{end}}
+```
+
+## Template Composition
+
+### GoDefine - Template Definition
+
+Defines a named template that can be reused with GoUseTemplate.
+
+```tsx
+<GoDefine name="email-header">
+  <Header>
+    <Logo src="logo.png" />
+    <Text>Welcome!</Text>
+  </Header>
+</GoDefine>
+
+// Outputs: {{define "email-header"}}...{{end}}
+```
+
+### GoUseTemplate - Template Invocation
+
+Invokes a previously defined template.
+
+```tsx
+<GoDefine name="email-header">
+  <Header><Text>Welcome!</Text></Header>
+</GoDefine>
+
+<GoUseTemplate name="email-header" />
+// Outputs: {{template "email-header"}}
+
+// With data
+<GoDefine name="user-info">
+  <div>
+    <Text>Name: <GoVar name="Name" /></Text>
+    <Text>Email: <GoVar name="Email" /></Text>
+  </div>
+</GoDefine>
+
+<GoUseTemplate name="user-info" data="currentUser" />
+// Outputs: {{template "user-info" .currentUser}}
+```
+
+### GoBlock - Template Block
+
+Defines a template block that can be overridden in child templates.
+
+```tsx
+<GoBlock name="email-content">
+  <Text>Default content</Text>
+</GoBlock>
+// Outputs: {{block "email-content" .}}<Text>Default content</Text>{{end}}
+```
+
+## Data Transformation Helpers
+
+### GoDate - Date Formatting
+
+Formats a date variable using Go template pipeline syntax.
+
+```tsx
+<GoDate var="createdAt" format="Jan 2, 2006" />
+// Outputs: {{.CreatedAt | formatDate "Jan 2, 2006"}}
+
+// With local variable
+<GoRange items="items" elementName="item">
+  <GoDate var="$item.createdAt" format="Jan 2, 2006" />
+</GoRange>
+// Outputs: {{range $item := .items}}{{$item.CreatedAt | formatDate "Jan 2, 2006"}}{{end}}
+```
+
+**Note:** Register the `formatDate` function in Go:
+```go
+funcMap := template.FuncMap{
+  "formatDate": formatDate,
+}
+
+func formatDate(date time.Time, layout string) string {
+  return date.Format(layout)
+}
+```
+
+### GoCurrency - Currency Formatting
+
+Formats a number as currency.
+
+```tsx
+<GoCurrency var="total" currency="USD" />
+// Outputs: {{.Total | formatCurrency "USD"}}
+```
+
+**Note:** Register the `formatCurrency` function in Go:
+```go
+funcMap := template.FuncMap{
+  "formatCurrency": formatCurrency,
+}
+
+func formatCurrency(amount float64, currency string) string {
+  return fmt.Sprintf("%s %.2f", currency, amount)
+}
+```
+
+### GoTruncate - Text Truncation
+
+Truncates a string to a specified length.
+
+```tsx
+<GoTruncate var="description" length="100" />
+// Outputs: {{.Description | truncate 100}}
+```
+
+**Note:** Register the `truncate` function in Go:
+```go
+funcMap := template.FuncMap{
+  "truncate": truncate,
+}
+
+func truncate(text string, length int) string {
+  if len(text) <= length {
+    return text
+  }
+  return text[:length] + "..."
+}
+```
+
+## Conditional Helpers
+
+### GoEqual - Equality Check
+
+Checks if two values are equal.
+
+```tsx
+<GoEqual var1="status" var2="active">
+  <Text>Status is active</Text>
+</GoEqual>
+// Outputs: {{if eq .Status "active"}}<Text>Status is active</Text>{{end}}
+
+// With else
+<GoEqual var1="status" var2="active">
+  <Text>Status is active</Text>
+  <GoElse>
+    <Text>Status is not active</Text>
+  </GoElse>
+</GoEqual>
+// Outputs: {{if eq .Status "active"}}<Text>Status is active</Text>{{else}}<Text>Status is not active</Text>{{end}}
+
+// Comparing two variables
+<GoEqual var1="count" var2="maxCount">
+  <Text>Reached maximum</Text>
+</GoEqual>
+// Outputs: {{if eq .Count .MaxCount}}<Text>Reached maximum</Text>{{end}}
+```
+
+### GoEmpty - Empty Check
+
+Checks if a value is empty (nil, zero value, empty string, etc.).
+
+```tsx
+<GoEmpty var="items">
+  <Text>No items found</Text>
+</GoEmpty>
+// Outputs: {{if not .Items}}<Text>No items found</Text>{{end}}
+
+// With else
+<GoEmpty var="items">
+  <Text>No items found</Text>
+  <GoElse>
+    <GoRange items="items">
+      <Text><GoVar name="Name" /></Text>
+    </GoRange>
+  </GoElse>
+</GoEmpty>
+// Outputs: {{if not .Items}}<Text>No items found</Text>{{else}}{{range .Items}}<Text>{{.Name}}</Text>{{end}}{{end}}
+```
+
+## Using with React Email
+
+This library is middleware - it doesn't wrap React Email components. Import React Email components directly:
+
+```tsx
+import {
+  Head,
+  Body,
+  Container,
+  Link,
+  Text,
+  Heading,
+  Button,
+  Img,
+  Hr,
+  Section,
+  Row,
+  Column,
+  Font,
+} from '@react-email/components'
+import {
+  GoVar,
+  GoIf,
+  GoRange,
+  GoWith,
+} from '@lumeweb/rego'
+```
+
+## Pipeline Chaining
+
+### GoPipe - Pipeline Composition
+
+Chains multiple template transformations using Go template pipeline syntax.
+
+```tsx
+<GoPipe>
+  <GoVar name="description" />
+  <GoTruncate length="100" />
+  <GoUpperCase />
+</GoPipe>
+// Outputs: {{.Description | truncate 100 | upper}}
+
+// With local variable
+<GoRange items="items" elementName="item">
+  <GoPipe>
+    <GoVar name="$item.title" />
+    <GoTruncate length="50" />
+    <GoUpperCase />
+  </GoPipe>
+</GoRange>
+// Outputs: {{range $item := .items}}{{$item.Title | truncate 50 | upper}}{{end}}
+```
+
+### GoLet - Variable Assignment
+
+Assigns values to variables in Go template syntax.
+
+```tsx
+// Simple variable reference
+<GoLet name="currentUser" value="user">
+  <Text>Hello, <GoVar name="$currentUser.name" /></Text>
+</GoLet>
+// Outputs: {{$currentUser := .user}}
+
+// Pipeline-based assignment
+<GoLet name="processedText">
+  <GoPipe>
+    <GoVar name="rawText" />
+    <GoTruncate length="100" />
+    <GoTrim />
+  </GoPipe>
+</GoLet>
+// Outputs: {{$processedText := .RawText | truncate 100 | trim}}
+
+// Format-based assignment
+<GoLet name="displayName">
+  <GoFormat format="%s %s">
+    <GoVar name="user.firstName" />
+    <GoVar name="user.lastName" />
+  </GoFormat>
+</GoLet>
+// Outputs: {{$displayName := printf "%s %s" .User.FirstName .User.LastName}}
+```
+
+### GoFormat - String Formatting
+
+Uses Go's printf syntax for string formatting.
+
+```tsx
+<GoFormat format="%s (%s)">
+  <GoVar name="name" />
+  <GoVar name="email" />
+</GoFormat>
+// Outputs: {{"%s (%s)" | printf .Name .Email}}
+
+// With local variables
+<GoRange items="items" elementName="item">
+  <GoFormat format="Item #%d: %s">
+    <GoVar name="$item.id" />
+    <GoVar name="$item.name" />
+  </GoFormat>
+</GoRange>
+// Outputs: {{range $item := .items}}{{"Item #%d: %s" | printf $item.Id $item.Name}}{{end}}
+```
+
+## String Transformations
+
+### GoUpperCase - Uppercase
+
+Converts text to uppercase.
+
+```tsx
+<GoUpperCase>
+  <GoVar name="name" />
+</GoUpperCase>
+// Outputs: {{.Name | upper}}
+
+// In pipeline
+<GoPipe>
+  <GoVar name="title" />
+  <GoTruncate length="50" />
+  <GoUpperCase />
+</GoPipe>
+```
+
+### GoLowerCase - Lowercase
+
+Converts text to lowercase.
+
+```tsx
+<GoLowerCase>
+  <GoVar name="name" />
+</GoLowerCase>
+// Outputs: {{.Name | lower}}
+```
+
+### GoTrim - Trim Whitespace
+
+Removes leading and trailing whitespace.
+
+```tsx
+<GoTrim>
+  <GoVar name="description" />
+</GoTrim>
+// Outputs: {{.Description | trim}}
+```
+
+## Function Invocation
+
+### GoFunc - Custom Functions
+
+Invokes custom Go template functions.
+
+```tsx
+// With variable and arguments
+<GoFunc name="pluralize" var="itemCount" args={["item", "items"]} />
+// Outputs: {{pluralize .ItemCount "item" "items"}}
+
+// With multiple variables
+<GoFunc name="formatFullName" vars={["firstName", "lastName"]} />
+// Outputs: {{formatFullName .FirstName .LastName}}
+
+// With local variable
+<GoRange items="items" elementName="item">
+  <GoFunc name="formatPrice" var="$item.price" args={["USD"]} />
+</GoRange>
+// Outputs: {{range $item := .items}}{{formatPrice $item.Price "USD"}}{{end}}
+
+// With literal arguments
+<GoFunc name="repeat" var="text" args={[3]} />
+// Outputs: {{repeat .Text 3}}
+```
+
+## URL Generation
+
+### GoUrl - URL Generation
+
+Generates URLs with optional query parameters.
+
+```tsx
+// Simple static path
+<GoUrl path="/dashboard" />
+// Outputs: {{"/dashboard"}}
+
+// With variable path
+<GoUrl var="dashboardUrl" />
+// Outputs: {{.DashboardUrl}}
+
+// With query parameters
+<GoUrl path="/verify" params={["token", "email"]} />
+// Outputs: {{"/verify" | addQueryParams .Token .Email}}
+
+// With variable path and parameters
+<GoUrl var="profileUrl" params={["id", "tab"]} />
+// Outputs: {{.ProfileUrl | addQueryParams .Id .Tab}}
+
+// With local variable
+<GoRange items="items" elementName="item">
+  <GoUrl var="$item.url" params={["ref", "source"]} />
+</GoRange>
+// Outputs: {{range $item := .items}}{{$item.Url | addQueryParams .Ref .Source}}{{end}}
+
+// With literal values
+<GoUrl path="/search" params={["q", "page"]} literalValues={["", "1"]} />
+// Outputs: {{"/search" | addQueryParams "" "1"}}
+```
+
+**Note:** Register the `addQueryParams` function in Go:
+```go
+func addQueryParams(baseURL string, params ...string) string {
+    if len(params) == 0 {
+        return baseURL
+    }
+    values := url.Values{}
+    for i := 0; i < len(params); i += 2 {
+        if i+1 < len(params) && params[i+1] != "" {
+            values.Set(params[i], params[i+1])
+        }
+    }
+    if len(values) > 0 {
+        return baseURL + "?" + values.Encode()
+    }
+    return baseURL
+}
+```
+
+## Array Operations
+
+### GoChunk - Array Chunking
+
+Splits an array into chunks of a specified size. Useful for creating grid layouts.
+
+```tsx
+// Basic chunking
+<GoChunk items="items" size="3" elementName="chunk">
+  <Row>
+    <GoRange items="$chunk" elementName="item">
+      <Column>
+        <Text><GoVar name="$item.name" /></Text>
+      </Column>
+    </GoRange>
+  </Row>
+</GoChunk>
+// Outputs: {{$chunk := chunk .Items 3}}
+//         <Row>{{range $item := $chunk}}<Column><Text>{{$item.Name}}</Text></Column>{{end}}</Row>
+
+// With chunk index
+<GoChunk items="products" size="2" elementName="productRow" indexName="chunkIndex">
+  <div style="row">
+    <Text>Row #<GoVar name="$chunkIndex" /></Text>
+    <GoRange items="$productRow" elementName="product">
+      <div style="col">
+        <Text><GoVar name="$product.name" /></Text>
+      </div>
+    </GoRange>
+  </div>
+</GoChunk>
+// Outputs: {{$chunkIndex, $productRow := chunk .Products 2}}
+//         <div style="row"><Text>Row #{{$chunkIndex}}</Text>{{range $product := $productRow}}<div style="col"><Text>{{$product.Name}}</Text></div>{{end}}</div>
+
+// With local variable
+<GoRange items="categories" elementName="category">
+  <GoChunk items="$category.items" size="4" elementName="itemChunk">
+    <Row>
+      <GoRange items="$itemChunk" elementName="item">
+        <Column><Text><GoVar name="$item.name" /></Text></Column>
+      </GoRange>
+    </Row>
+  </GoChunk>
+</GoRange>
+```
+
+**Note:** Register the `chunk` function in Go:
+
+**Option 1: Using `any` (Go 1.18+)**
+```go
+func chunk(slice any, size int) [][]any {
+    v := reflect.ValueOf(slice)
+    if v.Kind() != reflect.Slice {
+        return nil
+    }
+
+    length := v.Len()
+    var result [][]any
+
+    for i := 0; i < length; i += size {
+        end := i + size
+        if end > length {
+            end = length
+        }
+
+        var chunk []any
+        for j := i; j < end; j++ {
+            chunk = append(chunk, v.Index(j).Interface())
+        }
+        result = append(result, chunk)
+    }
+
+    return result
+}
+```
+
+**Option 2: Using `samber/lo` library**
+```go
+import "github.com/samber/lo"
+
+func chunk(slice any, size int) [][]any {
+    return lo.Chunk(slice, size)
+}
+```
+```
+
+## Comments
+
+### GoComment - Template Comments
+
+Adds comments to Go templates (ignored during execution).
+
+```tsx
+<GoComment>This section shows user profile information</GoComment>
+// Outputs: {{/* This section shows user profile information */}}
+
+// Multiline
+<GoComment>
+  This is a longer comment
+  that spans multiple lines
+</GoComment>
+```
+
+## Usage with Go
+
+### 1. Generate the Template
+
+Render your React component to HTML with embedded Go template syntax. You can use React Email's preview server or a custom SSR script to render your components:
+
+**Option 1: Using React Email Preview Server**
+```bash
+# Start the preview server
+npx email preview
+
+# View your component at http://localhost:3000
+# Copy the rendered HTML from the browser or use the API
+```
+
+**Option 2: Build the library**
+```bash
+npm run build
+```
+
+The output will be in `dist/` directory as compiled JavaScript/TypeScript. To get the actual HTML with Go template syntax, you need to render your components using a server-side renderer.
+
+**Option 3: Custom SSR Example**
+```tsx
+// render-email.ts
+import { render } from '@react-email/components'
+import { WelcomeEmail } from './WelcomeEmail'
+
+const html = await render(<WelcomeEmail />)
+console.log(html)
+```
+
+The rendered HTML will contain Go template syntax that can be executed by Go.
+
+### 2. Use in Go
+
+```go
+package main
+
+import (
+    "os"
+    "text/template"
+)
+
+type EmailData struct {
+    UserName      string
+    IsLoggedIn    bool
+    CartItems     []CartItem
+    IsPremium     bool
+}
+
+type CartItem struct {
+    Name  string
+    Price string
+}
+
+func main() {
+    // Read the generated template
+    tmplContent, err := os.ReadFile("welcome-email.html")
+    if err != nil {
+        panic(err)
+    }
+
+    // Parse the template
+    tmpl, err := template.New("welcome").Parse(string(tmplContent))
+    if err != nil {
+        panic(err)
+    }
+
+    // Prepare data
+    data := EmailData{
+        UserName:   "John Doe",
+        IsLoggedIn: true,
+        IsPremium:  true,
+        CartItems: []CartItem{
+            {Name: "Product A", Price: "$10.00"},
+            {Name: "Product B", Price: "$20.00"},
+        },
+    }
+
+    // Execute template
+    err = tmpl.Execute(os.Stdout, data)
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+### Registering Go Functions
+
+If you use data transformation helpers (GoDate, GoCurrency, GoTruncate, GoUrl, GoChunk, etc.), you need to register custom functions in your Go template:
+
+```go
+funcMap := template.FuncMap{
+    // Data transformations
+    "formatDate":     formatDate,
+    "formatCurrency": formatCurrency,
+    "truncate":       truncate,
+    // String transformations
+    "upper":          strings.ToUpper,
+    "lower":          strings.ToLower,
+    "trim":           strings.TrimSpace,
+    // URL generation
+    "addQueryParams": addQueryParams,
+    // Array operations
+    "chunk":          chunk,
+}
+
+tmpl := template.New("email").Funcs(funcMap).Parse(string(tmplContent))
+```
+
+See the individual component documentation for the required function signatures.
+
+## Examples
+
+See the `examples/` directory for complete examples:
+
+- `WelcomeEmail.tsx` - Basic welcome email with conditionals and loops
+- `OrderConfirmation.tsx` - Complex email with nested context and arrays
+- `TemplateCompositionExample.tsx` - Template reusability with GoDefine, GoUseTemplate, GoBlock
+- `DataTransformationExample.tsx` - Date, currency, and text formatting
+- `ConditionalHelpersExample.tsx` - GoEqual and GoEmpty for common conditions
+- `PipelineExample.tsx` - Pipeline chaining, variable assignment, and helper functions
+- `HelperFunctionsExample.tsx` - Using helper functions in JSX attributes
+- `ChunkExample.tsx` - Array chunking for grid layouts
+
+## Data Structure
+
+Your Go data structure should match the variable names used in your template:
+
+```go
+type TemplateData struct {
+    UserName      string
+    IsLoggedIn    bool
+    IsPremium     bool
+    CartItems     []struct {
+        Name  string
+        Price string
+    }
+    RecentItems   []struct {
+        Title string
+        Date  string
+    }
+    HasRecentActivity bool
+    DashboardURL     string
+}
+```
+
+## Why This Approach?
+
+### The Problem
+Building email templates is hard:
+- **HTML emails** require compatibility across many email clients
+- **React Email** provides great components and Tailwind styling
+- **Go templates** provide powerful runtime parameterization
+
+### The Solution
+Use each tool for what it's best at:
+- **React + Tailwind** for design and styling
+- **Go templates** for runtime data and logic
+- **@lumeweb/rego** as the bridge
+
+This gives you:
+- ✅ Beautiful, styled emails using React Email
+- ✅ Powerful Go template features (conditionals, loops, functions)
+- ✅ Type-safe TypeScript development
+- ✅ Easy maintenance and iteration
+
+## License
+
+MIT

--- a/libs/rego/examples/ChunkExample.tsx
+++ b/libs/rego/examples/ChunkExample.tsx
@@ -1,0 +1,243 @@
+/**
+ * Example: Array Chunking
+ *
+ * Demonstrates how to use GoChunk to create grid layouts
+ * by splitting arrays into chunks of specified sizes.
+ */
+
+import React from "react";
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Row,
+  Section,
+  Text,
+} from "@react-email/components";
+import { GoChunk, GoComment, GoRange, GoVar } from "../src";
+
+export const ChunkExample: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Container style={container}>
+          <Heading as="h1" style={h1}>
+            Product Gallery
+          </Heading>
+
+          <GoComment>Display products in a 3-column grid layout</GoComment>
+
+          <GoChunk items="products" size="3" elementName="productRow">
+            <Section style={rowSection}>
+              <GoRange items="$productRow" elementName="product">
+                <Column style={columnStyle}>
+                  <div style={productCard}>
+                    <Heading as="h3" style={productTitle}>
+                      <GoVar name="$product.name" />
+                    </Heading>
+                    <Text style={productPrice}>
+                      <GoVar name="$product.price" />
+                    </Text>
+                  </div>
+                </Column>
+              </GoRange>
+            </Section>
+          </GoChunk>
+
+          <Hr style={hr} />
+
+          <Heading as="h1" style={h1}>
+            Team Members
+          </Heading>
+
+          <GoComment>Display team members in pairs (2 per row)</GoComment>
+
+          <GoChunk items="teamMembers" size="2" elementName="memberPair">
+            <Section style={rowSection}>
+              <GoRange items="$memberPair" elementName="member">
+                <Column style={columnStyle}>
+                  <div style={memberCard}>
+                    <Text style={memberName}>
+                      <GoVar name="$member.name" />
+                    </Text>
+                    <Text style={memberRole}>
+                      <GoVar name="$member.role" />
+                    </Text>
+                  </div>
+                </Column>
+              </GoRange>
+            </Section>
+          </GoChunk>
+
+          <Hr style={hr} />
+
+          <Heading as="h1" style={h1}>
+            Feature List
+          </Heading>
+
+          <GoComment>Display features in a 4-column grid</GoComment>
+
+          <GoChunk
+            items="features"
+            size="4"
+            elementName="featureRow"
+            indexName="rowIndex">
+            <Section style={rowSection}>
+              <Text style={rowLabel}>
+                Row <GoVar name="$rowIndex" />
+              </Text>
+              <Row>
+                <GoRange items="$featureRow" elementName="feature">
+                  <Column style={columnStyle}>
+                    <Text style={featureText}>
+                      <GoVar name="$feature.name" />
+                    </Text>
+                  </Column>
+                </GoRange>
+              </Row>
+            </Section>
+          </GoChunk>
+
+          <Hr style={hr} />
+
+          <Heading as="h1" style={h1}>
+            Categories with Items
+          </Heading>
+
+          <GoComment>Nested chunking: categories with chunked items</GoComment>
+
+          <GoRange items="categories" elementName="category">
+            <Section style={categorySection}>
+              <Heading as="h2" style={h2}>
+                <GoVar name="$category.name" />
+              </Heading>
+
+              <GoChunk items="$category.items" size="3" elementName="itemChunk">
+                <Row>
+                  <GoRange items="$itemChunk" elementName="item">
+                    <Column style={columnStyle}>
+                      <Text style={itemText}>
+                        <GoVar name="$item.name" />
+                      </Text>
+                    </Column>
+                  </GoRange>
+                </Row>
+              </GoChunk>
+            </Section>
+          </GoRange>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const container = {
+  maxWidth: "800px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const h1 = {
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "0 0 20px",
+  color: "#333",
+};
+
+const h2 = {
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0 10px",
+  color: "#333",
+};
+
+const rowSection = {
+  marginBottom: "20px",
+};
+
+const columnStyle = {
+  padding: "8px",
+};
+
+const productCard = {
+  padding: "16px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "8px",
+  textAlign: "center" as const,
+};
+
+const productTitle = {
+  fontSize: "16px",
+  fontWeight: "bold",
+  margin: "0 0 8px",
+  color: "#333",
+};
+
+const productPrice = {
+  fontSize: "14px",
+  color: "#666",
+  margin: "0",
+};
+
+const memberCard = {
+  padding: "12px",
+  backgroundColor: "#ffffff",
+  border: "1px solid #e6ebf1",
+  borderRadius: "8px",
+};
+
+const memberName = {
+  fontSize: "14px",
+  fontWeight: "bold",
+  margin: "0 0 4px",
+  color: "#333",
+};
+
+const memberRole = {
+  fontSize: "12px",
+  color: "#666",
+  margin: "0",
+};
+
+const rowLabel = {
+  fontSize: "12px",
+  color: "#8898aa",
+  margin: "0 0 8px",
+};
+
+const featureText = {
+  fontSize: "14px",
+  color: "#333",
+  padding: "8px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "4px",
+  textAlign: "center" as const,
+};
+
+const categorySection = {
+  marginBottom: "30px",
+  padding: "16px",
+  backgroundColor: "#ffffff",
+  border: "1px solid #e6ebf1",
+  borderRadius: "8px",
+};
+
+const itemText = {
+  fontSize: "13px",
+  color: "#666",
+  padding: "6px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "4px",
+  textAlign: "center" as const,
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "30px 0",
+};

--- a/libs/rego/examples/ConditionalHelpersExample.tsx
+++ b/libs/rego/examples/ConditionalHelpersExample.tsx
@@ -1,0 +1,256 @@
+/**
+ * Example: Conditional Helpers
+ *
+ * Demonstrates how to use GoEqual and GoEmpty
+ * to create conditional content in email templates.
+ */
+
+import React from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Text,
+} from "@react-email/components";
+import { GoDate, GoElse, GoEmpty, GoEqual, GoRange, GoVar } from "../src";
+
+export const ConditionalHelpersExample: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Container style={container}>
+          <Heading as="h1" style={h1}>
+            Account Status
+          </Heading>
+
+          {/* Check if user is premium */}
+          <GoEqual var1="subscriptionType" var2="premium">
+            <Text style={premiumText}>
+              🎉 You're a Premium member! Enjoy all exclusive features.
+            </Text>
+            <GoElse>
+              <Text style={standardText}>
+                You're on the Standard plan. Upgrade to unlock all features!
+              </Text>
+            </GoElse>
+          </GoEqual>
+
+          <Hr style={hr} />
+
+          {/* Check account status */}
+          <GoEqual var1="status" var2="active">
+            <Text style={activeText}>
+              ✓ Your account is active and in good standing.
+            </Text>
+            <GoElse>
+              <GoEqual var1="status" var2="suspended">
+                <Text style={warningText}>
+                  ⚠ Your account is suspended. Please contact support.
+                </Text>
+                <GoElse>
+                  <Text style={errorText}>
+                    ✗ Your account is inactive. Please reactivate your account.
+                  </Text>
+                </GoElse>
+              </GoEqual>
+            </GoElse>
+          </GoEqual>
+
+          <Hr style={hr} />
+
+          {/* Check if user has notifications */}
+          <GoEqual var1="hasNotifications" var2="true">
+            <Heading as="h2" style={h2}>
+              Notifications
+            </Heading>
+            <GoRange items="notifications" elementName="notif">
+              <Text style={notificationText}>
+                • <GoVar name="$notif.message" />
+              </Text>
+            </GoRange>
+            <GoElse>
+              <Text style={text}>No new notifications</Text>
+            </GoElse>
+          </GoEqual>
+
+          <Hr style={hr} />
+
+          {/* Check if cart is empty */}
+          <GoEqual var1="cartItemCount" var2="0">
+            <Text style={text}>Your shopping cart is empty.</Text>
+            <GoElse>
+              <Text style={text}>
+                You have <GoVar name="cartItemCount" /> items in your cart.
+              </Text>
+            </GoElse>
+          </GoEqual>
+
+          <Hr style={hr} />
+
+          {/* Check if recent activity exists */}
+          <GoEmpty var="recentActivity">
+            <Text style={text}>No recent activity to show.</Text>
+            <GoElse>
+              <Heading as="h2" style={h2}>
+                Recent Activity
+              </Heading>
+              <GoRange items="recentActivity" elementName="activity">
+                <Text style={activityText}>
+                  <GoDate var="$activity.date" format="Jan 2" />:{" "}
+                  <GoVar name="$activity.description" />
+                </Text>
+              </GoRange>
+            </GoElse>
+          </GoEmpty>
+
+          <Hr style={hr} />
+
+          {/* Check if user has a profile picture */}
+          <GoEmpty var="profilePicture">
+            <Text style={text}>
+              You haven't uploaded a profile picture yet.
+            </Text>
+            <GoElse>
+              <Text style={text}>Your profile picture looks great!</Text>
+            </GoElse>
+          </GoEmpty>
+
+          <Hr style={hr} />
+
+          {/* Check if user has completed onboarding */}
+          <GoEqual var1="onboardingComplete" var2="true">
+            <Text style={successText}>
+              ✓ You've completed onboarding. Start exploring!
+            </Text>
+            <GoElse>
+              <Text style={infoText}>
+                Complete your onboarding to get the most out of your account.
+              </Text>
+            </GoElse>
+          </GoEqual>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const container = {
+  maxWidth: "600px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const h1 = {
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "0 0 20px",
+  color: "#333",
+};
+
+const h2 = {
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0 10px",
+  color: "#333",
+};
+
+const text = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  color: "#333",
+};
+
+const premiumText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "12px 0",
+  padding: "12px",
+  backgroundColor: "#d4edda",
+  color: "#155724",
+  borderRadius: "4px",
+};
+
+const standardText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "12px 0",
+  padding: "12px",
+  backgroundColor: "#fff3cd",
+  color: "#856404",
+  borderRadius: "4px",
+};
+
+const activeText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  padding: "8px",
+  backgroundColor: "#d4edda",
+  color: "#155724",
+  borderRadius: "4px",
+};
+
+const warningText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  padding: "8px",
+  backgroundColor: "#fff3cd",
+  color: "#856404",
+  borderRadius: "4px",
+};
+
+const errorText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  padding: "8px",
+  backgroundColor: "#f8d7da",
+  color: "#721c24",
+  borderRadius: "4px",
+};
+
+const notificationText = {
+  fontSize: "14px",
+  lineHeight: "20px",
+  margin: "4px 0",
+  color: "#666",
+};
+
+const activityText = {
+  fontSize: "14px",
+  lineHeight: "20px",
+  margin: "6px 0",
+  color: "#666",
+};
+
+const successText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  padding: "8px",
+  backgroundColor: "#d4edda",
+  color: "#155724",
+  borderRadius: "4px",
+};
+
+const infoText = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  padding: "8px",
+  backgroundColor: "#d1ecf1",
+  color: "#0c5460",
+  borderRadius: "4px",
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};

--- a/libs/rego/examples/DataTransformationExample.tsx
+++ b/libs/rego/examples/DataTransformationExample.tsx
@@ -1,0 +1,171 @@
+/**
+ * Example: Data Transformation Helpers
+ *
+ * Demonstrates how to use GoDate, GoCurrency, and GoTruncate
+ * to format data in email templates.
+ */
+
+import React from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Text,
+} from "@react-email/components";
+import { GoCurrency, GoDate, GoRange, GoTruncate, GoVar } from "../src";
+
+export const DataTransformationExample: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Container style={container}>
+          <Heading as="h1" style={h1}>
+            Order Summary
+          </Heading>
+
+          <Text style={text}>
+            Order #<GoVar name="OrderNumber" />
+          </Text>
+
+          <Text style={text}>
+            Placed on: <GoDate var="orderDate" format="Jan 2, 2006" />
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Order items with formatted prices */}
+          <Heading as="h2" style={h2}>
+            Items
+          </Heading>
+
+          <GoRange items="Items" elementName="item">
+            <div style={itemRow}>
+              <div>
+                <Text style={itemName}>
+                  <GoVar name="$item.Name" />
+                </Text>
+                <Text style={itemDescription}>
+                  <GoTruncate var="$item.Description" length="60" />
+                </Text>
+              </div>
+              <Text style={itemPrice}>
+                <GoCurrency var="$item.Price" currency="USD" />
+              </Text>
+            </div>
+          </GoRange>
+
+          <Hr style={hr} />
+
+          {/* Order totals with formatted currency */}
+          <div style={totals}>
+            <Text style={totalRow}>
+              Subtotal: <GoCurrency var="subtotal" currency="USD" />
+            </Text>
+            <Text style={totalRow}>
+              Tax: <GoCurrency var="tax" currency="USD" />
+            </Text>
+            <Text style={totalRow}>
+              Shipping: <GoCurrency var="shipping" currency="USD" />
+            </Text>
+            <Text style={totalRow}>
+              <strong>
+                Total: <GoCurrency var="total" currency="USD" />
+              </strong>
+            </Text>
+          </div>
+
+          <Hr style={hr} />
+
+          {/* Additional dates */}
+          <Text style={text}>
+            Estimated delivery:{" "}
+            <GoDate var="estimatedDelivery" format="Jan 2, 2006" />
+          </Text>
+
+          <Text style={text}>
+            Order expires:{" "}
+            <GoDate var="expiresAt" format="Jan 2, 2006 at 3:04 PM" />
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const container = {
+  maxWidth: "600px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const h1 = {
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "0 0 20px",
+  color: "#333",
+};
+
+const h2 = {
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0",
+  color: "#333",
+};
+
+const text = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  color: "#333",
+};
+
+const itemRow = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  padding: "12px 0",
+  borderBottom: "1px solid #e6ebf1",
+};
+
+const itemName = {
+  fontSize: "16px",
+  fontWeight: "bold",
+  margin: "0 0 4px",
+  color: "#333",
+};
+
+const itemDescription = {
+  fontSize: "14px",
+  color: "#666",
+  margin: "0",
+};
+
+const itemPrice = {
+  fontSize: "16px",
+  fontWeight: "bold",
+  color: "#333",
+  minWidth: "100px",
+  textAlign: "right" as const,
+};
+
+const totals = {
+  marginTop: "20px",
+};
+
+const totalRow = {
+  fontSize: "14px",
+  lineHeight: "24px",
+  textAlign: "right" as const,
+  margin: "4px 0",
+  color: "#333",
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};

--- a/libs/rego/examples/HelperFunctionsExample.tsx
+++ b/libs/rego/examples/HelperFunctionsExample.tsx
@@ -1,0 +1,384 @@
+/**
+ * Example: Helper Functions in JSX Attributes
+ *
+ * This example demonstrates how to use helper functions (goVar, goUrl, goDate, etc.)
+ * to embed Go template syntax in JSX attributes where React components can't be used.
+ *
+ * Helper functions return strings containing Go template syntax, which is perfect
+ * for use in attributes like href, src, alt, title, data-attributes, etc.
+ */
+
+import React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Image,
+  Link,
+  Section,
+  Text,
+} from "@react-email/components";
+import {
+  GoRange,
+  goCurrency,
+  goDate,
+  goFieldVar,
+  goFunc,
+  goLocalVar,
+  goUrl,
+  goVar,
+} from "../src";
+
+export const HelperFunctionsExample: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Container style={container}>
+          <Heading as="h1" style={h1}>
+            Helper Functions Demo
+          </Heading>
+
+          <Text style={text}>
+            Helper functions allow you to use Go template syntax in JSX
+            attributes where components can't be used.
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* goVar - Variable interpolation in attributes */}
+          <Heading as="h2" style={h2}>
+            goVar() - Variable Interpolation
+          </Heading>
+
+          <Text style={text}>
+            Profile image from user's avatar URL:
+          </Text>
+
+          <Section style={imageSection}>
+            <Image
+              src={goVar("user.avatarUrl")}
+              alt="User avatar"
+              width="80"
+              height="80"
+              style={avatarImage}
+            />
+          </Section>
+
+          <Text style={text}>
+            <Button style={button} href={goVar("dashboardUrl")}>
+              Go to Dashboard
+            </Button>
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* goLocalVar - Local variables in attributes */}
+          <Heading as="h2" style={h2}>
+            goLocalVar() - Local Variables
+          </Heading>
+
+          <Text style={text}>
+            Product links using loop variables:
+          </Text>
+
+          <GoRange items="products" elementName="product">
+            <Section style={productSection}>
+              <Text style={productName}>
+                {goLocalVar("product.name")}
+              </Text>
+              <Text style={text}>
+                <Link href={goLocalVar("product.url")} style={linkStyle}>
+                  View Product
+                </Link>
+              </Text>
+              <Text style={priceText}>
+                {goCurrency("$product.price", "USD")}
+              </Text>
+            </Section>
+          </GoRange>
+
+          <Hr style={hr} />
+
+          {/* goUrl - URL generation with query parameters */}
+          <Heading as="h2" style={h2}>
+            goUrl() - URL Generation
+          </Heading>
+
+          <Text style={text}>
+            Simple path:
+          </Text>
+          <Text style={text}>
+            <Link href={goUrl("/dashboard")} style={linkStyle}>
+              Dashboard
+            </Link>
+          </Text>
+
+          <Text style={text}>
+            Variable path with query params:
+          </Text>
+          <Text style={text}>
+            <Link
+              href={goUrl({
+                var: "profileUrl",
+                params: ["ref", "source"],
+              })}
+              style={linkStyle}>
+              Profile
+            </Link>
+          </Text>
+
+          <Text style={text}>
+            Path with literal values:
+          </Text>
+          <Text style={text}>
+            <Link
+              href={goUrl({
+                path: "/reset-password",
+                params: ["token", "email"],
+                literalValues: ["resetToken", ""],
+              })}
+              style={linkStyle}>
+              Reset Password
+            </Link>
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* goDate - Date formatting */}
+          <Heading as="h2" style={h2}>
+            goDate() - Date Formatting
+          </Heading>
+
+          <Text style={text}>
+            Order placed: {goDate("orderDate", "Jan 2, 2006")}
+          </Text>
+
+          <Text style={text}>
+            Due by: {goDate("dueDate", "Jan 2, 2006 at 3:04 PM")}
+          </Text>
+
+          <Text style={text}>
+            Expires: {goDate("expiresAt", "2006-01-02")}
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* goCurrency - Currency formatting */}
+          <Heading as="h2" style={h2}>
+            goCurrency() - Currency Formatting
+          </Heading>
+
+          <Text style={text}>
+            Subtotal: {goCurrency("subtotal", "USD")}
+          </Text>
+
+          <Text style={text}>
+            Tax: {goCurrency("tax", "USD")}
+          </Text>
+
+          <Text style={text}>
+            Total: {goCurrency("total", "USD")}
+          </Text>
+
+          <Text style={text}>
+            EUR Total: {goCurrency("totalEur", "EUR")}
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* goFunc - Custom function calls */}
+          <Heading as="h2" style={h2}>
+            goFunc() - Custom Functions
+          </Heading>
+
+          <Text style={text}>
+            Item count:{" "}
+            {goFunc("pluralize", {
+              var: "itemCount",
+              args: ["item", "items"],
+            })}
+          </Text>
+
+          <Text style={text}>
+            Subscription status:{" "}
+            {goFunc("formatSubscription", {
+              var: "subscriptionType",
+            })}
+          </Text>
+
+          <Text style={text}>
+            Full name:{" "}
+            {goFunc("formatFullName", {
+              vars: ["firstName", "lastName"],
+            })}
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* goFieldVar - Field access helper */}
+          <Heading as="h2" style={h2}>
+            goFieldVar() - Field Access
+          </Heading>
+
+          <Text style={text}>
+            Always uses field access (with dot prefix):
+          </Text>
+
+          <Text style={text}>
+            <Link href={goFieldVar("settingsUrl")} style={linkStyle}>
+              Settings
+            </Link>
+          </Text>
+
+          <Text style={text}>
+            <Link href={goFieldVar("helpUrl")} style={linkStyle}>
+              Help
+            </Link>
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Combined usage */}
+          <Heading as="h2" style={h2}>
+            Combined Usage
+          </Heading>
+
+          <Text style={text}>
+            Product cards with multiple helper functions:
+          </Text>
+
+          <GoRange items="featuredProducts" elementName="product">
+            <Section style={productCard}>
+              <Image
+                src={goLocalVar("product.imageUrl")}
+                alt={goLocalVar("product.name")}
+                width="200"
+                height="150"
+                style={productImage}
+              />
+              <Text style={productName}>
+                {goLocalVar("product.name")}
+              </Text>
+              <Text style={text}>
+                {goLocalVar("product.description")}
+              </Text>
+              <Text style={priceText}>
+                {goCurrency("$product.price", "USD")}
+              </Text>
+              <Button
+                style={button}
+                href={goLocalVar("product.url")}
+                width="100%">
+                Buy Now
+              </Button>
+            </Section>
+          </GoRange>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const container = {
+  maxWidth: "600px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const h1 = {
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "0 0 20px",
+  color: "#333",
+};
+
+const h2 = {
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0 10px",
+  color: "#333",
+};
+
+const text = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  color: "#333",
+};
+
+const imageSection = {
+  padding: "20px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "8px",
+  marginBottom: "16px",
+};
+
+const avatarImage = {
+  borderRadius: "50%",
+  border: "3px solid #5469d4",
+};
+
+const productSection = {
+  padding: "16px",
+  backgroundColor: "#ffffff",
+  border: "1px solid #e6ebf1",
+  borderRadius: "8px",
+  marginBottom: "12px",
+};
+
+const productName = {
+  fontSize: "16px",
+  fontWeight: "bold",
+  margin: "0 0 8px",
+  color: "#333",
+};
+
+const priceText = {
+  fontSize: "16px",
+  fontWeight: "bold",
+  color: "#5469d4",
+  margin: "8px 0",
+};
+
+const linkStyle = {
+  color: "#5469d4",
+  textDecoration: "underline",
+};
+
+const button = {
+  backgroundColor: "#5469d4",
+  borderRadius: "4px",
+  color: "#fff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+  fontSize: "16px",
+  fontWeight: "bold",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  padding: "12px 24px",
+};
+
+const productCard = {
+  padding: "20px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "8px",
+  marginBottom: "20px",
+  textAlign: "center" as const,
+};
+
+const productImage = {
+  borderRadius: "8px",
+  marginBottom: "12px",
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "30px 0",
+};

--- a/libs/rego/examples/OrderConfirmation.tsx
+++ b/libs/rego/examples/OrderConfirmation.tsx
@@ -1,0 +1,236 @@
+/**
+ * Example: Order Confirmation Email Template
+ *
+ * Demonstrates more advanced usage including:
+ * - GoWith for context switching
+ * - Nested conditionals and loops
+ * - Complex data structures
+ */
+
+import React from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Text,
+} from "@react-email/components";
+import { GoIf, GoRange, GoVar, GoWith } from "../src";
+
+export const OrderConfirmationEmail: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body style={main}>
+        <Container style={container}>
+          <Heading as="h1" style={h1}>
+            Order Confirmation
+          </Heading>
+
+          <Text style={text}>
+            Thank you for your order, <GoVar name="CustomerName" />!
+          </Text>
+
+          <Text style={text}>
+            Order #: <GoVar name="OrderNumber" />
+          </Text>
+
+          <Text style={text}>
+            Order Date: <GoVar name="OrderDate" />
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Use GoWith to switch to order context */}
+          <GoWith value="Order" fallback="Order details not available">
+            <Heading as="h2" style={h2}>
+              Order Details
+            </Heading>
+
+            {/* Shipping address */}
+            <Text style={label}>Shipping Address:</Text>
+            <GoWith value="ShippingAddress">
+              <Text style={address}>
+                <GoVar name="Name" />
+                <br />
+                <GoVar name="Street" />
+                <br />
+                <GoVar name="City" />, <GoVar name="State" />{" "}
+                <GoVar name="Zip" />
+              </Text>
+            </GoWith>
+
+            <Hr style={hr} />
+
+            {/* Order items */}
+            <Heading as="h2" style={h2}>
+              Items
+            </Heading>
+
+            <GoRange items="Items" elementName="item">
+              <div style={itemRow}>
+                <Text style={itemQty}>
+                  x<GoVar name="$item.Quantity" />
+                </Text>
+                <Text style={itemDetails}>
+                  <GoVar name="$item.ProductName" />
+                  <GoIf condition="$item.Variant">
+                    <Text style={itemVariant}>
+                      {" "}
+                      (<GoVar name="$item.Variant" />)
+                    </Text>
+                  </GoIf>
+                </Text>
+                <Text style={itemPrice}>
+                  $<GoVar name="$item.Price" />
+                </Text>
+              </div>
+            </GoRange>
+
+            <Hr style={hr} />
+
+            {/* Order totals */}
+            <div style={totals}>
+              <Text style={totalRow}>
+                Subtotal: <GoVar name="Subtotal" />
+              </Text>
+              <GoIf condition="HasDiscount">
+                <Text style={totalRow}>
+                  Discount: <GoVar name="Discount" />
+                </Text>
+              </GoIf>
+              <Text style={totalRow}>
+                Shipping: <GoVar name="Shipping" />
+              </Text>
+              <Text style={totalRow}>
+                Tax: <GoVar name="Tax" />
+              </Text>
+              <Text style={totalRow}>
+                <strong>
+                  Total: <GoVar name="Total" />
+                </strong>
+              </Text>
+            </div>
+          </GoWith>
+
+          <Hr style={hr} />
+
+          <Text style={footer}>
+            If you have any questions about your order, please contact our
+            support team.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const main = {
+  backgroundColor: "#f6f9fc",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+};
+
+const container = {
+  backgroundColor: "#ffffff",
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  marginBottom: "64px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "30px 0",
+  textAlign: "center" as const,
+};
+
+const h2 = {
+  color: "#333",
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0",
+};
+
+const text = {
+  color: "#333",
+  fontSize: "16px",
+  lineHeight: "26px",
+  margin: "8px 0",
+};
+
+const label = {
+  color: "#666",
+  fontSize: "14px",
+  fontWeight: "bold",
+  margin: "8px 0",
+};
+
+const address = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "20px",
+  margin: "4px 0",
+};
+
+const itemRow = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "12px 0",
+  borderBottom: "1px solid #e6ebf1",
+};
+
+const itemQty = {
+  color: "#666",
+  fontSize: "14px",
+  minWidth: "40px",
+};
+
+const itemDetails = {
+  color: "#333",
+  fontSize: "14px",
+  flex: 1,
+  padding: "0 16px",
+};
+
+const itemVariant = {
+  color: "#666",
+  fontSize: "12px",
+};
+
+const itemPrice = {
+  color: "#333",
+  fontSize: "14px",
+  fontWeight: "bold",
+  minWidth: "80px",
+  textAlign: "right" as const,
+};
+
+const totals = {
+  marginTop: "20px",
+};
+
+const totalRow = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  textAlign: "right" as const,
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};
+
+const footer = {
+  color: "#8898aa",
+  fontSize: "12px",
+  lineHeight: "16px",
+  textAlign: "center" as const,
+  marginTop: "32px",
+};

--- a/libs/rego/examples/PipelineExample.tsx
+++ b/libs/rego/examples/PipelineExample.tsx
@@ -1,0 +1,336 @@
+/**
+ * Example: Pipeline Chaining and Variable Assignment
+ *
+ * Demonstrates how to use GoPipe, GoLet, GoFormat, and GoFunc
+ * to create complex data transformations and variable assignments.
+ *
+ * Also demonstrates using helper functions (goVar, goUrl, etc.)
+ * in JSX attributes where components can't be used.
+ */
+
+import React from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Text,
+} from "@react-email/components";
+import {
+  GoComment,
+  GoFormat,
+  GoFunc,
+  GoLet,
+  GoLowerCase,
+  GoPipe,
+  GoRange,
+  GoTrim,
+  GoTruncate,
+  GoUpperCase,
+  GoUrl,
+  GoVar,
+  goCurrency,
+  goDate,
+  goFunc,
+  goLocalVar,
+  goUrl,
+  goVar,
+} from "../src";
+
+export const PipelineExample: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Container style={container}>
+          <Heading as="h1" style={h1}>
+            User Dashboard
+          </Heading>
+
+          <GoComment>
+            This section displays user information with formatted data
+          </GoComment>
+
+          {/* Assign display name using format */}
+          <GoLet name="displayName">
+            <GoFormat format="%s %s">
+              <GoVar name="user.firstName" />
+              <GoVar name="user.lastName" />
+            </GoFormat>
+          </GoLet>
+
+          <Text style={text}>
+            Welcome back, <GoVar name="$displayName" />!
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Process user bio with pipeline */}
+          <GoComment>User bio is truncated and trimmed</GoComment>
+          <GoLet name="shortBio">
+            <GoPipe>
+              <GoVar name="user.bio" />
+              <GoTruncate length="150" />
+              <GoTrim />
+            </GoPipe>
+          </GoLet>
+
+          <Text style={text}>
+            <strong>About:</strong> <GoVar name="$shortBio" />
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Format email with lowercase */}
+          <GoLet name="normalizedEmail">
+            <GoPipe>
+              <GoVar name="user.email" />
+              <GoLowerCase />
+            </GoPipe>
+          </GoLet>
+
+          <Text style={text}>
+            Email: <GoVar name="$normalizedEmail" />
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Use custom function for subscription status */}
+          <GoComment>Custom function to format subscription status</GoComment>
+          <Text style={text}>
+            Subscription:{" "}
+            <GoFunc name="formatSubscription" var="user.subscriptionType" />
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Process recent items with complex transformations */}
+          <Heading as="h2" style={h2}>
+            Recent Items
+          </Heading>
+
+          <GoRange items="recentItems" elementName="item" indexName="idx">
+            <div style={itemRow}>
+              <Text style={itemNumber}>
+                <GoVar name="$idx" />.
+              </Text>
+
+              <div style={itemContent}>
+                {/* Title: uppercase and truncated */}
+                <GoLet name="itemTitle">
+                  <GoPipe>
+                    <GoVar name="$item.title" />
+                    <GoUpperCase />
+                  </GoPipe>
+                </GoLet>
+
+                <Text style={itemTitle}>
+                  <GoVar name="$itemTitle" />
+                </Text>
+
+                {/* Description: truncated */}
+                <GoLet name="itemDesc">
+                  <GoPipe>
+                    <GoVar name="$item.description" />
+                    <GoTruncate length="80" />
+                  </GoPipe>
+                </GoLet>
+
+                <Text style={itemDescription}>
+                  <GoVar name="$itemDesc" />
+                </Text>
+              </div>
+
+              {/* Price formatted with custom function */}
+              <Text style={itemPrice}>
+                <GoFunc
+                  name="formatCurrency"
+                  var="$item.price"
+                  args={["USD"]}
+                />
+              </Text>
+            </div>
+          </GoRange>
+
+          <Hr style={hr} />
+
+          {/* Use pluralize function */}
+          <Text style={text}>
+            You have{" "}
+            <GoFunc name="pluralize" var="itemCount" args={["item", "items"]} />{" "}
+            in your cart.
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Format date with custom function */}
+          <Text style={text}>
+            Last login:{" "}
+            <GoFunc
+              name="formatDateTime"
+              vars={["lastLogin"]}
+              args={["Jan 2, 2006", "3:04 PM"]}
+            />
+          </Text>
+
+          <Hr style={hr} />
+
+          {/* Simple variable reference */}
+          <GoLet name="settingsUrl" value="settingsUrl">
+            <Text style={text}>
+              <Link href={goLocalVar("settingsUrl")} style={linkStyle}>
+                Manage your settings
+              </Link>
+            </Text>
+          </GoLet>
+
+          <Hr style={hr} />
+
+          <GoComment>
+            Helper functions allow using Go template syntax in JSX attributes
+          </GoComment>
+
+          {/* URL generation with query parameters */}
+          <GoComment>Generate URLs with query parameters</GoComment>
+
+          <Text style={text}>
+            <Link href={goUrl("/dashboard")} style={linkStyle}>
+              Go to Dashboard
+            </Link>
+          </Text>
+
+          <Text style={text}>
+            <Link
+              href={goUrl({ path: "/verify", params: ["token", "email"] })}
+              style={linkStyle}>
+              Verify Email
+            </Link>
+          </Text>
+
+          <Text style={text}>
+            <Link
+              href={goUrl({ var: "profileUrl", params: ["id", "tab"] })}
+              style={linkStyle}>
+              View Profile
+            </Link>
+          </Text>
+
+          <Text style={text}>
+            <Link
+              href={
+                goUrl({
+                  path: "/search",
+                  params: ["q", "page"],
+                  literalValues: ["", "1"]
+                })
+              }
+              style={linkStyle}>
+              Search Results
+            </Link>
+          </Text>
+
+          <Hr style={hr} />
+
+          <GoComment>
+            Using helper functions for inline template syntax in text
+          </GoComment>
+
+          <Text style={text}>
+            Profile: {goVar("userName")}
+          </Text>
+
+          <Text style={text}>
+            Due date: {goDate("dueDate", "Jan 2, 2006")}
+          </Text>
+
+          <Text style={text}>
+            Total: {goCurrency("total", "USD")}
+          </Text>
+
+          <Text style={text}>
+            Items: {goFunc("pluralize", { var: "itemCount", args: ["item", "items"] })}
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const container = {
+  maxWidth: "600px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const h1 = {
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "0 0 20px",
+  color: "#333",
+};
+
+const h2 = {
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0 10px",
+  color: "#333",
+};
+
+const text = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "8px 0",
+  color: "#333",
+};
+
+const itemRow = {
+  display: "flex",
+  gap: "12px",
+  padding: "12px 0",
+  borderBottom: "1px solid #e6ebf1",
+};
+
+const itemNumber = {
+  fontSize: "14px",
+  color: "#666",
+  minWidth: "30px",
+};
+
+const itemContent = {
+  flex: 1,
+};
+
+const itemTitle = {
+  fontSize: "14px",
+  fontWeight: "bold",
+  margin: "0 0 4px",
+  color: "#333",
+};
+
+const itemDescription = {
+  fontSize: "12px",
+  color: "#666",
+  margin: "0",
+};
+
+const itemPrice = {
+  fontSize: "14px",
+  fontWeight: "bold",
+  color: "#333",
+  minWidth: "80px",
+  textAlign: "right" as const,
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};
+
+const linkStyle = {
+  color: "#5469d4",
+  textDecoration: "underline",
+};

--- a/libs/rego/examples/TemplateCompositionExample.tsx
+++ b/libs/rego/examples/TemplateCompositionExample.tsx
@@ -1,0 +1,162 @@
+/**
+ * Example: Template Composition
+ *
+ * Demonstrates how to use GoDefine, GoUseTemplate, and GoBlock
+ * to create reusable email components and layouts.
+ */
+
+import React from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Text,
+} from "@react-email/components";
+import {
+  GoBlock,
+  GoDate,
+  GoDefine,
+  GoRange,
+  GoUseTemplate,
+  GoVar,
+} from "../src";
+
+export const TemplateCompositionExample: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        {/* Define reusable components */}
+        <GoDefine name="email-header">
+          <Container style={headerContainer}>
+            <Heading as="h2" style={headerHeading}>
+              <GoVar name="CompanyName" />
+            </Heading>
+            <Text style={headerText}>Your trusted partner</Text>
+          </Container>
+        </GoDefine>
+
+        <GoDefine name="email-footer">
+          <Container style={footerContainer}>
+            <Hr style={hr} />
+            <Text style={footerText}>
+              © <GoDate var="now" format="2006" /> <GoVar name="CompanyName" />.
+              All rights reserved.
+            </Text>
+            <Text style={footerText}>
+              <GoVar name="SupportEmail" />
+            </Text>
+          </Container>
+        </GoDefine>
+
+        {/* Main email content */}
+        <Container style={mainContainer}>
+          {/* Use the header template */}
+          <GoUseTemplate name="email-header" />
+
+          <Heading as="h1" style={h1}>
+            Welcome!
+          </Heading>
+
+          <Text style={text}>
+            Hello <GoVar name="UserName" />,
+          </Text>
+
+          <Text style={text}>
+            Thank you for joining us. We're excited to have you on board.
+          </Text>
+
+          {/* Block that can be overridden in child templates */}
+          <GoBlock name="main-content">
+            <Text style={text}>
+              This is the default content. You can override this in child
+              templates.
+            </Text>
+          </GoBlock>
+
+          {/* Show recent items if available */}
+          <GoRange
+            items="RecentItems"
+            elementName="item"
+            indexName="idx"
+            empty={<Text style={text}>No recent items</Text>}>
+            <Text style={itemText}>
+              <GoVar name="$idx" />. <GoVar name="$item.Title" />
+            </Text>
+          </GoRange>
+
+          {/* Use the footer template */}
+          <GoUseTemplate name="email-footer" />
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const mainContainer = {
+  maxWidth: "600px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const headerContainer = {
+  padding: "20px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "8px",
+  marginBottom: "20px",
+};
+
+const headerHeading = {
+  margin: "0",
+  fontSize: "20px",
+  fontWeight: "bold",
+  color: "#333",
+};
+
+const headerText = {
+  margin: "8px 0 0",
+  fontSize: "14px",
+  color: "#666",
+};
+
+const h1 = {
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "0 0 20px",
+  color: "#333",
+};
+
+const text = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "0 0 16px",
+  color: "#333",
+};
+
+const itemText = {
+  fontSize: "14px",
+  margin: "8px 0",
+  color: "#666",
+};
+
+const footerContainer = {
+  marginTop: "40px",
+  padding: "20px",
+  backgroundColor: "#f6f9fc",
+  borderRadius: "8px",
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};
+
+const footerText = {
+  fontSize: "12px",
+  color: "#8898aa",
+  margin: "4px 0",
+};

--- a/libs/rego/examples/WelcomeEmail.tsx
+++ b/libs/rego/examples/WelcomeEmail.tsx
@@ -1,0 +1,173 @@
+/**
+ * Example: Welcome Email Template
+ *
+ * This demonstrates how to use the React-to-Go Template DSL
+ * to create an email that can be rendered by Go at runtime.
+ */
+
+import React from "react";
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Text,
+} from "@react-email/components";
+import { GoElse, GoIf, GoRange, GoVar, goVar } from "../src";
+
+export const WelcomeEmail: React.FC = () => {
+  return (
+    <Html>
+      <Head />
+      <Body style={main}>
+        <Container style={container}>
+          {/* Logo or branding */}
+          <Text style={logo}>Welcome to Our App!</Text>
+
+          <Heading as="h1" style={h1}>
+            Hello, <GoVar name="UserName" />!
+          </Heading>
+
+          <Text style={text}>
+            Thank you for signing up. We're excited to have you on board.
+          </Text>
+
+          {/* Conditional content based on user type */}
+          <GoIf condition="IsPremium">
+            <Text style={premiumText}>
+              🎉 You're a premium member! Enjoy all the exclusive features.
+            </Text>
+            <GoElse>
+              <Text style={text}>
+                Upgrade to premium to unlock all features.
+              </Text>
+            </GoElse>
+          </GoIf>
+
+          {/* Show recent activity if available */}
+          <GoIf condition="HasRecentActivity">
+            <Hr style={hr} />
+            <Heading as="h2" style={h2}>
+              Recent Activity
+            </Heading>
+            <GoRange
+              items="RecentItems"
+              elementName="item"
+              indexName="idx"
+              empty={<Text style={text}>No recent activity</Text>}>
+              <Text style={itemText}>
+                <GoVar name="$idx" />. <GoVar name="$item.Title" /> -{" "}
+                <GoVar name="$item.Date" />
+              </Text>
+            </GoRange>
+          </GoIf>
+
+          <Hr style={hr} />
+
+          {/* Action button */}
+          <Button style={button} href={goVar("DashboardURL")}>
+            Go to Dashboard
+          </Button>
+
+          <Text style={footer}>
+            If you have any questions, just reply to this email.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+// Styles
+const main = {
+  backgroundColor: "#f6f9fc",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+};
+
+const container = {
+  backgroundColor: "#ffffff",
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  marginBottom: "64px",
+};
+
+const logo = {
+  margin: "0 auto",
+  fontSize: "24px",
+  fontWeight: "bold",
+  textAlign: "center" as const,
+  color: "#333",
+};
+
+const h1 = {
+  color: "#333",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "30px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const h2 = {
+  color: "#333",
+  fontSize: "18px",
+  fontWeight: "bold",
+  margin: "20px 0",
+};
+
+const text = {
+  color: "#333",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+  fontSize: "16px",
+  lineHeight: "26px",
+  textAlign: "left" as const,
+};
+
+const premiumText = {
+  ...text,
+  backgroundColor: "#fff3cd",
+  padding: "12px",
+  borderRadius: "4px",
+  margin: "16px 0",
+};
+
+const itemText = {
+  ...text,
+  fontSize: "14px",
+  margin: "8px 0",
+};
+
+const button = {
+  backgroundColor: "#5469d4",
+  borderRadius: "4px",
+  color: "#fff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+  fontSize: "16px",
+  fontWeight: "bold",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  width: "100%",
+  padding: "12px",
+};
+
+const hr = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};
+
+const footer = {
+  color: "#8898aa",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+  fontSize: "12px",
+  lineHeight: "16px",
+};

--- a/libs/rego/package.json
+++ b/libs/rego/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@lumeweb/rego",
+  "version": "0.0.0",
+  "description": "React components that compile to Go templates for email generation - combining React/Tailwind DX with Go native templating",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "lint": "tsc --noEmit",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@lumeweb/tsdown-config": "workspace:*",
+    "@react-email/preview-server": "5.2.2",
+    "react-email": "5.2.2",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "dependencies": {
+    "@react-email/components": "1.0.4",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}

--- a/libs/rego/src/GoBlock.tsx
+++ b/libs/rego/src/GoBlock.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+/**
+ * GoBlock - Template block component
+ *
+ * Defines a template block that can be overridden in child templates
+ * Combines define and template invocation: {{block "name" .}}...{{end}}
+ *
+ * @example
+ * <GoBlock name="email-content">
+ *   <Text>Default content</Text>
+ * </GoBlock>
+ * // Outputs: {{block "email-content" .}}<Text>Default content</Text>{{end}}
+ *
+ * @example with override in child template
+ * // In base template:
+ * <GoBlock name="email-content">
+ *   <Text>Default content</Text>
+ * </GoBlock>
+ *
+ * // In child template:
+ * <GoDefine name="email-content">
+ *   <Text>Custom content</Text>
+ * </GoDefine>
+ * <GoUseTemplate name="base-template" />
+ */
+export interface GoBlockProps {
+  /** Block name for override */
+  name: string;
+  /** Optional context to pass (defaults to current dot) */
+  context?: string;
+  /** Content of the block */
+  children: React.ReactNode;
+}
+
+export const GoBlock: React.FC<GoBlockProps> = ({
+  name,
+  context,
+  children,
+}) => {
+  if (context) {
+    // Remove leading dot if present
+    const contextSyntax = context.startsWith('.') ? context : '.' + context;
+    return (
+      <>
+        {'{{block "' + name + '" ' + contextSyntax + "}}"}
+        {children}
+        {"{{end}}"}
+      </>
+    );
+  }
+  return (
+    <>
+      {'{{block "' + name + '" .}}'}
+      {children}
+      {"{{end}}"}
+    </>
+  );
+};

--- a/libs/rego/src/GoChunk.tsx
+++ b/libs/rego/src/GoChunk.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { generateChunkSyntax } from "./template-generators";
+
+/**
+ * GoChunk - Array chunking component
+ *
+ * Splits an array into chunks of a specified size using Go template syntax
+ * Useful for creating grid layouts (e.g., 3 items per row)
+ *
+ * @example
+ * <GoChunk items="items" size="3" elementName="chunk" indexName="chunkIndex">
+ *   <Row>
+ *     <GoRange items="$chunk" elementName="item">
+ *       <Column>
+ *         <Text><GoVar name="$item.name" /></Text>
+ *       </Column>
+ *     </GoRange>
+ *   </Row>
+ * </GoChunk>
+ * // Outputs: {{$chunkIndex, $chunk := chunk .Items 3}}
+ * //         <Row>{{range $item := $chunk}}<Column><Text>{{$item.Name}}</Text></Column>{{end}}</Row>
+ *
+ * @example without index
+ * <GoChunk items="products" size="2" elementName="productRow">
+ *   <div style="row">
+ *     <GoRange items="$productRow" elementName="product">
+ *       <div style="col">
+ *         <Text><GoVar name="$product.name" /></Text>
+ *       </div>
+ *     </GoRange>
+ *   </div>
+ * </GoChunk>
+ * // Outputs: {{$productRow := chunk .Products 2}}
+ * //         <div style="row">{{range $product := $productRow}}<div style="col"><Text>{{$product.Name}}</Text></div>{{end}}</div>
+ *
+ * @note
+ * The chunk function must be registered in Go:
+ *
+ * **Option 1: Using `any` (Go 1.18+)**
+ *   funcMap := template.FuncMap{
+ *     "chunk": chunk,
+ *   }
+ *
+ *   func chunk(slice any, size int) [][]any {
+ *     v := reflect.ValueOf(slice)
+ *     if v.Kind() != reflect.Slice {
+ *       return nil
+ *     }
+ *
+ *     length := v.Len()
+ *     var result [][]any
+ *
+ *     for i := 0; i < length; i += size {
+ *       end := i + size
+ *       if end > length {
+ *         end = length
+ *       }
+ *
+ *       var chunk []any
+ *       for j := i; j < end; j++ {
+ *         chunk = append(chunk, v.Index(j).Interface())
+ *       }
+ *       result = append(result, chunk)
+ *     }
+ *
+ *     return result
+ *   }
+ *
+ * **Option 2: Using `samber/lo` library**
+ *   import "github.com/samber/lo"
+ *
+ *   funcMap := template.FuncMap{
+ *     "chunk": chunk,
+ *   }
+ *
+ *   func chunk(slice any, size int) [][]any {
+ *     return lo.Chunk(slice, size)
+ *   }
+ */
+export interface GoChunkProps {
+  /** Variable name of the array to chunk */
+  items: string;
+  /** Size of each chunk */
+  size: number;
+  /** Optional: name for the chunk element variable (e.g., "chunk") */
+  elementName: string;
+  /** Optional: name for the chunk index variable (e.g., "chunkIndex") */
+  indexName?: string;
+  /** Content to render for each chunk */
+  children: React.ReactNode;
+}
+
+export const GoChunk: React.FC<GoChunkProps> = ({
+  items,
+  size,
+  elementName,
+  indexName,
+  children,
+}) => {
+  return (
+    <>
+      {generateChunkSyntax(items, size, elementName, indexName)}
+      {children}
+    </>
+  );
+};

--- a/libs/rego/src/GoComment.tsx
+++ b/libs/rego/src/GoComment.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { generateCommentSyntax } from "./template-generators";
+
+/**
+ * GoComment - Template comment component
+ *
+ * Adds comments to Go templates that are ignored during execution
+ * Outputs Go template comment syntax that is ignored during execution
+ *
+ * @example
+ * <GoComment>This section shows user profile information</GoComment>
+ * // Outputs template comment syntax
+ *
+ * @example multiline
+ * <GoComment>
+ *   This is a longer comment
+ *   that spans multiple lines
+ * </GoComment>
+ * // Outputs template comment syntax
+ *
+ * @note
+ * Comments are completely ignored by Go during template execution.
+ * They're useful for documentation and debugging.
+ */
+export interface GoCommentProps {
+  /** Comment text */
+  children: React.ReactNode;
+}
+
+export const GoComment: React.FC<GoCommentProps> = ({ children }) => {
+  // Convert children to string
+  const text = React.Children.toArray(children).join(" ");
+
+  return <>{generateCommentSyntax(text)}</>;
+};

--- a/libs/rego/src/GoCurrency.tsx
+++ b/libs/rego/src/GoCurrency.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { generateCurrencySyntax } from "./template-generators";
+
+/**
+ * GoCurrency - Currency formatting component
+ *
+ * Formats a number as currency using Go template pipeline syntax
+ * Outputs: {{.Total | formatCurrency "USD"}}
+ *
+ * @example
+ * <GoCurrency var="total" currency="USD" />
+ * // Outputs: {{.Total | formatCurrency "USD"}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoCurrency var="$item.price" currency="USD" />
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{$item.Price | formatCurrency "USD"}}{{end}}
+ *
+ * @note
+ * The formatCurrency function must be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "formatCurrency": formatCurrency,
+ *   }
+ *
+ *   func formatCurrency(amount float64, currency string) string {
+ *     return fmt.Sprintf("%s %.2f", currency, amount)
+ *   }
+ */
+export interface GoCurrencyProps {
+  /** Variable name containing the amount */
+  var: string;
+  /** Currency code (e.g., "USD", "EUR", "GBP") */
+  currency: string;
+}
+
+export const GoCurrency: React.FC<GoCurrencyProps> = ({
+  var: varName,
+  currency,
+}) => {
+  return <>{generateCurrencySyntax(varName, currency)}</>;
+};
+
+/**
+ * Helper function to get Go template currency formatting syntax as a string
+ * Useful for use in JSX attributes where components can't be used
+ *
+ * @example
+ * <Text>Total: {goCurrency("total", "USD")}</Text>
+ * // Outputs: Total: {{.Total | formatCurrency "USD"}}
+ */
+export function goCurrency(varName: string, currency: string): string {
+  return generateCurrencySyntax(varName, currency);
+}

--- a/libs/rego/src/GoDate.tsx
+++ b/libs/rego/src/GoDate.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { generateDateSyntax } from "./template-generators";
+
+/**
+ * GoDate - Date formatting component
+ *
+ * Formats a date variable using Go template pipeline syntax
+ * Outputs: {{.Date | formatDate "Jan 2, 2006"}}
+ *
+ * @example
+ * <GoDate var="createdAt" format="Jan 2, 2006" />
+ * // Outputs: {{.CreatedAt | formatDate "Jan 2, 2006"}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoDate var="$item.createdAt" format="Jan 2, 2006" />
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{$item.CreatedAt | formatDate "Jan 2, 2006"}}{{end}}
+ *
+ * @note
+ * The formatDate function must be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "formatDate": formatDate,
+ *   }
+ *
+ *   func formatDate(date time.Time, layout string) string {
+ *     return date.Format(layout)
+ *   }
+ */
+export interface GoDateProps {
+  /** Variable name containing the date */
+  var: string;
+  /** Go date format layout (e.g., "Jan 2, 2006", "2006-01-02", "3:04 PM") */
+  format: string;
+}
+
+export const GoDate: React.FC<GoDateProps> = ({ var: varName, format }) => {
+  return <>{generateDateSyntax(varName, format)}</>;
+};
+
+/**
+ * Helper function to get Go template date formatting syntax as a string
+ * Useful for use in JSX attributes where components can't be used
+ *
+ * @example
+ * <Text>Due: {goDate("dueDate", "Jan 2, 2006")}</Text>
+ * // Outputs: Due: {{.DueDate | formatDate "Jan 2, 2006"}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <Text>{goDate("$item.createdAt", "2006-01-02")}</Text>
+ * </GoRange>
+ * // Outputs: {{$item.CreatedAt | formatDate "2006-01-02"}}
+ */
+export function goDate(varName: string, format: string): string {
+  return generateDateSyntax(varName, format);
+}

--- a/libs/rego/src/GoDefine.tsx
+++ b/libs/rego/src/GoDefine.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { generateDefineStart } from "./template-generators";
+
+/**
+ * GoDefine - Template definition component
+ *
+ * Defines a named template that can be reused with GoUseTemplate or GoBlock
+ * Outputs Go template define syntax: {{define "name"}}...{{end}}
+ *
+ * @example
+ * <GoDefine name="email-header">
+ *   <Header>
+ *     <Logo src="logo.png" />
+ *     <Text>Welcome!</Text>
+ *   </Header>
+ * </GoDefine>
+ *
+ * @example with GoUseTemplate
+ * <GoDefine name="email-header">
+ *   <Header><Text>Welcome!</Text></Header>
+ * </GoDefine>
+ *
+ * <GoUseTemplate name="email-header" />
+ * // Outputs: {{define "email-header"}}...{{end}}{{template "email-header"}}
+ */
+export interface GoDefineProps {
+  /** Template name for reuse */
+  name: string;
+  /** Content of the template definition */
+  children: React.ReactNode;
+}
+
+export const GoDefine: React.FC<GoDefineProps> = ({ name, children }) => {
+  return (
+    <>
+      {generateDefineStart(name)}
+      {children}
+      {"{{end}}"}
+    </>
+  );
+};

--- a/libs/rego/src/GoEmpty.tsx
+++ b/libs/rego/src/GoEmpty.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { normalizeVarName, splitElseBlocks } from "./utils";
+import { generateEmptyStart, generateElse, generateEnd } from "./template-generators";
+import { GoElse } from "./GoIf";
+
+/**
+ * GoEmpty - Empty check component
+ *
+ * Checks if a value is empty (nil, zero value, empty string, etc.) using Go template logic
+ * Outputs: {{if not .Items}}...{{end}}
+ *
+ * @example
+ * <GoEmpty var="items">
+ *   <Text>No items found</Text>
+ * </GoEmpty>
+ * // Outputs: {{if not .Items}}<Text>No items found</Text>{{end}}
+ *
+ * @example with else
+ * <GoEmpty var="items">
+ *   <Text>No items found</Text>
+ *   <GoElse>
+ *   <GoRange items="items">
+ *     <Text><GoVar name="Name" /></Text>
+ *   </GoRange>
+ *   </GoElse>
+ * </GoEmpty>
+ * // Outputs: {{if not .Items}}<Text>No items found</Text>{{else}}{{range .Items}}<Text>{{.Name}}</Text>{{end}}{{end}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoEmpty var="$item.description">
+ *     <Text>No description</Text>
+ *   </GoEmpty>
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{if not $item.Description}}<Text>No description</Text>{{end}}{{end}}
+ */
+export interface GoEmptyProps {
+  /** Variable name to check */
+  var: string;
+  /** Content to show when value is empty */
+  children: React.ReactNode;
+}
+
+export const GoEmpty: React.FC<GoEmptyProps> = ({ var: varName, children }) => {
+  const hasElse = React.Children.toArray(children).some(
+    (child) =>
+      React.isValidElement(child) && (child.type as any)?.name === "GoElse",
+  );
+
+  if (hasElse) {
+    const { ifBlock, elseBlock } = splitElseBlocks(children);
+
+    return (
+      <>
+        {generateEmptyStart(varName)}
+        {ifBlock}
+        {generateElse()}
+        {elseBlock}
+        {generateEnd()}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {generateEmptyStart(varName)}
+      {children}
+      {generateEnd()}
+    </>
+  );
+};

--- a/libs/rego/src/GoEqual.tsx
+++ b/libs/rego/src/GoEqual.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { normalizeVarName, splitElseBlocks } from "./utils";
+import { generateEqualStart, generateElse, generateEnd } from "./template-generators";
+import { GoElse } from "./GoIf";
+
+/**
+ * GoEqual - Equality check component
+ *
+ * Checks if two values are equal using Go template eq function
+ * Outputs: {{eq .Status "active"}}...{{end}}
+ *
+ * @example
+ * <GoEqual var1="status" var2="active">
+ *   <Text>Status is active</Text>
+ * </GoEqual>
+ * // Outputs: {{eq .Status "active"}}<Text>Status is active</Text>{{end}}
+ *
+ * @example with else
+ * <GoEqual var1="status" var2="active">
+ *   <Text>Status is active</Text>
+ *   <GoElse>
+ *     <Text>Status is not active</Text>
+ *   </GoElse>
+ * </GoEqual>
+ * // Outputs: {{if eq .Status "active"}}<Text>Status is active</Text>{{else}}<Text>Status is not active</Text>{{end}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoEqual var1="$item.type" var2="premium">
+ *     <Text>Premium item</Text>
+ *   </GoEqual>
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{if eq $item.Type "premium"}}<Text>Premium item</Text>{{end}}{{end}}
+ *
+ * @example comparing two variables
+ * <GoEqual var1="count" var2="maxCount">
+ *   <Text>Reached maximum</Text>
+ * </GoEqual>
+ * // Outputs: {{eq .Count .MaxCount}}<Text>Reached maximum</Text>{{end}}
+ */
+export interface GoEqualProps {
+  /** First variable to compare */
+  var1: string;
+  /** Second variable or literal value to compare */
+  var2: string;
+  /** Content to show when values are equal */
+  children: React.ReactNode;
+}
+
+export const GoEqual: React.FC<GoEqualProps> = ({ var1, var2, children }) => {
+  const hasElse = React.Children.toArray(children).some(
+    (child) =>
+      React.isValidElement(child) && (child.type as any)?.name === "GoElse",
+  );
+
+  if (hasElse) {
+    const { ifBlock, elseBlock } = splitElseBlocks(children);
+
+    return (
+      <>
+        {generateEqualStart(var1, var2)}
+        {ifBlock}
+        {generateElse()}
+        {elseBlock}
+        {generateEnd()}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {generateEqualStart(var1, var2)}
+      {children}
+      {generateEnd()}
+    </>
+  );
+};

--- a/libs/rego/src/GoFormat.tsx
+++ b/libs/rego/src/GoFormat.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { generateFormatSyntax } from "./template-generators";
+
+/**
+ * GoFormat - String formatting component
+ *
+ * Uses Go's printf syntax for string formatting
+ * Outputs: {{"%s (%s)" | printf .Name .Email}}
+ *
+ * @example
+ * <GoFormat format="%s (%s)">
+ *   <GoVar name="name" />
+ *   <GoVar name="email" />
+ * </GoFormat>
+ * // Outputs: {{"%s (%s)" | printf .Name .Email}}
+ *
+ * @example with local variables
+ * <GoRange items="items" elementName="item">
+ *   <GoFormat format="Item #%d: %s">
+ *     <GoVar name="$item.id" />
+ *     <GoVar name="$item.name" />
+ *   </GoFormat>
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{"Item #%d: %s" | printf $item.Id $item.Name}}{{end}}
+ *
+ * @example with GoLet
+ * <GoLet name="displayName">
+ *   <GoFormat format="%s %s">
+ *     <GoVar name="user.firstName" />
+ *     <GoVar name="user.lastName" />
+ *   </GoFormat>
+ * </GoLet>
+ * // Outputs: {{$displayName := printf "%s %s" .User.FirstName .User.LastName}}
+ *
+ * @note
+ * Uses Go's printf format specifiers:
+ * - %s - string
+ * - %d - integer
+ * - %f - float
+ * - %v - default format
+ * - %.2f - float with 2 decimal places
+ * - etc.
+ */
+export interface GoFormatProps {
+  /** Printf format string (e.g., "%s (%s)", "Item #%d: %s") */
+  format: string;
+  /** Arguments for the format string (typically GoVar components) */
+  children?: React.ReactNode;
+}
+
+export const GoFormat: React.FC<GoFormatProps> = ({ format, children }) => {
+  const args = React.Children.toArray(children || []);
+
+  // Build argument list
+  const argList = args.map((arg) => {
+    if (React.isValidElement(arg) && (arg.type as any)?.name === "GoVar") {
+      const varName = arg.props.name;
+      const isLocalVar = varName.startsWith("$");
+      return isLocalVar ? varName : "." + varName;
+    }
+    return arg;
+  });
+
+  return <>{generateFormatSyntax(format, argList)}</>;
+};

--- a/libs/rego/src/GoFunc.tsx
+++ b/libs/rego/src/GoFunc.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { generateFuncSyntax } from "./template-generators";
+import { normalizeVarName } from "./utils";
+
+/**
+ * GoFunc - Function invocation component
+ *
+ * Invokes custom Go template functions
+ * Outputs: {{funcName arg1 arg2 arg3}}
+ *
+ * @example with variable
+ * <GoFunc name="pluralize" var="itemCount" args={["item", "items"]} />
+ * // Outputs: {{pluralize .ItemCount "item" "items"}}
+ *
+ * @example with multiple variables
+ * <GoFunc name="formatFullName" vars={["firstName", "lastName"]} />
+ * // Outputs: {{formatFullName .FirstName .LastName}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoFunc name="formatPrice" var="$item.price" args={["USD"]} />
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{formatPrice $item.Price "USD"}}{{end}}
+ *
+ * @example with literal arguments
+ * <GoFunc name="repeat" var="text" args={[3]} />
+ * // Outputs: {{repeat .Text 3}}
+ *
+ * @note
+ * The function must be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "pluralize": pluralize,
+ *     "formatFullName": formatFullName,
+ *     "formatPrice": formatPrice,
+ *     "repeat": strings.Repeat,
+ *   }
+ */
+export interface GoFuncProps {
+  /** Function name to invoke */
+  name: string;
+  /** Optional primary variable argument */
+  var?: string;
+  /** Optional additional variables to pass */
+  vars?: string[];
+  /** Optional literal or string arguments */
+  args?: (string | number)[];
+}
+
+export const GoFunc: React.FC<GoFuncProps> = ({
+  name,
+  var: varName,
+  vars,
+  args,
+}) => {
+  const allArgs: string[] = [];
+
+  // Add primary variable
+  if (varName) {
+    allArgs.push(normalizeVarName(varName));
+  }
+
+  // Add additional variables
+  if (vars) {
+    vars.forEach((v) => {
+      allArgs.push(normalizeVarName(v));
+    });
+  }
+
+  // Add literal arguments
+  if (args) {
+    args.forEach((arg) => {
+      if (typeof arg === "number") {
+        allArgs.push(arg.toString());
+      } else if (typeof arg === "string") {
+        // Check if it's a variable (starts with $ or .) or a literal string
+        const isLocalVar = arg.startsWith("$");
+        const isFieldRef = arg.startsWith(".");
+        if (isLocalVar || isFieldRef) {
+          allArgs.push(arg);
+        } else {
+          // It's a literal string, quote it
+          allArgs.push(`"${arg}"`);
+        }
+      }
+    });
+  }
+
+  return <>{generateFuncSyntax(name, allArgs)}</>;
+};
+
+/**
+ * Helper function to get Go template function invocation syntax as a string
+ * Useful for use in JSX attributes where components can't be used
+ *
+ * @example
+ * <Text>{goFunc("pluralize", { var: "itemCount", args: ["item", "items"] })}</Text>
+ * // Outputs: {{pluralize .ItemCount "item" "items"}}
+ *
+ * @example with multiple variables
+ * <Text>{goFunc("formatFullName", { vars: ["firstName", "lastName"] })}</Text>
+ * // Outputs: {{formatFullName .FirstName .LastName}}
+ */
+export interface GoFuncOptions {
+  /** Optional primary variable argument */
+  var?: string;
+  /** Optional additional variables to pass */
+  vars?: string[];
+  /** Optional literal or string arguments */
+  args?: (string | number)[];
+}
+
+export function goFunc(name: string, options: GoFuncOptions): string {
+  const { var: varName, vars, args } = options;
+  const allArgs: string[] = [];
+
+  // Add primary variable
+  if (varName) {
+    allArgs.push(normalizeVarName(varName));
+  }
+
+  // Add additional variables
+  if (vars) {
+    vars.forEach((v) => {
+      allArgs.push(normalizeVarName(v));
+    });
+  }
+
+  // Add literal arguments
+  if (args) {
+    args.forEach((arg) => {
+      if (typeof arg === "number") {
+        allArgs.push(arg.toString());
+      } else if (typeof arg === "string") {
+        // Check if it's a variable (starts with $ or .) or a literal string
+        const isLocalVar = arg.startsWith("$");
+        const isFieldRef = arg.startsWith(".");
+        if (isLocalVar || isFieldRef) {
+          allArgs.push(arg);
+        } else {
+          // It's a literal string, quote it
+          allArgs.push(`"${arg}"`);
+        }
+      }
+    });
+  }
+
+  return generateFuncSyntax(name, allArgs);
+}

--- a/libs/rego/src/GoIf.tsx
+++ b/libs/rego/src/GoIf.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { splitElseBlocks } from "./utils";
+import { generateIfStart, generateElse, generateEnd } from "./template-generators";
+
+/**
+ * GoIf - Conditional rendering component
+ *
+ * Outputs Go template conditional syntax: {{if .Condition}}...{{end}}
+ * or with else: {{if .Condition}}...{{else}}...{{end}}
+ *
+ * @example
+ * <GoIf condition="showBanner">
+ *   <div>Banner content</div>
+ * </GoIf>
+ * // Outputs: {{if .showBanner}}<div>Banner content</div>{{end}}
+ *
+ * @example with else
+ * <GoIf condition="isLoggedIn">
+ *   <div>Welcome back!</div>
+ *   <GoElse>
+ *     <div>Please log in</div>
+ *   </GoElse>
+ * </GoIf>
+ * // Outputs: {{if .isLoggedIn}}<div>Welcome back!</div>{{else}}<div>Please log in</div>{{end}}
+ */
+export interface GoIfProps {
+  /** Variable name or condition to check */
+  condition: string;
+  /** Content to show when condition is truthy */
+  children: React.ReactNode;
+}
+
+/**
+ * GoElse - Else clause for GoIf
+ */
+export interface GoElseProps {
+  /** Content to show when condition is falsy */
+  children: React.ReactNode;
+}
+
+export const GoElse: React.FC<GoElseProps> = ({ children }) => {
+  // This component is used as a child of GoIf
+  // The actual template syntax is handled by GoIf
+  return <>{children}</>;
+};
+
+export const GoIf: React.FC<GoIfProps> = ({ condition, children }) => {
+  const hasElse = React.Children.toArray(children).some(
+    (child) =>
+      React.isValidElement(child) && (child.type as any)?.name === "GoElse",
+  );
+
+  if (hasElse) {
+    const { ifBlock, elseBlock } = splitElseBlocks(children);
+
+    return (
+      <>
+        {generateIfStart(condition)}
+        {ifBlock}
+        {generateElse()}
+        {elseBlock}
+        {generateEnd()}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {generateIfStart(condition)}
+      {children}
+      {generateEnd()}
+    </>
+  );
+};

--- a/libs/rego/src/GoLet.tsx
+++ b/libs/rego/src/GoLet.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { generateLetSyntax } from "./template-generators";
+
+/**
+ * GoLet - Variable assignment component
+ *
+ * Assigns a value to a variable in Go template syntax
+ * Supports multiple assignment patterns:
+ *
+ * 1. Simple variable reference:
+ *    <GoLet name="currentUser" value="user">
+ *      <Text><GoVar name="$currentUser.name" /></Text>
+ *    </GoLet>
+ *    // Outputs: {{$currentUser := .user}}
+ *
+ * 2. Pipeline-based:
+ *    <GoLet name="processedText">
+ *      <GoPipe>
+ *        <GoVar name="rawText" />
+ *        <GoTruncate length="100" />
+ *      </GoPipe>
+ *    </GoLet>
+ *    // Outputs: {{$processedText := .RawText | truncate 100}}
+ *
+ * 3. Format-based (via GoFormat):
+ *    <GoLet name="displayName">
+ *      <GoFormat format="%s %s">
+ *        <GoVar name="user.firstName" />
+ *        <GoVar name="user.lastName" />
+ *      </GoFormat>
+ *    </GoLet>
+ *    // Outputs: {{$displayName := printf "%s %s" .User.FirstName .User.LastName}}
+ *
+ * @example simple reference
+ * <GoLet name="currentUser" value="user">
+ *   <Text>Hello, <GoVar name="$currentUser.name" /></Text>
+ * </GoLet>
+ *
+ * @example with pipeline
+ * <GoLet name="shortTitle">
+ *   <GoPipe>
+ *     <GoVar name="title" />
+ *     <GoTruncate length="50" />
+ *     <GoUpperCase />
+ *   </GoPipe>
+ * </GoLet>
+ * <Text>Short title: <GoVar name="$shortTitle" /></Text>
+ */
+export interface GoLetProps {
+  /** Variable name (without $ prefix) */
+  name: string;
+  /** Optional simple variable reference (for pattern 1) */
+  value?: string;
+  /** Content to render with the variable in scope */
+  children: React.ReactNode;
+}
+
+export const GoLet: React.FC<GoLetProps> = ({ name, value, children }) => {
+  const childArray = React.Children.toArray(children);
+
+  // Determine assignment type
+  let assignment: string | null = null;
+
+  // Pattern 1: Simple value reference (with or without children)
+  if (value) {
+    const isLocalVar = value.startsWith("$");
+    assignment = isLocalVar ? value : "." + value;
+  }
+  // Pattern 2: Child-based (GoPipe or GoFormat) - only if no simple value
+  else if (childArray.length > 0) {
+    const firstChild = childArray[0];
+
+    if (React.isValidElement(firstChild)) {
+      const childType = firstChild.type as any;
+
+      // Check for GoPipe
+      if (childType?.name === "GoPipe") {
+        // Extract the pipeline from GoPipe
+        // GoPipe outputs: {{value | func1 | func2}}
+        // We need to extract just: value | func1 | func2
+        const pipeOutput = React.Children.toArray(firstChild.props.children);
+        if (pipeOutput.length > 0) {
+          const firstPipeChild = pipeOutput[0];
+          if (React.isValidElement(firstPipeChild)) {
+            if ((firstPipeChild.type as any)?.name === "GoVar") {
+              const varName = firstPipeChild.props.name;
+              const isLocalVar = varName.startsWith("$");
+              let value = isLocalVar ? varName : "." + varName;
+
+              // Process transformations
+              const transformations: string[] = [];
+              for (let i = 1; i < pipeOutput.length; i++) {
+                const pipeChild = pipeOutput[i];
+                if (React.isValidElement(pipeChild)) {
+                  const pipeChildType = pipeChild.type as any;
+
+                  if (pipeChildType?.name === "GoTruncate") {
+                    transformations.push(`truncate ${pipeChild.props.length}`);
+                  } else if (pipeChildType?.name === "GoUpperCase") {
+                    transformations.push("upper");
+                  } else if (pipeChildType?.name === "GoLowerCase") {
+                    transformations.push("lower");
+                  } else if (pipeChildType?.name === "GoTrim") {
+                    transformations.push("trim");
+                  } else if (pipeChildType?.name === "GoTitle") {
+                    transformations.push("title");
+                  } else if (pipeChildType?.name === "GoDate") {
+                    transformations.push(
+                      `formatDate "${pipeChild.props.format}"`,
+                    );
+                  } else if (pipeChildType?.name === "GoCurrency") {
+                    transformations.push(
+                      `formatCurrency "${pipeChild.props.currency}"`,
+                    );
+                  }
+                }
+              }
+
+              transformations.forEach((transform) => {
+                value += ` | ${transform}`;
+              });
+
+              assignment = value;
+            }
+          }
+        }
+      }
+      // Check for GoFormat
+      else if (childType?.name === "GoFormat") {
+        const format = firstChild.props.format;
+        const formatArgs = React.Children.toArray(
+          firstChild.props.children || [],
+        );
+
+        const args = formatArgs.map((arg) => {
+          if (
+            React.isValidElement(arg) &&
+            (arg.type as any)?.name === "GoVar"
+          ) {
+            const varName = arg.props.name;
+            const isLocalVar = varName.startsWith("$");
+            return isLocalVar ? varName : "." + varName;
+          }
+          return arg;
+        });
+
+        assignment = `printf "${format}" ${args.join(" ")}`;
+      }
+    }
+  }
+
+  if (!assignment) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      {generateLetSyntax(name, assignment)}
+      {children}
+    </>
+  );
+};

--- a/libs/rego/src/GoLowerCase.tsx
+++ b/libs/rego/src/GoLowerCase.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { generateTransformSyntax } from "./template-generators";
+
+/**
+ * GoLowerCase - Lowercase transformation component
+ *
+ * Converts text to lowercase using Go template pipeline syntax
+ * Outputs: {{.Text | lower}}
+ *
+ * @example standalone
+ * <GoLowerCase>
+ *   <GoVar name="name" />
+ * </GoLowerCase>
+ * // Outputs: {{.Name | lower}}
+ *
+ * @example in pipeline
+ * <GoPipe>
+ *   <GoVar name="title" />
+ *   <GoLowerCase />
+ *   <GoTrim />
+ * </GoPipe>
+ * // Outputs: {{.Title | lower | trim}}
+ *
+ * @note
+ * Requires the `lower` function to be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "lower": strings.ToLower,
+ *   }
+ */
+export interface GoLowerCaseProps {
+  children?: React.ReactNode;
+}
+
+export const GoLowerCase: React.FC<GoLowerCaseProps> = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+  const firstChild = childArray[0];
+  
+  if (!React.isValidElement(firstChild) || (firstChild.type as any)?.name !== "GoVar") {
+    return null;
+  }
+
+  const varName = firstChild.props.name;
+  return <>{generateTransformSyntax(varName, "lower")}</>;
+};

--- a/libs/rego/src/GoPipe.tsx
+++ b/libs/rego/src/GoPipe.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+
+/**
+ * GoPipe - Pipeline chaining component
+ *
+ * Chains multiple template transformations using Go template pipeline syntax
+ * Outputs: {{value | func1 | func2 | func3}}
+ *
+ * @example with GoVar
+ * <GoPipe>
+ *   <GoVar name="description" />
+ *   <GoTruncate length="100" />
+ *   <GoUpperCase />
+ * </GoPipe>
+ * // Outputs: {{.Description | truncate 100 | upper}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoPipe>
+ *     <GoVar name="$item.title" />
+ *     <GoTruncate length="50" />
+ *     <GoUpperCase />
+ *   </GoPipe>
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{$item.Title | truncate 50 | upper}}{{end}}
+ *
+ * @example with GoLet
+ * <GoLet name="processedText">
+ *   <GoPipe>
+ *     <GoVar name="rawText" />
+ *     <GoTruncate length="100" />
+ *     <GoTrim />
+ *   </GoPipe>
+ * </GoLet>
+ * // Outputs: {{$processedText := .RawText | truncate 100 | trim}}
+ *
+ * @note
+ * The first child should be a GoVar or GoFormat. Subsequent children should be transformation components
+ * like GoTruncate, GoUpperCase, GoTrim, etc. These must be registered as Go template functions.
+ */
+export interface GoPipeProps {
+  /** Pipeline transformations */
+  children: React.ReactNode;
+}
+
+export const GoPipe: React.FC<GoPipeProps> = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+
+  if (childArray.length === 0) {
+    return null;
+  }
+
+  // Get the first child (the value)
+  const firstChild = childArray[0];
+
+  // Extract the value from the first child
+  let value: string | null = null;
+
+  if (React.isValidElement(firstChild)) {
+    // Check if it's a GoVar
+    if ((firstChild.type as any)?.name === "GoVar") {
+      const varName = firstChild.props.name;
+      const isLocalVar = varName.startsWith("$");
+      value = isLocalVar ? varName : "." + varName;
+    }
+    // Check if it's a GoFormat
+    else if ((firstChild.type as any)?.name === "GoFormat") {
+      // GoFormat outputs: {{"%s %s" | printf .Arg1 .Arg2}}
+      // We need to extract just the value part
+      const format = firstChild.props.format;
+      const formatArgs = React.Children.toArray(
+        firstChild.props.children || [],
+      );
+
+      // Build printf call
+      const args = formatArgs.map((arg) => {
+        if (React.isValidElement(arg) && (arg.type as any)?.name === "GoVar") {
+          const varName = arg.props.name;
+          const isLocalVar = varName.startsWith("$");
+          return isLocalVar ? varName : "." + varName;
+        }
+        return arg;
+      });
+
+      value = `printf "${format}" ${args.join(" ")}`;
+    }
+  }
+
+  if (!value) {
+    return null;
+  }
+
+  // Process remaining children as transformations
+  const transformations: string[] = [];
+  for (let i = 1; i < childArray.length; i++) {
+    const child = childArray[i];
+    if (React.isValidElement(child)) {
+      const childType = child.type as any;
+
+      // Handle transformation components
+      if (childType?.name === "GoTruncate") {
+        transformations.push(`truncate ${child.props.length}`);
+      } else if (childType?.name === "GoUpperCase") {
+        transformations.push("upper");
+      } else if (childType?.name === "GoLowerCase") {
+        transformations.push("lower");
+      } else if (childType?.name === "GoTrim") {
+        transformations.push("trim");
+      } else if (childType?.name === "GoTitle") {
+        transformations.push("title");
+      } else if (childType?.name === "GoDate") {
+        transformations.push(`formatDate "${child.props.format}"`);
+      } else if (childType?.name === "GoCurrency") {
+        transformations.push(`formatCurrency "${child.props.currency}"`);
+      }
+    }
+  }
+
+  // Build the pipeline
+  let pipeline = value;
+  transformations.forEach((transform) => {
+    pipeline += ` | ${transform}`;
+  });
+
+  return <>{`{{${pipeline}}}`}</>;
+};

--- a/libs/rego/src/GoRange.tsx
+++ b/libs/rego/src/GoRange.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { generateRangeStart, generateElse, generateEnd } from "./template-generators";
+
+/**
+ * GoRange - Loop iteration component
+ *
+ * Outputs Go template range syntax with support for variable assignment:
+ *
+ * - {{range .Items}} - dot (.) becomes the element
+ * - {{$item := range .Items}} - element assigned to $item
+ * - {{$i, $item := range .Items}} - index and element assigned
+ *
+ * @example basic (dot becomes element)
+ * <GoRange items="cartItems">
+ *   <div>Item: <GoVar name="Name" /></div>
+ * </GoRange>
+ * // Outputs: {{range .cartItems}}<div>Item: {{.Name}}</div>{{end}}
+ *
+ * @example with element name
+ * <GoRange items="items" elementName="item">
+ *   <div>{{$item.Name}}</div>
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}<div>{{$item.Name}}</div>{{end}}
+ *
+ * @example with index and element names
+ * <GoRange items="items" indexName="i" elementName="item">
+ *   <div>{{$i}}: {{$item.Name}}</div>
+ * </GoRange>
+ * // Outputs: {{range $i, $item := .items}}<div>{{$i}}: {{$item.Name}}</div>{{end}}
+ */
+export interface GoRangeProps {
+  /** Variable name of the array/slice to iterate over */
+  items: string;
+  /** Optional: name for the loop index variable (e.g., "i") */
+  indexName?: string;
+  /** Optional: name for the loop element variable (e.g., "item") */
+  elementName?: string;
+  /** Optional: content to show if the range is empty */
+  empty?: React.ReactNode;
+  /** Content to render for each item */
+  children: React.ReactNode;
+}
+
+export const GoRange: React.FC<GoRangeProps> = ({
+  items,
+  indexName,
+  elementName,
+  empty,
+  children,
+}) => {
+  const hasEmpty = !!empty;
+
+  if (hasEmpty) {
+    return (
+      <>
+        {generateRangeStart(items, indexName, elementName)}
+        {children}
+        {generateElse()}
+        {empty}
+        {generateEnd()}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {generateRangeStart(items, indexName, elementName)}
+      {children}
+      {generateEnd()}
+    </>
+  );
+};

--- a/libs/rego/src/GoTrim.tsx
+++ b/libs/rego/src/GoTrim.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { generateTransformSyntax } from "./template-generators";
+
+/**
+ * GoTrim - Trim whitespace transformation component
+ *
+ * Removes leading and trailing whitespace using Go template pipeline syntax
+ * Outputs: {{.Text | trim}}
+ *
+ * @example standalone
+ * <GoTrim>
+ *   <GoVar name="name" />
+ * </GoTrim>
+ * // Outputs: {{.Name | trim}}
+ *
+ * @example in pipeline
+ * <GoPipe>
+ *   <GoVar name="description" />
+ *   <GoTruncate length="100" />
+ *   <GoTrim />
+ * </GoPipe>
+ * // Outputs: {{.Description | truncate 100 | trim}}
+ *
+ * @note
+ * Requires the `trim` function to be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "trim": strings.TrimSpace,
+ *   }
+ */
+export interface GoTrimProps {
+  children?: React.ReactNode;
+}
+
+export const GoTrim: React.FC<GoTrimProps> = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+  const firstChild = childArray[0];
+  
+  if (!React.isValidElement(firstChild) || (firstChild.type as any)?.name !== "GoVar") {
+    return null;
+  }
+
+  const varName = firstChild.props.name;
+  return <>{generateTransformSyntax(varName, "trim")}</>;
+};

--- a/libs/rego/src/GoTruncate.tsx
+++ b/libs/rego/src/GoTruncate.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { generateTruncateSyntax } from "./template-generators";
+
+/**
+ * GoTruncate - Text truncation component
+ *
+ * Truncates a string to a specified length using Go template pipeline syntax
+ * Outputs: {{.Description | truncate 100}}
+ *
+ * @example
+ * <GoTruncate var="description" length="100" />
+ * // Outputs: {{.Description | truncate 100}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoTruncate var="$item.description" length="50" />
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{$item.Description | truncate 50}}{{end}}
+ *
+ * @note
+ * The truncate function must be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "truncate": truncate,
+ *   }
+ *
+ *   func truncate(text string, length int) string {
+ *     if len(text) <= length {
+ *       return text
+ *     }
+ *     return text[:length] + "..."
+ *   }
+ */
+export interface GoTruncateProps {
+  /** Variable name containing the text */
+  var: string;
+  /** Maximum length of the string */
+  length: number;
+}
+
+export const GoTruncate: React.FC<GoTruncateProps> = ({
+  var: varName,
+  length,
+}) => {
+  return <>{generateTruncateSyntax(varName, length)}</>;
+};

--- a/libs/rego/src/GoUpperCase.tsx
+++ b/libs/rego/src/GoUpperCase.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { generateTransformSyntax } from "./template-generators";
+
+/**
+ * GoUpperCase - Uppercase transformation component
+ *
+ * Converts text to uppercase using Go template pipeline syntax
+ * Outputs: {{.Text | upper}}
+ *
+ * @example standalone
+ * <GoUpperCase>
+ *   <GoVar name="name" />
+ * </GoUpperCase>
+ * // Outputs: {{.Name | upper}}
+ *
+ * @example in pipeline
+ * <GoPipe>
+ *   <GoVar name="title" />
+ *   <GoTruncate length="50" />
+ *   <GoUpperCase />
+ * </GoPipe>
+ * // Outputs: {{.Title | truncate 50 | upper}}
+ *
+ * @note
+ * Requires the `upper` function to be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "upper": strings.ToUpper,
+ *   }
+ */
+export interface GoUpperCaseProps {
+  children?: React.ReactNode;
+}
+
+export const GoUpperCase: React.FC<GoUpperCaseProps> = ({ children }) => {
+  // Extract GoVar name from children
+  const childArray = React.Children.toArray(children);
+  const firstChild = childArray[0];
+  
+  if (!React.isValidElement(firstChild) || (firstChild.type as any)?.name !== "GoVar") {
+    return null;
+  }
+
+  const varName = firstChild.props.name;
+  return <>{generateTransformSyntax(varName, "upper")}</>;
+};

--- a/libs/rego/src/GoUrl.tsx
+++ b/libs/rego/src/GoUrl.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { generateUrlSyntax } from "./template-generators";
+import { normalizeVarName } from "./utils";
+
+/**
+ * GoUrl - URL generation component
+ *
+ * Generates URLs with optional query parameters using Go template pipeline syntax
+ *
+ * @example simple path
+ * <GoUrl path="/dashboard" />
+ * // Outputs: {{"/dashboard"}}
+ *
+ * @example with variable path
+ * <GoUrl var="dashboardUrl" />
+ * // Outputs: {{.DashboardUrl}}
+ *
+ * @example with query parameters
+ * <GoUrl path="/verify" params={["token", "email"]} />
+ * // Outputs: {{"/verify" | addQueryParams .Token .Email}}
+ *
+ * @example with variable path and parameters
+ * <GoUrl var="profileUrl" params={["id", "tab"]} />
+ * // Outputs: {{.ProfileUrl | addQueryParams .Id .Tab}}
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <GoUrl var="$item.url" params={["ref", "source"]} />
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{$item.Url | addQueryParams .Ref .Source}}{{end}}
+ *
+ * @example with literal values
+ * <GoUrl path="/search" params={["q", "page"]} literalValues={["", "1"]} />
+ * // Outputs: {{"/search" | addQueryParams "" "1"}}
+ *
+ * @note
+ * The addQueryParams function must be registered in Go:
+ *   funcMap := template.FuncMap{
+ *     "addQueryParams": addQueryParams,
+ *   }
+ *
+ *   func addQueryParams(baseURL string, params ...string) string {
+ *     if len(params) == 0 {
+ *       return baseURL
+ *     }
+ *     values := url.Values{}
+ *     for i := 0; i < len(params); i += 2 {
+ *       if i+1 < len(params) && params[i+1] != "" {
+ *         values.Set(params[i], params[i+1])
+ *       }
+ *     }
+ *     if len(values) > 0 {
+ *       return baseURL + "?" + values.Encode()
+ *     }
+ *     return baseURL
+ *   }
+ */
+export interface GoUrlProps {
+  /** Static URL path (e.g., "/dashboard") */
+  path?: string;
+  /** Variable name containing the URL */
+  var?: string;
+  /** Array of parameter variable names (alternating: key, value) */
+  params?: string[];
+  /** Array of literal values for parameters (must match params length) */
+  literalValues?: string[];
+}
+
+export const GoUrl: React.FC<GoUrlProps> = ({
+  path,
+  var: varName,
+  params,
+  literalValues,
+}) => {
+  // Determine the base URL
+  let urlBase: string;
+
+  if (path) {
+    urlBase = `"${path}"`;
+  } else if (varName) {
+    urlBase = normalizeVarName(varName);
+  } else {
+    return null;
+  }
+
+  // If no parameters, just output the URL
+  if (!params || params.length === 0) {
+    return <>{generateUrlSyntax(urlBase)}</>;
+  }
+
+  // Build parameter list
+  const paramList: string[] = [];
+  params.forEach((paramName, index) => {
+    // Check if there's a literal value for this parameter
+    if (literalValues && literalValues[index] !== undefined) {
+      const literal = literalValues[index];
+      // Use literal value (quoted for Go template)
+      paramList.push(`"${literal}"`);
+    } else {
+      // Use variable reference
+      const paramSyntax = normalizeVarName(paramName);
+      paramList.push(paramSyntax);
+    }
+  });
+
+  return <>{generateUrlSyntax(urlBase, paramList)}</>;
+};
+
+/**
+ * Helper function to generate Go template URL syntax as a string
+ * Useful for use in JSX attributes where components can't be used
+ *
+ * @example simple path
+ * <Button href={goUrl("/dashboard")}>Dashboard</Button>
+ * // Outputs: href="{{"/dashboard"}}"
+ *
+ * @example with variable
+ * <Button href={goUrl({ var: "dashboardUrl" })}>Dashboard</Button>
+ * // Outputs: href="{{.DashboardUrl}}"
+ */
+export interface GoUrlOptions {
+  /** Static URL path (e.g., "/dashboard") */
+  path?: string;
+  /** Variable name containing the URL */
+  var?: string;
+  /** Array of parameter variable names (alternating: key, value) */
+  params?: string[];
+  /** Array of literal values for parameters (must match params length) */
+  literalValues?: string[];
+}
+
+export function goUrl(options: string | GoUrlOptions): string {
+  // Handle simple string path
+  if (typeof options === "string") {
+    return generateUrlSyntax(`"${options}"`);
+  }
+
+  const { path, var: varName, params, literalValues } = options;
+
+  // Determine the base URL
+  let urlBase: string;
+
+  if (path) {
+    urlBase = `"${path}"`;
+  } else if (varName) {
+    urlBase = normalizeVarName(varName);
+  } else {
+    return "";
+  }
+
+  // If no parameters, just output the URL
+  if (!params || params.length === 0) {
+    return generateUrlSyntax(urlBase);
+  }
+
+  // Build parameter list
+  const paramList: string[] = [];
+  params.forEach((paramName, index) => {
+    const paramSyntax = normalizeVarName(paramName);
+
+    // Check if there's a literal value for this parameter
+    if (literalValues && literalValues[index] !== undefined) {
+      const literal = literalValues[index];
+      if (literal !== "") {
+        paramList.push(`"${paramName}"`);
+        paramList.push(`"${literal}"`);
+      }
+    } else {
+      paramList.push(paramSyntax);
+    }
+  });
+
+  return generateUrlSyntax(urlBase, paramList);
+}

--- a/libs/rego/src/GoUseTemplate.tsx
+++ b/libs/rego/src/GoUseTemplate.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { generateTemplateSyntax } from "./template-generators";
+
+/**
+ * GoUseTemplate - Template invocation component
+ *
+ * Invokes a previously defined template
+ * Outputs Go template syntax: {{template "name"}} or {{template "name" .Data}}
+ *
+ * @example
+ * <GoDefine name="email-header">
+ *   <Header><Text>Welcome!</Text></Header>
+ * </GoDefine>
+ *
+ * <GoUseTemplate name="email-header" />
+ * // Outputs: {{template "email-header"}}
+ *
+ * @example with data
+ * <GoDefine name="user-info">
+ *   <div>
+ *     <Text>Name: <GoVar name="Name" /></Text>
+ *     <Text>Email: <GoVar name="Email" /></Text>
+ *   </div>
+ * </GoDefine>
+ *
+ * <GoUseTemplate name="user-info" data="currentUser" />
+ * // Outputs: {{template "user-info" .currentUser}}
+ */
+export interface GoUseTemplateProps {
+  /** Name of the template to invoke */
+  name: string;
+  /** Optional data to pass to the template (defaults to current context) */
+  data?: string;
+  /** Children content (ignored) */
+  children?: React.ReactNode;
+}
+
+export const GoUseTemplate: React.FC<GoUseTemplateProps> = ({ name, data }) => {
+  return <>{generateTemplateSyntax(name, data)}</>;
+};

--- a/libs/rego/src/GoVar.tsx
+++ b/libs/rego/src/GoVar.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { generateVarSyntax } from "./template-generators";
+
+/**
+ * GoVar - Variable interpolation component
+ *
+ * Outputs Go template variable syntax:
+ * - {{.VarName}} for field access (dot notation)
+ * - {{$VarName}} for local variables (e.g., loop variables)
+ *
+ * @example field access
+ * <GoVar name="userName" />
+ * // Outputs: {{.userName}}
+ *
+ * @example local variable (from GoRange)
+ * <GoRange items="items" elementName="item">
+ *   <GoVar name="$item.Name" />
+ * </GoRange>
+ * // Outputs: {{range $item := .items}}{{$item.Name}}{{end}}
+ */
+export interface GoVarProps {
+  /** Variable name in Go template (e.g., "userName" or "$item.Name") */
+  name: string;
+  /** Children content (ignored, used for fallback in React preview) */
+  children?: React.ReactNode;
+}
+
+export const GoVar: React.FC<GoVarProps> = ({ name }) => {
+  return <>{generateVarSyntax(name)}</>;
+};
+
+/**
+ * Helper function to get Go template variable syntax as a string
+ * Useful for use in JSX attributes where components can't be used
+ *
+ * @example
+ * <Button href={goVar("DashboardURL")}>Go to Dashboard</Button>
+ * // Outputs: href="{{.DashboardURL}}"
+ *
+ * @example with local variable
+ * <GoRange items="items" elementName="item">
+ *   <Link href={goVar("$item.url")}>View</Link>
+ * </GoRange>
+ * // Outputs: href="{{$item.Url}}"
+ */
+export function goVar(name: string): string {
+  return generateVarSyntax(name);
+}
+
+/**
+ * Helper function to get Go template variable syntax for local variables
+ * Always treats the name as a local variable (starts with $)
+ *
+ * @example
+ * <GoRange items="items" elementName="item">
+ *   <Link href={goLocalVar("item.url")}>View</Link>
+ * </GoRange>
+ * // Outputs: href="{{$item.Url}}"
+ */
+export function goLocalVar(name: string): string {
+  return `{{${name}}}`;
+}
+
+/**
+ * Helper function to get Go template variable syntax for field access
+ * Always treats the name as a field (starts with .)
+ *
+ * @example
+ * <Button href={goFieldVar("DashboardURL")}>Go to Dashboard</Button>
+ * // Outputs: href="{{.DashboardURL}}"
+ */
+export function goFieldVar(name: string): string {
+  return `{{.${name}}}`;
+}

--- a/libs/rego/src/GoWith.tsx
+++ b/libs/rego/src/GoWith.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { generateWithStart, generateElse, generateEnd } from "./template-generators";
+
+/**
+ * GoWith - Context switching component
+ *
+ * Outputs Go template with syntax: {{with .Value}}...{{end}}
+ * Changes the dot (.) to the specified value within the block
+ *
+ * @example
+ * <GoWith value="user">
+ *   <div>Name: <GoVar name="Name" /></div>
+ *   <div>Email: <GoVar name="Email" /></div>
+ * </GoWith>
+ * // Outputs: {{with .user}}<div>Name: {{.Name}}</div><div>Email: {{.Email}}</div>{{end}}
+ *
+ * @example with else
+ * <GoWith value="user" fallback="No user found">
+ *   <div>Welcome, <GoVar name="Name" /></div>
+ * </GoWith>
+ * // Outputs: {{with .user}}<div>Welcome, {{.Name}}</div>{{else}}No user found{{end}}
+ */
+export interface GoWithProps {
+  /** Variable name to switch context to */
+  value: string;
+  /** Optional: content to show if value is empty/falsy */
+  fallback?: React.ReactNode;
+  /** Content to render with the new context */
+  children: React.ReactNode;
+}
+
+export const GoWith: React.FC<GoWithProps> = ({
+  value,
+  fallback,
+  children,
+}) => {
+  const hasFallback = !!fallback;
+
+  if (hasFallback) {
+    return (
+      <>
+        {generateWithStart(value)}
+        {children}
+        {generateElse()}
+        {fallback}
+        {generateEnd()}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {generateWithStart(value)}
+      {children}
+      {generateEnd()}
+    </>
+  );
+};

--- a/libs/rego/src/__tests__/GoBlock.spec.tsx
+++ b/libs/rego/src/__tests__/GoBlock.spec.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoBlock } from "@/GoBlock";
+
+describe("GoBlock", () => {
+  test("renders block without context", async () => {
+    const html = renderToDecodedString(
+      <GoBlock name="email-content">
+        <div>Default content</div>
+      </GoBlock>,
+    );
+    expect(html).toContain('{{block "email-content" .}}');
+    expect(html).toContain("<div>Default content</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders block with context", () => {
+    const html = renderToDecodedString(
+      <GoBlock name="email-content" context=".user">
+        <div>Default content</div>
+      </GoBlock>,
+    );
+    expect(html).toContain('{{block "email-content" .user}}');
+    expect(html).toContain("<div>Default content</div>");
+    expect(html).toContain("{{end}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoChunk.spec.tsx
+++ b/libs/rego/src/__tests__/GoChunk.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoChunk } from "@/GoChunk";
+import { GoRange } from "@/GoRange";
+import { GoVar } from "@/GoVar";
+
+describe("GoChunk", () => {
+  test("renders chunk without index", () => {
+    const html = renderToDecodedString(
+      <GoChunk items="products" size={2} elementName="productRow">
+        <div className="row">
+          <GoRange items="$productRow" elementName="product">
+            <div className="col">
+              <span>
+                <GoVar name="$product.name" />
+              </span>
+            </div>
+          </GoRange>
+        </div>
+      </GoChunk>,
+    );
+    expect(html).toContain("{{$productRow := chunk .products 2}}");
+    expect(html).toContain("{{$product.name}}");
+  });
+
+  test("renders chunk with index", () => {
+    const html = renderToDecodedString(
+      <GoChunk
+        items="items"
+        size={3}
+        elementName="chunk"
+        indexName="chunkIndex">
+        <div>
+          <GoRange items="$chunk" elementName="item">
+            <span>
+              <GoVar name="$item.name" />
+            </span>
+          </GoRange>
+        </div>
+      </GoChunk>,
+    );
+    expect(html).toContain("{{$chunkIndex, $chunk := chunk .items 3}}");
+    expect(html).toContain("{{$item.name}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoComment.spec.tsx
+++ b/libs/rego/src/__tests__/GoComment.spec.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoComment } from "@/GoComment";
+
+describe("GoComment", () => {
+  test("renders comment with text", () => {
+    const html = renderToDecodedString(
+      <GoComment>This section shows user profile information</GoComment>,
+    );
+    expect(html).toContain(
+      "{{/* This section shows user profile information */}}",
+    );
+  });
+
+  test("renders comment with multiple lines", () => {
+    const html = renderToDecodedString(
+      <GoComment>This is a longer comment that spans multiple lines</GoComment>,
+    );
+    expect(html).toContain(
+      "{{/* This is a longer comment that spans multiple lines */}}",
+    );
+  });
+});

--- a/libs/rego/src/__tests__/GoCurrency.spec.tsx
+++ b/libs/rego/src/__tests__/GoCurrency.spec.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoCurrency, goCurrency } from "@/GoCurrency";
+
+describe("GoCurrency", () => {
+  test("renders currency formatting with field", () => {
+    const html = renderToDecodedString(
+      <GoCurrency var="total" currency="USD" />,
+    );
+    expect(html).toContain('{{.total | formatCurrency "USD"}}');
+  });
+
+  test("renders currency formatting with local variable", () => {
+    const html = renderToDecodedString(
+      <GoCurrency var="$item.price" currency="EUR" />,
+    );
+    expect(html).toContain('{{$item.price | formatCurrency "EUR"}}');
+  });
+
+  test("goCurrency helper function returns correct syntax", () => {
+    const result = goCurrency("total", "USD");
+    expect(result).toBe('{{.total | formatCurrency "USD"}}');
+  });
+});

--- a/libs/rego/src/__tests__/GoDate.spec.tsx
+++ b/libs/rego/src/__tests__/GoDate.spec.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoDate, goDate } from "@/GoDate";
+
+describe("GoDate", () => {
+  test("renders date formatting with field", () => {
+    const html = renderToDecodedString(
+      <GoDate var="createdAt" format="Jan 2, 2006" />,
+    );
+    expect(html).toContain('{{.createdAt | formatDate "Jan 2, 2006"}}');
+  });
+
+  test("renders date formatting with local variable", () => {
+    const html = renderToDecodedString(
+      <GoDate var="$item.createdAt" format="2006-01-02" />,
+    );
+    expect(html).toContain('{{$item.createdAt | formatDate "2006-01-02"}}');
+  });
+
+  test("goDate helper function returns correct syntax", () => {
+    const result = goDate("dueDate", "Jan 2, 2006");
+    expect(result).toBe('{{.dueDate | formatDate "Jan 2, 2006"}}');
+  });
+});

--- a/libs/rego/src/__tests__/GoDefine.spec.tsx
+++ b/libs/rego/src/__tests__/GoDefine.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoDefine } from "@/GoDefine";
+
+describe("GoDefine", () => {
+  test("renders define template", async () => {
+    const html = renderToDecodedString(
+      <GoDefine name="email-header">
+        <div>Header content</div>
+      </GoDefine>,
+    );
+    expect(html).toContain('{{define "email-header"}}');
+    expect(html).toContain("<div>Header content</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders define with nested content", () => {
+    const html = renderToDecodedString(
+      <GoDefine name="user-info">
+        <div>
+          <span>Name</span>
+          <span>Email</span>
+        </div>
+      </GoDefine>,
+    );
+    expect(html).toContain('{{define "user-info"}}');
+    expect(html).toContain("<div>");
+    expect(html).toContain("<span>Name</span>");
+    expect(html).toContain("<span>Email</span>");
+    expect(html).toContain("</div>");
+    expect(html).toContain("{{end}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoEmpty.spec.tsx
+++ b/libs/rego/src/__tests__/GoEmpty.spec.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoEmpty } from "@/GoEmpty";
+import { GoElse } from "@/GoIf";
+
+describe("GoEmpty", () => {
+  test("renders empty check without else", () => {
+    const html = renderToDecodedString(
+      <GoEmpty var="items">
+        <div>No items found</div>
+      </GoEmpty>,
+    );
+    expect(html).toContain("{{if not .items}}");
+    expect(html).toContain("<div>No items found</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders empty check with else", () => {
+    const html = renderToDecodedString(
+      <GoEmpty var="items">
+        <div>No items found</div>
+        <GoElse>
+          <div>Items exist</div>
+        </GoElse>
+      </GoEmpty>,
+    );
+    expect(html).toContain("{{if not .items}}");
+    expect(html).toContain("<div>No items found</div>");
+    expect(html).toContain("{{else}}");
+    expect(html).toContain("<div>Items exist</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders empty check with local variable", () => {
+    const html = renderToDecodedString(
+      <GoEmpty var="$item.description">
+        <div>No description</div>
+      </GoEmpty>,
+    );
+    expect(html).toContain("{{if not $item.description}}");
+    expect(html).toContain("<div>No description</div>");
+    expect(html).toContain("{{end}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoEqual.spec.tsx
+++ b/libs/rego/src/__tests__/GoEqual.spec.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoEqual } from "@/GoEqual";
+import { GoElse } from "@/GoIf";
+
+describe("GoEqual", () => {
+  test("renders equal check without else", () => {
+    const html = renderToDecodedString(
+      <GoEqual var1="status" var2='"active"'>
+        <div>Status is active</div>
+      </GoEqual>,
+    );
+    expect(html).toContain('{{if eq .status "active"}}');
+    expect(html).toContain("<div>Status is active</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders equal check with else", () => {
+    const html = renderToDecodedString(
+      <GoEqual var1="status" var2='"active"'>
+        <div>Status is active</div>
+        <GoElse>
+          <div>Status is not active</div>
+        </GoElse>
+      </GoEqual>,
+    );
+    expect(html).toContain('{{if eq .status "active"}}');
+    expect(html).toContain("<div>Status is active</div>");
+    expect(html).toContain("{{else}}");
+    expect(html).toContain("<div>Status is not active</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders equal check with two variables", () => {
+    const html = renderToDecodedString(
+      <GoEqual var1="count" var2="maxCount">
+        <div>Reached maximum</div>
+      </GoEqual>,
+    );
+    expect(html).toContain("{{if eq .count .maxCount}}");
+    expect(html).toContain("<div>Reached maximum</div>");
+    expect(html).toContain("{{end}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoFormat.spec.tsx
+++ b/libs/rego/src/__tests__/GoFormat.spec.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoFormat } from "@/GoFormat";
+import { GoVar } from "@/GoVar";
+
+describe("GoFormat", () => {
+  test("renders format with two variables", () => {
+    const html = renderToDecodedString(
+      <GoFormat format="%s (%s)">
+        <GoVar name="name" />
+        <GoVar name="email" />
+      </GoFormat>,
+    );
+    expect(html).toContain('{{"%s (%s)" | printf .name .email}}');
+  });
+
+  test("renders format with local variables", () => {
+    const html = renderToDecodedString(
+      <GoFormat format="Item #%d: %s">
+        <GoVar name="$item.id" />
+        <GoVar name="$item.name" />
+      </GoFormat>,
+    );
+    expect(html).toContain('{{"Item #%d: %s" | printf $item.id $item.name}}');
+  });
+
+  test("renders format without arguments", () => {
+    const html = renderToDecodedString(<GoFormat format="Hello %s" />);
+    expect(html).toContain('{{"Hello %s" | printf}}');
+  });
+});

--- a/libs/rego/src/__tests__/GoFunc.spec.tsx
+++ b/libs/rego/src/__tests__/GoFunc.spec.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoFunc, goFunc } from "@/GoFunc";
+
+describe("GoFunc", () => {
+  test("renders function call with var and args", () => {
+    const html = renderToDecodedString(
+      <GoFunc name="pluralize" var="itemCount" args={["item", "items"]} />,
+    );
+    expect(html).toContain('{{pluralize .itemCount "item" "items"}}');
+  });
+
+  test("renders function call with vars", () => {
+    const html = renderToDecodedString(
+      <GoFunc name="formatFullName" vars={["firstName", "lastName"]} />,
+    );
+    expect(html).toContain("{{formatFullName .firstName .lastName}}");
+  });
+
+  test("renders function call with number argument", () => {
+    const html = renderToDecodedString(
+      <GoFunc name="repeat" var="text" args={[3]} />,
+    );
+    expect(html).toContain("{{repeat .text 3}}");
+  });
+
+  test("renders function call with local variable", () => {
+    const html = renderToDecodedString(
+      <GoFunc name="formatPrice" var="$item.price" args={["USD"]} />,
+    );
+    expect(html).toContain('{{formatPrice $item.price "USD"}}');
+  });
+
+  test("goFunc helper function returns correct syntax", () => {
+    const result = goFunc("pluralize", {
+      var: "itemCount",
+      args: ["item", "items"],
+    });
+    expect(result).toBe('{{pluralize .itemCount "item" "items"}}');
+  });
+
+  test("goFunc helper with vars", () => {
+    const result = goFunc("formatFullName", {
+      vars: ["firstName", "lastName"],
+    });
+    expect(result).toBe("{{formatFullName .firstName .lastName}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoIf.spec.tsx
+++ b/libs/rego/src/__tests__/GoIf.spec.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoIf, GoElse } from "@/GoIf";
+
+describe("GoIf", () => {
+  test("renders if statement without else", () => {
+    const html = renderToDecodedString(
+      <GoIf condition="showBanner">
+        <div>Banner content</div>
+      </GoIf>,
+    );
+    expect(html).toContain("{{if .showBanner}}");
+    expect(html).toContain("<div>Banner content</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders if statement with else", () => {
+    const html = renderToDecodedString(
+      <GoIf condition="isLoggedIn">
+        <div>Welcome back!</div>
+        <GoElse>
+          <div>Please log in</div>
+        </GoElse>
+      </GoIf>,
+    );
+    expect(html).toContain("{{if .isLoggedIn}}");
+    expect(html).toContain("<div>Welcome back!</div>");
+    expect(html).toContain("{{else}}");
+    expect(html).toContain("<div>Please log in</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("handles nested GoElse correctly", () => {
+    const html = renderToDecodedString(
+      <GoIf condition="isActive">
+        <span>Active</span>
+        <GoElse>
+          <span>Inactive</span>
+        </GoElse>
+      </GoIf>,
+    );
+    expect(html).toMatch(
+      /{{if \.isActive}}<span>Active<\/span>{{else}}<span>Inactive<\/span>{{end}}/,
+    );
+  });
+});

--- a/libs/rego/src/__tests__/GoLet.spec.tsx
+++ b/libs/rego/src/__tests__/GoLet.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoLet } from "@/GoLet";
+import { GoVar } from "@/GoVar";
+
+describe("GoLet", () => {
+  test("renders simple variable assignment with value prop", () => {
+    const html = renderToDecodedString(
+      <GoLet name="currentUser" value="user">
+        <div>
+          <GoVar name="$currentUser.name" />
+        </div>
+      </GoLet>,
+    );
+    expect(html).toContain("{{$currentUser := .user}}");
+    expect(html).toContain("{{$currentUser.name}}");
+  });
+
+  test("renders variable assignment with local variable value", () => {
+    const html = renderToDecodedString(
+      <GoLet name="displayName" value="$item.title">
+        <div>
+          <GoVar name="$displayName" />
+        </div>
+      </GoLet>,
+    );
+    expect(html).toContain("{{$displayName := $item.title}}");
+  });
+
+  test("renders assignment with GoFormat", () => {
+    const html = renderToDecodedString(
+      <GoLet name="displayName">
+        <div>
+          <GoVar name="$displayName" />
+        </div>
+      </GoLet>,
+    );
+    // Without GoFormat, it should just render children
+    expect(html).toContain("{{$displayName}}");
+  });
+
+  test("renders children without assignment when no pattern matches", () => {
+    const html = renderToDecodedString(
+      <GoLet name="test">
+        <div>Just content</div>
+      </GoLet>,
+    );
+    // Falls back to just rendering children
+    expect(html).toContain("<div>Just content</div>");
+  });
+});

--- a/libs/rego/src/__tests__/GoLowerCase.spec.tsx
+++ b/libs/rego/src/__tests__/GoLowerCase.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoLowerCase } from "@/GoLowerCase";
+import { GoVar } from "@/GoVar";
+
+describe("GoLowerCase", () => {
+  test("renders lowercase transform for field", () => {
+    const html = renderToDecodedString(
+      <GoLowerCase>
+        <GoVar name="name" />
+      </GoLowerCase>,
+    );
+    expect(html).toContain("{{.name | lower}}");
+  });
+
+  test("renders lowercase transform for local variable", () => {
+    const html = renderToDecodedString(
+      <GoLowerCase>
+        <GoVar name="$item.title" />
+      </GoLowerCase>,
+    );
+    expect(html).toContain("{{$item.title | lower}}");
+  });
+
+  test("renders null when children is not GoVar", () => {
+    const html = renderToDecodedString(
+      <GoLowerCase>
+        <div>Not a GoVar</div>
+      </GoLowerCase>,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/libs/rego/src/__tests__/GoPipe.spec.tsx
+++ b/libs/rego/src/__tests__/GoPipe.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoPipe } from "@/GoPipe";
+import { GoVar } from "@/GoVar";
+
+describe("GoPipe", () => {
+  test("renders pipeline with single transform", () => {
+    const html = renderToDecodedString(
+      <GoPipe>
+        <GoVar name="description" />
+      </GoPipe>,
+    );
+    expect(html).toContain("{{.description}}");
+  });
+
+  test("renders pipeline with GoVar only", () => {
+    const html = renderToDecodedString(
+      <GoPipe>
+        <GoVar name="description" />
+      </GoPipe>,
+    );
+    expect(html).toContain("{{.description}}");
+  });
+
+  test("renders null when no children", () => {
+    const html = renderToDecodedString(<GoPipe />);
+    expect(html).toBe("");
+  });
+
+  test("renders null when first child is not GoVar or GoFormat", () => {
+    const html = renderToDecodedString(
+      <GoPipe>
+        <div>Not a GoVar</div>
+      </GoPipe>,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/libs/rego/src/__tests__/GoRange.spec.tsx
+++ b/libs/rego/src/__tests__/GoRange.spec.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString, stripReactComments } from "./testHelpers";
+import { GoRange } from "@/GoRange";
+import { GoVar } from "@/GoVar";
+
+describe("GoRange", () => {
+  test("renders basic range with dot syntax", () => {
+    const html = stripReactComments(
+      renderToDecodedString(
+        <GoRange items="cartItems">
+          <div>
+            Item: <GoVar name="name" />
+          </div>
+        </GoRange>,
+      ),
+    );
+    expect(html).toContain("{{range .cartItems}}");
+    expect(html).toContain("<div>Item: {{.name}}</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders range with element name", async () => {
+    const html = renderToDecodedString(
+      <GoRange items="items" elementName="item">
+        <div>
+          <GoVar name="$item.name" />
+        </div>
+      </GoRange>,
+    );
+    expect(html).toContain("{{range $item := .items}}");
+    expect(html).toContain("{{$item.name}}");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders range with index and element names", () => {
+    const html = renderToDecodedString(
+      <GoRange items="items" indexName="i" elementName="item">
+        <div>
+          <GoVar name="$i" />: <GoVar name="$item.name" />
+        </div>
+      </GoRange>,
+    );
+    expect(html).toContain("{{range $i, $item := .items}}");
+    expect(html).toContain("{{$i}}");
+    expect(html).toContain("{{$item.name}}");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders range with empty fallback", () => {
+    const html = renderToDecodedString(
+      <GoRange items="items" empty={<div>No items</div>}>
+        <div>
+          <GoVar name="Name" />
+        </div>
+      </GoRange>,
+    );
+    expect(html).toContain("{{range .items}}");
+    expect(html).toContain("{{else}}");
+    expect(html).toContain("<div>No items</div>");
+    expect(html).toContain("{{end}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoTrim.spec.tsx
+++ b/libs/rego/src/__tests__/GoTrim.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoTrim } from "@/GoTrim";
+import { GoVar } from "@/GoVar";
+
+describe("GoTrim", () => {
+  test("renders trim transform for field", () => {
+    const html = renderToDecodedString(
+      <GoTrim>
+        <GoVar name="name" />
+      </GoTrim>,
+    );
+    expect(html).toContain("{{.name | trim}}");
+  });
+
+  test("renders trim transform for local variable", () => {
+    const html = renderToDecodedString(
+      <GoTrim>
+        <GoVar name="$item.title" />
+      </GoTrim>,
+    );
+    expect(html).toContain("{{$item.title | trim}}");
+  });
+
+  test("renders null when children is not GoVar", () => {
+    const html = renderToDecodedString(
+      <GoTrim>
+        <div>Not a GoVar</div>
+      </GoTrim>,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/libs/rego/src/__tests__/GoTruncate.spec.tsx
+++ b/libs/rego/src/__tests__/GoTruncate.spec.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoTruncate } from "@/GoTruncate";
+
+describe("GoTruncate", () => {
+  test("renders truncate for field", () => {
+    const html = renderToDecodedString(
+      <GoTruncate var="description" length={100} />,
+    );
+    expect(html).toContain("{{.description | truncate 100}}");
+  });
+
+  test("renders truncate for local variable", () => {
+    const html = renderToDecodedString(
+      <GoTruncate var="$item.description" length={50} />,
+    );
+    expect(html).toContain("{{$item.description | truncate 50}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoUpperCase.spec.tsx
+++ b/libs/rego/src/__tests__/GoUpperCase.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoUpperCase } from "@/GoUpperCase";
+import { GoVar } from "@/GoVar";
+
+describe("GoUpperCase", () => {
+  test("renders uppercase transform for field", () => {
+    const html = renderToDecodedString(
+      <GoUpperCase>
+        <GoVar name="name" />
+      </GoUpperCase>,
+    );
+    expect(html).toContain("{{.name | upper}}");
+  });
+
+  test("renders uppercase transform for local variable", () => {
+    const html = renderToDecodedString(
+      <GoUpperCase>
+        <GoVar name="$item.title" />
+      </GoUpperCase>,
+    );
+    expect(html).toContain("{{$item.title | upper}}");
+  });
+
+  test("renders null when children is not GoVar", () => {
+    const html = renderToDecodedString(
+      <GoUpperCase>
+        <div>Not a GoVar</div>
+      </GoUpperCase>,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/libs/rego/src/__tests__/GoUrl.spec.tsx
+++ b/libs/rego/src/__tests__/GoUrl.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoUrl, goUrl } from "@/GoUrl";
+
+describe("GoUrl", () => {
+  test("renders simple path URL", () => {
+    const html = renderToDecodedString(<GoUrl path="/dashboard" />);
+    expect(html).toContain('{{"/dashboard"}}');
+  });
+
+  test("renders URL with variable", () => {
+    const html = renderToDecodedString(<GoUrl var="dashboardUrl" />);
+    expect(html).toContain("{{.dashboardUrl}}");
+  });
+
+  test("renders URL with query parameters", () => {
+    const html = renderToDecodedString(
+      <GoUrl path="/verify" params={["token", "email"]} />,
+    );
+    expect(html).toContain('{{"/verify" | addQueryParams .token .email}}');
+  });
+
+  test("renders URL with variable path and parameters", () => {
+    const html = renderToDecodedString(
+      <GoUrl var="profileUrl" params={["id", "tab"]} />,
+    );
+    expect(html).toContain("{{.profileUrl | addQueryParams .id .tab}}");
+  });
+
+  test("renders URL with literal values", () => {
+    const html = renderToDecodedString(
+      <GoUrl path="/search" params={["q", "page"]} literalValues={["", "1"]} />,
+    );
+    expect(html).toContain('{{"/search" | addQueryParams "" "1"}}');
+  });
+
+  test("goUrl helper with simple path", () => {
+    const result = goUrl("/dashboard");
+    expect(result).toBe('{{"/dashboard"}}');
+  });
+
+  test("goUrl helper with options object", () => {
+    const result = goUrl({ var: "dashboardUrl" });
+    expect(result).toBe("{{.dashboardUrl}}");
+  });
+
+  test("goUrl helper with params", () => {
+    const result = goUrl({ path: "/verify", params: ["token", "email"] });
+    expect(result).toBe('{{"/verify" | addQueryParams .token .email}}');
+  });
+});

--- a/libs/rego/src/__tests__/GoUseTemplate.spec.tsx
+++ b/libs/rego/src/__tests__/GoUseTemplate.spec.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoUseTemplate } from "@/GoUseTemplate";
+
+describe("GoUseTemplate", () => {
+  test("renders template invocation without data", () => {
+    const html = renderToDecodedString(<GoUseTemplate name="email-header" />);
+    expect(html).toContain('{{template "email-header"}}');
+  });
+
+  test("renders template invocation with data", () => {
+    const html = renderToDecodedString(
+      <GoUseTemplate name="user-info" data="currentUser" />,
+    );
+    expect(html).toContain('{{template "user-info" .currentUser}}');
+  });
+
+  test("renders template invocation ignoring children", () => {
+    const html = renderToDecodedString(
+      <GoUseTemplate name="header">
+        <div>This should be ignored</div>
+      </GoUseTemplate>,
+    );
+    expect(html).toContain('{{template "header"}}');
+    expect(html).not.toContain("This should be ignored");
+  });
+});

--- a/libs/rego/src/__tests__/GoVar.spec.tsx
+++ b/libs/rego/src/__tests__/GoVar.spec.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString } from "./testHelpers";
+import { GoVar, goVar, goLocalVar, goFieldVar } from "@/GoVar";
+
+describe("GoVar", () => {
+  test("renders field access variable syntax", () => {
+    const html = renderToDecodedString(<GoVar name="userName" />);
+    expect(html).toContain("{{.userName}}");
+  });
+
+  test("renders local variable syntax", () => {
+    const html = renderToDecodedString(<GoVar name="$item.Name" />);
+    expect(html).toContain("{{$item.Name}}");
+  });
+
+  test("renders nested field access", () => {
+    const html = renderToDecodedString(<GoVar name="user.profile.name" />);
+    expect(html).toContain("{{.user.profile.name}}");
+  });
+
+  test("goVar helper function returns field syntax", () => {
+    expect(goVar("userName")).toBe("{{.userName}}");
+  });
+
+  test("goVar helper function returns local variable syntax", () => {
+    expect(goVar("$item.Name")).toBe("{{$item.Name}}");
+  });
+
+  test("goLocalVar helper function returns local variable syntax", () => {
+    expect(goLocalVar("item.url")).toBe("{{item.url}}");
+  });
+
+  test("goFieldVar helper function returns field syntax", () => {
+    expect(goFieldVar("DashboardURL")).toBe("{{.DashboardURL}}");
+  });
+});

--- a/libs/rego/src/__tests__/GoWith.spec.tsx
+++ b/libs/rego/src/__tests__/GoWith.spec.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { renderToDecodedString, stripReactComments } from "./testHelpers";
+import { GoWith } from "@/GoWith";
+import { GoVar } from "@/GoVar";
+
+describe("GoWith", () => {
+  test("renders with statement without fallback", () => {
+    const html = stripReactComments(
+      renderToDecodedString(
+        <GoWith value="user">
+          <div>
+            Name: <GoVar name="name" />
+          </div>
+          <div>
+            Email: <GoVar name="email" />
+          </div>
+        </GoWith>,
+      ),
+    );
+    expect(html).toContain("{{with .user}}");
+    expect(html).toContain("<div>Name: {{.name}}</div>");
+    expect(html).toContain("<div>Email: {{.email}}</div>");
+    expect(html).toContain("{{end}}");
+  });
+
+  test("renders with statement with fallback", () => {
+    const html = stripReactComments(
+      renderToDecodedString(
+        <GoWith value="user" fallback="No user found">
+          <div>
+            Welcome, <GoVar name="name" />
+          </div>
+        </GoWith>,
+      ),
+    );
+    expect(html).toContain("{{with .user}}");
+    expect(html).toContain("<div>Welcome, {{.name}}</div>");
+    expect(html).toContain("{{else}}");
+    expect(html).toContain("No user found");
+    expect(html).toContain("{{end}}");
+  });
+});

--- a/libs/rego/src/__tests__/setup.ts
+++ b/libs/rego/src/__tests__/setup.ts
@@ -1,0 +1,23 @@
+// Test setup file
+import { afterEach, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// Cleanup after each test
+afterEach(() => {
+  cleanup();
+});
+
+// Mock window.matchMedia
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/libs/rego/src/__tests__/template-generators.spec.ts
+++ b/libs/rego/src/__tests__/template-generators.spec.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from "vitest";
+import {
+  generateVarSyntax,
+  generateIfStart,
+  generateElse,
+  generateEqualStart,
+  generateEmptyStart,
+  generateRangeStart,
+  generateWithStart,
+  generateWithSyntax,
+  generateEnd,
+  generatePipeSyntax,
+  generateLetSyntax,
+  generateFormatSyntax,
+  generateTruncateSyntax,
+  generateDateSyntax,
+  generateCurrencySyntax,
+  generateFuncSyntax,
+  generateUrlSyntax,
+  generateTransformSyntax,
+  generateChunkSyntax,
+  generateDefineStart,
+  generateDefineSyntax,
+  generateTemplateSyntax,
+  generateCommentSyntax,
+} from "@/template-generators";
+
+describe("template-generators", () => {
+  describe("generateVarSyntax", () => {
+    test("generates field access syntax", () => {
+      expect(generateVarSyntax("userName")).toBe("{{.userName}}");
+      expect(generateVarSyntax("user.name")).toBe("{{.user.name}}");
+    });
+
+    test("generates local variable syntax", () => {
+      expect(generateVarSyntax("$item")).toBe("{{$item}}");
+      expect(generateVarSyntax("$item.name")).toBe("{{$item.name}}");
+    });
+  });
+
+  describe("generateIfStart", () => {
+    test("generates if statement opening syntax", () => {
+      expect(generateIfStart("showBanner")).toBe("{{if .showBanner}}");
+      expect(generateIfStart("isActive")).toBe("{{if .isActive}}");
+    });
+  });
+
+  describe("generateElse", () => {
+    test("generates else syntax", () => {
+      expect(generateElse()).toBe("{{else}}");
+    });
+  });
+
+  describe("generateEqualStart", () => {
+    test("generates equal check with field and literal", () => {
+      expect(generateEqualStart("status", '"active"')).toBe(
+        '{{if eq .status "active"}}',
+      );
+    });
+
+    test("generates equal check with two fields", () => {
+      expect(generateEqualStart("status", "userStatus")).toBe(
+        "{{if eq .status .userStatus}}",
+      );
+    });
+
+    test("generates equal check with local variable", () => {
+      expect(generateEqualStart("$item.type", '"premium"')).toBe(
+        '{{if eq $item.type "premium"}}',
+      );
+    });
+
+    test("generates equal check with number literal", () => {
+      expect(generateEqualStart("count", "0")).toBe("{{if eq .count 0}}");
+    });
+  });
+
+  describe("generateEmptyStart", () => {
+    test("generates empty check for field", () => {
+      expect(generateEmptyStart("items")).toBe("{{if not .items}}");
+      expect(generateEmptyStart("description")).toBe("{{if not .description}}");
+    });
+
+    test("generates empty check for local variable", () => {
+      expect(generateEmptyStart("$item.description")).toBe(
+        "{{if not $item.description}}",
+      );
+    });
+  });
+
+  describe("generateRangeStart", () => {
+    test("generates basic range with dot", () => {
+      expect(generateRangeStart("items", undefined, undefined)).toBe(
+        "{{range .items}}",
+      );
+    });
+
+    test("generates range with element name", () => {
+      expect(generateRangeStart("items", undefined, "item")).toBe(
+        "{{range $item := .items}}",
+      );
+    });
+
+    test("generates range with index and element names", () => {
+      expect(generateRangeStart("items", "i", "item")).toBe(
+        "{{range $i, $item := .items}}",
+      );
+    });
+  });
+
+  describe("generateWithStart", () => {
+    test("generates with statement opening syntax", () => {
+      expect(generateWithStart("user")).toBe("{{with .user}}");
+      expect(generateWithStart("order")).toBe("{{with .order}}");
+    });
+  });
+
+  describe("generateWithSyntax", () => {
+    test("generates with statement without fallback", () => {
+      expect(generateWithSyntax("user", false)).toBe("{{with .user}}{{end}}");
+    });
+
+    test("generates with statement with fallback", () => {
+      expect(generateWithSyntax("user", true)).toBe(
+        "{{with .user}}{{else}}{{end}}",
+      );
+    });
+  });
+
+  describe("generateEnd", () => {
+    test("generates end syntax", () => {
+      expect(generateEnd()).toBe("{{end}}");
+    });
+  });
+
+  describe("generatePipeSyntax", () => {
+    test("generates single transform pipeline", () => {
+      expect(generatePipeSyntax(".text", ["upper"])).toBe("{{.text | upper}}");
+    });
+
+    test("generates multiple transform pipeline", () => {
+      expect(generatePipeSyntax(".text", ["trim", "upper"])).toBe(
+        "{{.text | trim | upper}}",
+      );
+    });
+
+    test("generates pipeline with local variable", () => {
+      expect(generatePipeSyntax("$item.title", ["truncate 50", "upper"])).toBe(
+        "{{$item.title | truncate 50 | upper}}",
+      );
+    });
+  });
+
+  describe("generateLetSyntax", () => {
+    test("generates simple variable assignment", () => {
+      expect(generateLetSyntax("currentUser", ".user")).toBe(
+        "{{$currentUser := .user}}",
+      );
+    });
+
+    test("generates assignment with pipeline", () => {
+      expect(
+        generateLetSyntax("processedText", ".RawText | truncate 100"),
+      ).toBe("{{$processedText := .RawText | truncate 100}}");
+    });
+  });
+
+  describe("generateFormatSyntax", () => {
+    test("generates format without arguments", () => {
+      expect(generateFormatSyntax("Hello %s", [])).toBe(
+        '{{"Hello %s" | printf}}',
+      );
+    });
+
+    test("generates format with arguments", () => {
+      expect(generateFormatSyntax("%s (%s)", [".name", ".Email"])).toBe(
+        '{{"%s (%s)" | printf .name .Email}}',
+      );
+    });
+  });
+
+  describe("generateTruncateSyntax", () => {
+    test("generates truncate for field", () => {
+      expect(generateTruncateSyntax("description", 100)).toBe(
+        "{{.description | truncate 100}}",
+      );
+    });
+
+    test("generates truncate for local variable", () => {
+      expect(generateTruncateSyntax("$item.title", 50)).toBe(
+        "{{$item.title | truncate 50}}",
+      );
+    });
+  });
+
+  describe("generateDateSyntax", () => {
+    test("generates date formatting syntax", () => {
+      expect(generateDateSyntax("createdAt", "Jan 2, 2006")).toBe(
+        '{{.createdAt | formatDate "Jan 2, 2006"}}',
+      );
+    });
+  });
+
+  describe("generateCurrencySyntax", () => {
+    test("generates currency formatting syntax", () => {
+      expect(generateCurrencySyntax("total", "USD")).toBe(
+        '{{.total | formatCurrency "USD"}}',
+      );
+    });
+  });
+
+  describe("generateFuncSyntax", () => {
+    test("generates function call with arguments", () => {
+      expect(
+        generateFuncSyntax("pluralize", [".count", '"item"', '"items"']),
+      ).toBe('{{pluralize .count "item" "items"}}');
+    });
+
+    test("generates function call with single argument", () => {
+      expect(generateFuncSyntax("upper", [".text"])).toBe("{{upper .text}}");
+    });
+  });
+
+  describe("generateUrlSyntax", () => {
+    test("generates URL without params", () => {
+      expect(generateUrlSyntax('"/dashboard"', [])).toBe('{{"/dashboard"}}');
+    });
+
+    test("generates URL with field reference", () => {
+      expect(generateUrlSyntax(".dashboardUrl", [])).toBe("{{.dashboardUrl}}");
+    });
+
+    test("generates URL with query params", () => {
+      expect(generateUrlSyntax('"/verify"', [".Token", ".Email"])).toBe(
+        '{{"/verify" | addQueryParams .Token .Email}}',
+      );
+    });
+  });
+
+  describe("generateTransformSyntax", () => {
+    test("generates upper transform", () => {
+      expect(generateTransformSyntax("name", "upper")).toBe(
+        "{{.name | upper}}",
+      );
+    });
+
+    test("generates lower transform", () => {
+      expect(generateTransformSyntax("$item.title", "lower")).toBe(
+        "{{$item.title | lower}}",
+      );
+    });
+
+    test("generates trim transform", () => {
+      expect(generateTransformSyntax("text", "trim")).toBe("{{.text | trim}}");
+    });
+  });
+
+  describe("generateChunkSyntax", () => {
+    test("generates chunk without index", () => {
+      expect(generateChunkSyntax("items", 3, "chunk", undefined)).toBe(
+        "{{$chunk := chunk .items 3}}",
+      );
+    });
+
+    test("generates chunk with index", () => {
+      expect(generateChunkSyntax("items", 3, "chunk", "chunkIndex")).toBe(
+        "{{$chunkIndex, $chunk := chunk .items 3}}",
+      );
+    });
+  });
+
+  describe("generateDefineStart", () => {
+    test("generates define opening syntax", () => {
+      expect(generateDefineStart("email-header")).toBe(
+        '{{define "email-header"}}',
+      );
+    });
+  });
+
+  describe("generateDefineSyntax", () => {
+    test("generates define syntax", () => {
+      expect(generateDefineSyntax("email-header")).toBe(
+        '{{define "email-header"}}{{end}}',
+      );
+    });
+  });
+
+  describe("generateTemplateSyntax", () => {
+    test("generates template invocation without data", () => {
+      expect(generateTemplateSyntax("email-header", undefined)).toBe(
+        '{{template "email-header"}}',
+      );
+    });
+
+    test("generates template invocation with data", () => {
+      expect(generateTemplateSyntax("user-info", "currentUser")).toBe(
+        '{{template "user-info" .currentUser}}',
+      );
+    });
+  });
+
+  describe("generateCommentSyntax", () => {
+    test("generates comment syntax", () => {
+      expect(generateCommentSyntax("This is a comment")).toBe(
+        "{{/* This is a comment */}}",
+      );
+    });
+  });
+});

--- a/libs/rego/src/__tests__/testHelpers.ts
+++ b/libs/rego/src/__tests__/testHelpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Test helper utilities
+ */
+
+import { renderToString } from 'react-dom/server';
+
+/**
+ * Decodes HTML entities in a string
+ * Converts &quot; -> ", &apos; -> ', &lt; -> <, &gt; -> >, &amp; -> &
+ */
+export function decodeHtmlEntities(html: string): string {
+  const textArea = document.createElement('textarea');
+  textArea.innerHTML = html;
+  return textArea.value;
+}
+
+/**
+ * Renders a React component to string and decodes HTML entities
+ */
+export function renderToDecodedString(jsx: React.ReactNode): string {
+  const html = renderToString(jsx);
+  return decodeHtmlEntities(html);
+}
+
+/**
+ * Removes React's comment nodes from rendered HTML
+ * React inserts <!-- --> between fragments which can interfere with string matching
+ */
+export function stripReactComments(html: string): string {
+  return html.replace(/<!--\s*-->/g, '');
+}

--- a/libs/rego/src/__tests__/utils.spec.ts
+++ b/libs/rego/src/__tests__/utils.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { normalizeVarName } from "@/utils";
+
+describe("utils", () => {
+  describe("normalizeVarName", () => {
+    test("prefixes field variables with dot", () => {
+      expect(normalizeVarName("userName")).toBe(".userName");
+      expect(normalizeVarName("user.name")).toBe(".user.name");
+      expect(normalizeVarName("items")).toBe(".items");
+    });
+
+    test("preserves local variable syntax", () => {
+      expect(normalizeVarName("$item")).toBe("$item");
+      expect(normalizeVarName("$item.Name")).toBe("$item.Name");
+      expect(normalizeVarName("$idx")).toBe("$idx");
+    });
+  });
+});

--- a/libs/rego/src/index.ts
+++ b/libs/rego/src/index.ts
@@ -1,0 +1,81 @@
+/**
+ * @lumeweb/rego - React-to-Go Template DSL for Email Generation
+ *
+ * This library provides React components that output Go template syntax
+ * wrapped around React Email components. The generated HTML contains
+ * Go template tags that can be executed by Go at runtime.
+ */
+
+// Core DSL components
+export { GoVar, goVar, goLocalVar, goFieldVar } from './GoVar'
+export { GoIf, GoElse } from './GoIf'
+export { GoRange } from './GoRange'
+export { GoWith } from './GoWith'
+
+// Template Composition
+export { GoDefine } from './GoDefine'
+export { GoUseTemplate } from './GoUseTemplate'
+export { GoBlock } from './GoBlock'
+
+// Data Transformation Helpers
+export { GoDate, goDate } from './GoDate'
+export { GoCurrency, goCurrency } from './GoCurrency'
+export { GoTruncate } from './GoTruncate'
+
+// String Transformations
+export { GoUpperCase } from './GoUpperCase'
+export { GoLowerCase } from './GoLowerCase'
+export { GoTrim } from './GoTrim'
+
+// Pipeline and Variable Assignment
+export { GoPipe } from './GoPipe'
+export { GoLet } from './GoLet'
+export { GoFormat } from './GoFormat'
+
+// Function Invocation
+export { GoFunc, goFunc } from './GoFunc'
+
+// URL Generation
+export { GoUrl, goUrl } from './GoUrl'
+
+// Array Operations
+export { GoChunk } from './GoChunk'
+
+// Comments
+export { GoComment } from './GoComment'
+
+// Conditional Helpers
+export { GoEqual } from './GoEqual'
+export { GoEmpty } from './GoEmpty'
+
+// Types
+export type { TemplateData } from './types'
+
+// Utilities
+export { normalizeVarName, splitElseBlocks, extractGoVarName } from './utils'
+
+// Template Generators
+export {
+  generateVarSyntax,
+  generateIfStart,
+  generateElse,
+  generateEnd,
+  generateEqualStart,
+  generateEmptyStart,
+  generateRangeStart,
+  generateWithStart,
+  generatePipeSyntax,
+  generateLetSyntax,
+  generateFormatSyntax,
+  generateTruncateSyntax,
+  generateDateSyntax,
+  generateCurrencySyntax,
+  generateFuncSyntax,
+  generateUrlSyntax,
+  generateTransformSyntax,
+  generateChunkSyntax,
+  generateDefineStart,
+  generateDefineSyntax,
+  generateTemplateSyntax,
+  generateCommentSyntax,
+} from './template-generators'

--- a/libs/rego/src/template-generators.ts
+++ b/libs/rego/src/template-generators.ts
@@ -1,0 +1,408 @@
+/**
+ * Pure template syntax generation functions
+ *
+ * These functions generate Go template syntax strings without any React dependencies.
+ * They can be tested in isolation and reused by both React components and helper functions.
+ */
+
+import { normalizeVarName } from "./utils";
+
+/**
+ * Generates Go template variable syntax
+ *
+ * @param name - Variable name (e.g., "userName" or "$item.Name")
+ * @returns Go template syntax (e.g., "{{.userName}}" or "{{$item.Name}}")
+ *
+ * @example
+ * generateVarSyntax("userName") // "{{.userName}}"
+ * generateVarSyntax("$item.Name") // "{{$item.Name}}"
+ */
+export function generateVarSyntax(name: string): string {
+  const isLocalVar = name.startsWith("$");
+  return isLocalVar ? `{{${name}}}` : `{{.${name}}}`;
+}
+
+/**
+ * Generates Go template if statement opening syntax
+ *
+ * @param condition - Condition variable name
+ * @returns Template opening syntax for if statement
+ *
+ * @example
+ * generateIfStart("showBanner") // "{{if .showBanner}}"
+ */
+export function generateIfStart(condition: string): string {
+  return `{{if .${condition}}}`;
+}
+
+/**
+ * Generates Go template else syntax
+ *
+ * @returns Template else syntax
+ *
+ * @example
+ * generateElse() // "{{else}}"
+ */
+export function generateElse(): string {
+  return "{{else}}";
+}
+
+/**
+ * Generates Go template equal check opening syntax
+ *
+ * @param var1 - First variable name
+ * @param var2 - Second variable or literal value
+ * @returns Template opening syntax for equal check
+ *
+ * @example
+ * generateEqualStart("status", "active") // "{{if eq .Status "active"}}"
+ * generateEqualStart("$item.type", "premium") // "{{if eq $item.Type "premium"}}"
+ */
+export function generateEqualStart(var1: string, var2: string): string {
+  const var1Syntax = normalizeVarName(var1);
+  
+  const isLocalVar2 = var2.startsWith("$");
+  const isNumberLiteral = !isNaN(Number(var2));
+  let var2Syntax: string;
+  
+  if (isLocalVar2) {
+    var2Syntax = var2;
+  } else if (isNumberLiteral) {
+    var2Syntax = var2;
+  } else if (var2.startsWith('"')) {
+    var2Syntax = var2;
+  } else if (var2.startsWith("'")) {
+    // Convert single-quoted string to double-quoted for Go template
+    var2Syntax = `"${var2.slice(1, -1)}"`;
+  } else {
+    var2Syntax = "." + var2;
+  }
+
+  return `{{if eq ${var1Syntax} ${var2Syntax}}}`;
+}
+
+/**
+ * Generates Go template empty check opening syntax
+ *
+ * @param varName - Variable name to check
+ * @returns Template opening syntax for empty check
+ *
+ * @example
+ * generateEmptyStart("items") // "{{if not .Items}}"
+ * generateEmptyStart("$item.description") // "{{if not $item.Description}}"
+ */
+export function generateEmptyStart(varName: string): string {
+  const varSyntax = normalizeVarName(varName);
+  return `{{if not ${varSyntax}}}`;
+}
+
+/**
+ * Generates Go template range loop opening syntax
+ *
+ * @param items - Array variable name
+ * @param indexName - Optional index variable name
+ * @param elementName - Optional element variable name
+ * @returns Template opening syntax for range loop
+ *
+ * @example
+ * generateRangeStart("items", undefined, undefined) // "{{range .items}}"
+ * generateRangeStart("items", undefined, "item") // "{{range $item := .items}}"
+ * generateRangeStart("items", "i", "item") // "{{range $i, $item := .items}}"
+ */
+export function generateRangeStart(
+  items: string,
+  indexName?: string,
+  elementName?: string
+): string {
+  if (indexName && elementName) {
+    return `{{range $${indexName}, $${elementName} := .${items}}}`;
+  }
+  if (elementName) {
+    return `{{range $${elementName} := .${items}}}`;
+  }
+  return `{{range .${items}}}`;
+}
+
+/**
+ * Generates Go template with statement opening syntax
+ *
+ * @param value - Variable name to switch context to
+ * @returns Template opening syntax for with statement
+ *
+ * @example
+ * generateWithStart("user") // "{{with .user}}"
+ */
+export function generateWithStart(value: string): string {
+  return `{{with .${value}}}`;
+}
+
+/**
+ * Generates Go template end syntax
+ *
+ * @returns Template end syntax
+ *
+ * @example
+ * generateEnd() // "{{end}}"
+ */
+export function generateEnd(): string {
+  return "{{end}}";
+}
+
+
+
+
+
+
+
+
+
+/**
+ * Generates Go template with statement syntax
+ *
+ * @param value - Variable name to switch context to
+ * @param hasFallback - Whether a fallback block exists
+ * @returns Template syntax for with statement
+ *
+ * @example
+ * generateWithSyntax("user", false) // "{{with .user}}...{{end}}"
+ * generateWithSyntax("user", true) // "{{with .user}}...{{else}}...{{end}}"
+ */
+export function generateWithSyntax(value: string, hasFallback: boolean = false): string {
+  if (hasFallback) {
+    return `{{with .${value}}}{{else}}{{end}}`;
+  }
+  return `{{with .${value}}}{{end}}`;
+}
+
+/**
+ * Generates Go template pipeline syntax
+ *
+ * @param value - Base value (e.g., ".Text" or "$item.title")
+ * @param transforms - Array of transform specifiers (e.g., ["upper", "truncate 50"])
+ * @returns Template syntax for pipeline
+ *
+ * @example
+ * generatePipeSyntax(".Text", ["upper"]) // "{{.Text | upper}}"
+ * generatePipeSyntax("$item.title", ["truncate 50", "upper"]) // "{{$item.Title | truncate 50 | upper}}"
+ */
+export function generatePipeSyntax(value: string, transforms: string[]): string {
+  let pipeline = value;
+  transforms.forEach((transform) => {
+    pipeline += ` | ${transform}`;
+  });
+  return `{{${pipeline}}}`;
+}
+
+/**
+ * Generates Go template variable assignment syntax
+ *
+ * @param name - Variable name (without $ prefix)
+ * @param assignment - Assignment expression
+ * @returns Template syntax for variable assignment
+ *
+ * @example
+ * generateLetSyntax("currentUser", ".user") // "{{$currentUser := .user}}"
+ * generateLetSyntax("processedText", ".RawText | truncate 100") // "{{$processedText := .RawText | truncate 100}}"
+ */
+export function generateLetSyntax(name: string, assignment: string): string {
+  return `{{$${name} := ${assignment}}}`;
+}
+
+/**
+ * Generates Go template printf formatting syntax
+ *
+ * @param format - Printf format string
+ * @param args - Array of argument strings
+ * @returns Template syntax for printf
+ *
+ * @example
+ * generateFormatSyntax("%s (%s)", [".Name", ".Email"]) // "{{"%s (%s)" | printf .Name .Email}}"
+ * generateFormatSyntax("Hello %s", []) // "{{"Hello %s" | printf}}"
+ */
+export function generateFormatSyntax(format: string, args: string[]): string {
+  if (args.length === 0) {
+    return `{{"${format}" | printf}}`;
+  }
+  return `{{"${format}" | printf ${args.join(" ")}}}`;
+}
+
+/**
+ * Generates Go template truncate syntax
+ *
+ * @param varName - Variable name
+ * @param length - Maximum length
+ * @returns Template syntax for truncate
+ *
+ * @example
+ * generateTruncateSyntax("description", 100) // "{{.Description | truncate 100}}"
+ * generateTruncateSyntax("$item.title", 50) // "{{$item.Title | truncate 50}}"
+ */
+export function generateTruncateSyntax(varName: string, length: number): string {
+  const varSyntax = normalizeVarName(varName);
+  return `{{${varSyntax} | truncate ${length}}}`;
+}
+
+/**
+ * Generates Go template date formatting syntax
+ *
+ * @param varName - Variable name containing the date
+ * @param format - Go date format layout
+ * @returns Template syntax for date formatting
+ *
+ * @example
+ * generateDateSyntax("createdAt", "Jan 2, 2006") // "{{.CreatedAt | formatDate "Jan 2, 2006"}}"
+ */
+export function generateDateSyntax(varName: string, format: string): string {
+  const varSyntax = normalizeVarName(varName);
+  return `{{${varSyntax} | formatDate "${format}"}}`;
+}
+
+/**
+ * Generates Go template currency formatting syntax
+ *
+ * @param varName - Variable name containing the amount
+ * @param currency - Currency code
+ * @returns Template syntax for currency formatting
+ *
+ * @example
+ * generateCurrencySyntax("total", "USD") // "{{.Total | formatCurrency "USD"}}"
+ */
+export function generateCurrencySyntax(varName: string, currency: string): string {
+  const varSyntax = normalizeVarName(varName);
+  return `{{${varSyntax} | formatCurrency "${currency}"}}`;
+}
+
+/**
+ * Generates Go template function invocation syntax
+ *
+ * @param name - Function name
+ * @param args - Array of argument strings
+ * @returns Template syntax for function call
+ *
+ * @example
+ * generateFuncSyntax("pluralize", [".count", '"item"', '"items"']) // "{{pluralize .Count "item" "items"}}"
+ */
+export function generateFuncSyntax(name: string, args: string[]): string {
+  return `{{${name} ${args.join(" ")}}}`;
+}
+
+/**
+ * Generates Go template URL syntax
+ *
+ * @param baseURL - Base URL (can be literal or variable)
+ * @param params - Array of parameter variable names (optional)
+ * @returns Template syntax for URL
+ *
+ * @example
+ * generateUrlSyntax('"/dashboard"', []) // '{{"/dashboard"}}'
+ * generateUrlSyntax(".dashboardUrl", []) // "{{.DashboardUrl}}"
+ * generateUrlSyntax('"/verify'", [".Token", ".Email"]) // '{{"/verify" | addQueryParams .Token .Email}}'
+ */
+export function generateUrlSyntax(baseURL: string, params: string[] = []): string {
+  if (params.length === 0) {
+    return `{{${baseURL}}}`;
+  }
+  return `{{${baseURL} | addQueryParams ${params.join(" ")}}}`;
+}
+
+/**
+ * Generates Go template string transform syntax
+ *
+ * @param varName - Variable name
+ * @param transform - Transform type (upper, lower, trim)
+ * @returns Template syntax for transform
+ *
+ * @example
+ * generateTransformSyntax("name", "upper") // "{{.Name | upper}}"
+ * generateTransformSyntax("$item.title", "lower") // "{{$item.Title | lower}}"
+ */
+export function generateTransformSyntax(varName: string, transform: "upper" | "lower" | "trim"): string {
+  const varSyntax = normalizeVarName(varName);
+  return `{{${varSyntax} | ${transform}}}`;
+}
+
+/**
+ * Generates Go template chunk syntax
+ *
+ * @param items - Array variable name
+ * @param size - Chunk size
+ * @param elementName - Chunk element variable name
+ * @param indexName - Optional chunk index variable name
+ * @returns Template syntax for chunk
+ *
+ * @example
+ * generateChunkSyntax("items", 3, "chunk", undefined) // "{{$chunk := chunk .Items 3}}"
+ * generateChunkSyntax("items", 3, "chunk", "chunkIndex") // "{{$chunkIndex, $chunk := chunk .Items 3}}"
+ */
+export function generateChunkSyntax(
+  items: string,
+  size: number,
+  elementName: string,
+  indexName?: string
+): string {
+  const itemsSyntax = normalizeVarName(items);
+  
+  if (indexName) {
+    return `{{$${indexName}, $${elementName} := chunk ${itemsSyntax} ${size}}}`;
+  }
+  return `{{$${elementName} := chunk ${itemsSyntax} ${size}}}`;
+}
+
+/**
+ * Generates Go template define opening syntax
+ *
+ * @param name - Template name
+ * @returns Template opening syntax for define
+ *
+ * @example
+ * generateDefineStart("email-header") // '{{define "email-header"}}'
+ */
+export function generateDefineStart(name: string): string {
+  return `{{define "${name}"}}`;
+}
+
+/**
+ * Generates Go template define syntax
+ *
+ * @param name - Template name
+ * @returns Template syntax for define
+ *
+ * @example
+ * generateDefineSyntax("email-header") // '{{define "email-header"}}...{{end}}'
+ */
+export function generateDefineSyntax(name: string): string {
+  return `{{define "${name}"}}{{end}}`;
+}
+
+/**
+ * Generates Go template invocation syntax
+ *
+ * @param name - Template name
+ * @param data - Optional data variable name
+ * @returns Template syntax for template invocation
+ *
+ * @example
+ * generateTemplateSyntax("email-header", undefined) // '{{template "email-header"}}'
+ * generateTemplateSyntax("user-info", "currentUser") // '{{template "user-info" .currentUser}}'
+ */
+export function generateTemplateSyntax(name: string, data?: string): string {
+  if (data) {
+    return `{{template "${name}" .${data}}}`;
+  }
+  return `{{template "${name}"}}`;
+}
+
+/**
+ * Generates Go template comment syntax
+ *
+ * @param text - Comment text
+ * @returns Template syntax for comment
+ *
+ * @example
+ * generateCommentSyntax("This is a comment") // '{{&#47;* This is a comment *&#47;}}'
+ */
+export function generateCommentSyntax(text: string): string {
+  return `{{/* ${text} */}}`;
+}
+
+

--- a/libs/rego/src/types.ts
+++ b/libs/rego/src/types.ts
@@ -1,0 +1,34 @@
+/**
+ * React-to-Go Template DSL for Email Generation
+ *
+ * This library provides a thin React DSL layer that wraps React Email components
+ * and outputs Go template syntax. The generated HTML contains Go template tags
+ * that can be executed by Go at runtime.
+ */
+
+/**
+ * Represents a Go template variable reference
+ * Outputs: {{.VariableName}}
+ */
+export interface GoTemplateVar {
+  type: 'var'
+  name: string
+  defaultValue?: string
+}
+
+/**
+ * Creates a Go template variable reference
+ * @example
+ * <GoVar name="userName">Default Name</GoVar>
+ * // Outputs: {{.userName}}
+ */
+export function GoVar(name: string, defaultValue?: string): GoTemplateVar {
+  return { type: 'var', name, defaultValue }
+}
+
+/**
+ * Template data interface - the shape of data passed to Go templates
+ */
+export interface TemplateData {
+  [key: string]: any
+}

--- a/libs/rego/src/utils.ts
+++ b/libs/rego/src/utils.ts
@@ -1,0 +1,103 @@
+import React from "react";
+import { GoVar } from "./GoVar";
+
+/**
+ * Normalizes a variable name to Go template syntax.
+ * 
+ * If the variable starts with "$", it's treated as a local variable
+ * and returned as-is (e.g., "$myVar" stays "$myVar").
+ * Otherwise, it's prefixed with "." to reference a field from the current context
+ * (e.g., "myVar" becomes ".myVar").
+ * 
+ * @param varName - The variable name to normalize
+ * @returns The normalized variable name for Go template usage
+ * 
+ * @example
+ * normalizeVarName("userName") // Returns ".userName"
+ * normalizeVarName("$item") // Returns "$item"
+ */
+export function normalizeVarName(varName: string): string {
+  const isLocalVar = varName.startsWith("$");
+  return isLocalVar ? varName : "." + varName;
+}
+
+/**
+ * Splits React children into if-block and else-block sections.
+ * 
+ * This function iterates through children and separates them into two arrays:
+ * - All children before the first GoElse component go into ifBlock
+ * - All children after the first GoElse component go into elseBlock
+ * 
+ * @param children - React children to split
+ * @returns Object containing ifBlock and elseBlock arrays
+ * 
+ * @example
+ * const { ifBlock, elseBlock } = splitElseBlocks(
+ *   <GoIf condition="isActive">
+ *     <Text>Active</Text>
+ *     <GoElse />
+ *     <Text>Inactive</Text>
+ *   </GoIf>
+ * );
+ */
+export function splitElseBlocks(
+  children: React.ReactNode
+): { ifBlock: React.ReactNode[]; elseBlock: React.ReactNode[] } {
+  const ifBlock: React.ReactNode[] = [];
+  const elseBlock: React.ReactNode[] = [];
+  let inElse = false;
+
+  React.Children.forEach(children, (child) => {
+    if (React.isValidElement(child)) {
+      // Check if this is a GoElse component
+      const isGoElse =
+        (child.type as any)?.name === "GoElse" ||
+        (child.type as any)?.displayName === "GoElse";
+
+      if (isGoElse) {
+        inElse = true;
+        // Add the GoElse component's children to elseBlock
+        if (child.props.children) {
+          elseBlock.push(child.props.children);
+        }
+        return;
+      }
+    }
+
+    if (inElse) {
+      elseBlock.push(child);
+    } else {
+      ifBlock.push(child);
+    }
+  });
+
+  return { ifBlock, elseBlock };
+}
+
+/**
+ * Extracts the variable name from a GoVar component in the children.
+ * 
+ * This function looks for a GoVar component as the first child and returns
+ * its name prop. Returns null if no GoVar is found or if the GoVar has no name.
+ * 
+ * @param children - React children to search
+ * @returns The variable name from GoVar, or null if not found
+ * 
+ * @example
+ * extractGoVarName(<GoVar name="userName" />) // Returns "userName"
+ * extractGoVarName(<Text>Hello</Text>) // Returns null
+ */
+export function extractGoVarName(children: React.ReactNode): string | null {
+  const childArray = React.Children.toArray(children);
+  const firstChild = childArray[0];
+
+  if (
+    React.isValidElement(firstChild) &&
+    (firstChild.type as any)?.name === "GoVar"
+  ) {
+    const varName = firstChild.props.name;
+    return varName || null;
+  }
+
+  return null;
+}

--- a/libs/rego/tsconfig.json
+++ b/libs/rego/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/rego/tsdown.config.ts
+++ b/libs/rego/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+import { createLibraryConfig, entryPatterns } from "@lumeweb/tsdown-config";
+
+export default defineConfig(
+  createLibraryConfig(entryPatterns.withoutTests, {
+    hash: false,
+  })
+);

--- a/libs/rego/vitest.config.ts
+++ b/libs/rego/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/__tests__/setup.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,7 +393,7 @@ importers:
         version: 19.2.3
       vocs:
         specifier: ^1.4.1
-        version: 1.4.1(@types/node@25.0.6)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3)
+        version: 1.4.1(@types/node@25.0.6)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3)
 
   apps/lumeweb.com:
     dependencies:
@@ -1701,6 +1701,37 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+
+  libs/rego:
+    dependencies:
+      '@react-email/components':
+        specifier: 1.0.4
+        version: 1.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.3
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@lumeweb/tsdown-config':
+        specifier: workspace:*
+        version: link:../tsdown-config
+      '@react-email/preview-server':
+        specifier: 5.2.2
+        version: 5.2.2(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2)
+      react-email:
+        specifier: 5.2.2
+        version: 5.2.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.19.0-beta.5(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@types/node@25.0.6)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.15)(happy-dom@20.1.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(yaml@2.8.2)
 
   libs/tsdown-config:
     devDependencies:
@@ -3343,6 +3374,57 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@next/env@16.1.1':
+    resolution: {integrity: sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==}
+
+  '@next/swc-darwin-arm64@16.1.1':
+    resolution: {integrity: sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.1.1':
+    resolution: {integrity: sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.1.1':
+    resolution: {integrity: sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@16.1.1':
+    resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@16.1.1':
+    resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@16.1.1':
+    resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@16.1.1':
+    resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.1.1':
+    resolution: {integrity: sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
@@ -4352,6 +4434,168 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-email/body@0.2.1':
+    resolution: {integrity: sha512-ljDiQiJDu/Fq//vSIIP0z5Nuvt4+DX1RqGasstChDGJB/14ogd4VdNS9aacoede/ZjGy3o3Qb+cxyS+XgM6SwQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/button@0.2.1':
+    resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-block@0.2.1':
+    resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-inline@0.0.6':
+    resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/column@0.0.14':
+    resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/components@1.0.4':
+    resolution: {integrity: sha512-XpSs/mN0APMD9E3TYZnj8N6kRXqb6WBl9WrE+IHyB4PdgLNqXe7uZ5+5oZkKSE8Tskzw/K2vDJUqSZ2v+sRjUA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/container@0.0.16':
+    resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/font@0.0.10':
+    resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/head@0.0.13':
+    resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/heading@0.0.16':
+    resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/hr@0.0.12':
+    resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/html@0.0.12':
+    resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/img@0.0.12':
+    resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/link@0.0.13':
+    resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/markdown@0.0.18':
+    resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/preview-server@5.2.2':
+    resolution: {integrity: sha512-wdxN+kIWNgBoVpQUUIRgzn36qea5LI56oCFHKJIjyBWL0UloKicGQUUI4bmqcFsyHUK7p1NddG+UoJpWWyW2Vw==}
+
+  '@react-email/preview@0.0.14':
+    resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.2':
+    resolution: {integrity: sha512-AGuNo86TP9Y2JBUwFcT+z0frPDML4WLIFlnCi7laCPYJA+43kdim0y+qRNPxRxZkJiUz1JMPnE2M5HaNYhWwIg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/row@0.0.13':
+    resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/section@0.0.17':
+    resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/tailwind@2.0.3':
+    resolution: {integrity: sha512-URXb/T2WS4RlNGM5QwekYnivuiVUcU87H0y5sqLl6/Oi3bMmgL0Bmw/W9GeJylC+876Vw+E6NkE0uRiUFIQwGg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@react-email/body': 0.2.1
+      '@react-email/button': 0.2.1
+      '@react-email/code-block': 0.2.1
+      '@react-email/code-inline': 0.0.6
+      '@react-email/container': 0.0.16
+      '@react-email/heading': 0.0.16
+      '@react-email/hr': 0.0.12
+      '@react-email/img': 0.0.12
+      '@react-email/link': 0.0.13
+      '@react-email/preview': 0.0.14
+      '@react-email/text': 0.1.6
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@react-email/body':
+        optional: true
+      '@react-email/button':
+        optional: true
+      '@react-email/code-block':
+        optional: true
+      '@react-email/code-inline':
+        optional: true
+      '@react-email/container':
+        optional: true
+      '@react-email/heading':
+        optional: true
+      '@react-email/hr':
+        optional: true
+      '@react-email/img':
+        optional: true
+      '@react-email/link':
+        optional: true
+      '@react-email/preview':
+        optional: true
+
+  '@react-email/text@0.1.6':
+    resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@react-native/assets-registry@0.83.1':
     resolution: {integrity: sha512-AT7/T6UwQqO39bt/4UL5EXvidmrddXrt0yJa7ENXndAv+8yBzMsZn6fyiax6+ERMt9GLzAECikv3lj22cn2wJA==}
     engines: {node: '>= 20.19.4'}
@@ -4756,6 +5000,9 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
@@ -4816,6 +5063,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -5077,6 +5327,9 @@ packages:
     resolution: {integrity: sha512-EwquDRUDVvWcZds3T2abmB5wSN/Vattal4YtZ6fpBlIUqONV4o/cOBX39cFfQSUCBrIXIjQ6RmapQCHK/PvBYw==}
     peerDependencies:
       storybook: ^8.6.15
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
@@ -5386,6 +5639,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -5997,6 +6253,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -6182,6 +6446,9 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  atomically@2.1.0:
+    resolution: {integrity: sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==}
+
   autoprefixer@10.4.23:
     resolution: {integrity: sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6243,6 +6510,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
@@ -6497,6 +6768,9 @@ packages:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
 
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -6519,6 +6793,10 @@ packages:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -6530,6 +6808,9 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -6597,6 +6878,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -6636,8 +6921,15 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  conf@15.0.2:
+    resolution: {integrity: sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==}
+    engines: {node: '>=20'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
   configstore@5.0.1:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
@@ -6646,6 +6938,10 @@ packages:
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -6685,6 +6981,10 @@ packages:
 
   core-js-pure@3.47.0:
     resolution: {integrity: sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -6967,6 +7267,14 @@ packages:
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -7210,6 +7518,10 @@ packages:
   dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
 
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -7302,6 +7614,14 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.5:
+    resolution: {integrity: sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==}
+    engines: {node: '>=10.2.0'}
+
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
@@ -7321,6 +7641,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   err-code@3.0.1:
     resolution: {integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==}
@@ -7598,6 +7922,9 @@ packages:
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -8149,11 +8476,18 @@ packages:
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
@@ -8568,6 +8902,10 @@ packages:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
 
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-upper-case@1.1.2:
     resolution: {integrity: sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==}
 
@@ -8873,6 +9211,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -8954,6 +9295,9 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   level-supports@6.2.0:
     resolution: {integrity: sha512-QNxVXP0IRnBmMsJIh+sb2kwNCYcKciQZJEt+L1hPCHrKNELllXhvrlClVHXBYZVT+a7aTSM6StgNXdAldoab3w==}
@@ -9156,6 +9500,14 @@ packages:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   log4js@6.9.1:
     resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
     engines: {node: '>=8.0'}
@@ -9262,6 +9614,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
@@ -9778,6 +10135,27 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
+  next@16.1.1:
+    resolution: {integrity: sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
@@ -9893,6 +10271,11 @@ packages:
         optional: true
       react-router-dom:
         optional: true
+
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
 
   oas-kit-common@1.0.8:
     resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
@@ -10016,6 +10399,10 @@ packages:
   ora@7.0.1:
     resolution: {integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==}
     engines: {node: '>=16'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   orval@7.18.0:
     resolution: {integrity: sha512-mPGSQeAAxhvRoxMKn22vmmtFa5eoJiwTBUSsrwKjKjC+rJdA3eWOLRiU1ICq2lep22S+3qpEy5WizP5FW26+rg==}
@@ -10152,6 +10539,9 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -10212,6 +10602,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
+
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -10255,6 +10648,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   playwright-core@1.57.0:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
@@ -10341,6 +10737,10 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
@@ -10623,6 +11023,11 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-email@5.2.2:
+    resolution: {integrity: sha512-tRamuPw48cH1hYxPJXvnqqA+z49JkUjDkHVJ5lrQ/8h2Oo31H2M7HW11qfqJTMaqh4TmmgaVyAqEey+hO0vT4Q==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   react-error-boundary@6.0.3:
     resolution: {integrity: sha512-5guqn2UYpCFjE8UDMA8J7Kke+YSGBFrKQRJb3XdcaGZXYINZfQXgBt3ifY6MvjkN7QROc5A8zclyoSCwrcRUKw==}
@@ -11223,6 +11628,9 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -11396,6 +11804,17 @@ packages:
   snake-case@2.1.0:
     resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
 
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
+
+  socket.io-parser@4.2.5:
+    resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -11475,6 +11894,10 @@ packages:
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -11592,6 +12015,12 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -11600,6 +12029,19 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
@@ -12118,6 +12560,10 @@ packages:
 
   uint8-varint@2.0.4:
     resolution: {integrity: sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   uint8arraylist@2.4.8:
     resolution: {integrity: sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==}
@@ -12707,6 +13153,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   wherearewe@2.0.1:
     resolution: {integrity: sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==}
@@ -15481,6 +15930,32 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/env@16.1.1': {}
+
+  '@next/swc-darwin-arm64@16.1.1':
+    optional: true
+
+  '@next/swc-darwin-x64@16.1.1':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.1.1':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.1.1':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.1.1':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.1.1':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.1.1':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.1.1':
+    optional: true
+
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.9.7':
@@ -16643,6 +17118,143 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-email/body@0.2.1(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/button@0.2.1(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/code-block@0.2.1(react@19.2.3)':
+    dependencies:
+      prismjs: 1.30.0
+      react: 19.2.3
+
+  '@react-email/code-inline@0.0.6(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/column@0.0.14(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/components@1.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@react-email/body': 0.2.1(react@19.2.3)
+      '@react-email/button': 0.2.1(react@19.2.3)
+      '@react-email/code-block': 0.2.1(react@19.2.3)
+      '@react-email/code-inline': 0.0.6(react@19.2.3)
+      '@react-email/column': 0.0.14(react@19.2.3)
+      '@react-email/container': 0.0.16(react@19.2.3)
+      '@react-email/font': 0.0.10(react@19.2.3)
+      '@react-email/head': 0.0.13(react@19.2.3)
+      '@react-email/heading': 0.0.16(react@19.2.3)
+      '@react-email/hr': 0.0.12(react@19.2.3)
+      '@react-email/html': 0.0.12(react@19.2.3)
+      '@react-email/img': 0.0.12(react@19.2.3)
+      '@react-email/link': 0.0.13(react@19.2.3)
+      '@react-email/markdown': 0.0.18(react@19.2.3)
+      '@react-email/preview': 0.0.14(react@19.2.3)
+      '@react-email/render': 2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-email/row': 0.0.13(react@19.2.3)
+      '@react-email/section': 0.0.17(react@19.2.3)
+      '@react-email/tailwind': 2.0.3(@react-email/body@0.2.1(react@19.2.3))(@react-email/button@0.2.1(react@19.2.3))(@react-email/code-block@0.2.1(react@19.2.3))(@react-email/code-inline@0.0.6(react@19.2.3))(@react-email/container@0.0.16(react@19.2.3))(@react-email/heading@0.0.16(react@19.2.3))(@react-email/hr@0.0.12(react@19.2.3))(@react-email/img@0.0.12(react@19.2.3))(@react-email/link@0.0.13(react@19.2.3))(@react-email/preview@0.0.14(react@19.2.3))(@react-email/text@0.1.6(react@19.2.3))(react@19.2.3)
+      '@react-email/text': 0.1.6(react@19.2.3)
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
+  '@react-email/container@0.0.16(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/font@0.0.10(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/head@0.0.13(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/heading@0.0.16(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/hr@0.0.12(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/html@0.0.12(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/img@0.0.12(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/link@0.0.13(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/markdown@0.0.18(react@19.2.3)':
+    dependencies:
+      marked: 15.0.12
+      react: 19.2.3
+
+  '@react-email/preview-server@5.2.2(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2)':
+    dependencies:
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@opentelemetry/api'
+      - '@playwright/test'
+      - babel-plugin-macros
+      - babel-plugin-react-compiler
+      - react
+      - react-dom
+      - sass
+
+  '@react-email/preview@0.0.14(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/render@2.0.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.7.4
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@react-email/row@0.0.13(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/section@0.0.17(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
+  '@react-email/tailwind@2.0.3(@react-email/body@0.2.1(react@19.2.3))(@react-email/button@0.2.1(react@19.2.3))(@react-email/code-block@0.2.1(react@19.2.3))(@react-email/code-inline@0.0.6(react@19.2.3))(@react-email/container@0.0.16(react@19.2.3))(@react-email/heading@0.0.16(react@19.2.3))(@react-email/hr@0.0.12(react@19.2.3))(@react-email/img@0.0.12(react@19.2.3))(@react-email/link@0.0.13(react@19.2.3))(@react-email/preview@0.0.14(react@19.2.3))(@react-email/text@0.1.6(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@react-email/text': 0.1.6(react@19.2.3)
+      react: 19.2.3
+      tailwindcss: 4.1.18
+    optionalDependencies:
+      '@react-email/body': 0.2.1(react@19.2.3)
+      '@react-email/button': 0.2.1(react@19.2.3)
+      '@react-email/code-block': 0.2.1(react@19.2.3)
+      '@react-email/code-inline': 0.0.6(react@19.2.3)
+      '@react-email/container': 0.0.16(react@19.2.3)
+      '@react-email/heading': 0.0.16(react@19.2.3)
+      '@react-email/hr': 0.0.12(react@19.2.3)
+      '@react-email/img': 0.0.12(react@19.2.3)
+      '@react-email/link': 0.0.13(react@19.2.3)
+      '@react-email/preview': 0.0.14(react@19.2.3)
+
+  '@react-email/text@0.1.6(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+
   '@react-native/assets-registry@0.83.1': {}
 
   '@react-native/codegen@0.83.1(@babel/core@7.28.5)':
@@ -16970,6 +17582,11 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
+
   '@shikijs/core@1.29.2':
     dependencies:
       '@shikijs/engine-javascript': 1.29.2
@@ -17070,6 +17687,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -17469,6 +18088,10 @@ snapshots:
       '@vitest/spy': 2.0.5
       storybook: 10.1.10(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.8.1
@@ -17758,6 +18381,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.0.6
 
   '@types/d3-array@3.2.2': {}
 
@@ -18663,6 +19290,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.17.1
 
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv-keywords@5.1.0(ajv@8.17.1):
     dependencies:
       ajv: 8.17.1
@@ -18955,6 +19586,11 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  atomically@2.1.0:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   autoprefixer@10.4.23(postcss@8.4.49):
     dependencies:
       browserslist: 4.28.1
@@ -19066,6 +19702,8 @@ snapshots:
   base-64@1.0.0: {}
 
   base64-js@1.5.1: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.9.11: {}
 
@@ -19387,6 +20025,10 @@ snapshots:
 
   ci-info@4.3.1: {}
 
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -19405,11 +20047,17 @@ snapshots:
     dependencies:
       restore-cursor: 4.0.0
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-spinners@2.9.2: {}
 
   cli-width@3.0.0: {}
 
   cli-width@4.1.0: {}
+
+  client-only@0.0.1: {}
 
   cliui@6.0.0:
     dependencies:
@@ -19476,6 +20124,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@13.1.0: {}
+
   commander@14.0.2: {}
 
   commander@2.20.3: {}
@@ -19513,7 +20163,21 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  conf@15.0.2:
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      atomically: 2.1.0
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.7.3
+      uint8array-extras: 1.5.0
+
   confbox@0.1.8: {}
+
+  confbox@0.2.2: {}
 
   configstore@5.0.1:
     dependencies:
@@ -19532,6 +20196,8 @@ snapshots:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  consola@3.4.2: {}
 
   constant-case@2.0.0:
     dependencies:
@@ -19562,6 +20228,11 @@ snapshots:
       keygrip: 1.1.0
 
   core-js-pure@3.47.0: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -19908,6 +20579,12 @@ snapshots:
 
   dayjs@1.11.19: {}
 
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -20104,6 +20781,10 @@ snapshots:
     dependencies:
       no-case: 2.3.2
 
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.3.1
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -20180,6 +20861,24 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.5:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 25.0.6
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   enhanced-resolve@5.18.4:
     dependencies:
       graceful-fs: 4.2.11
@@ -20200,6 +20899,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  env-paths@3.0.0: {}
 
   err-code@3.0.1: {}
 
@@ -20693,6 +21394,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  exsolve@1.0.8: {}
 
   ext@1.7.0:
     dependencies:
@@ -21454,9 +22157,24 @@ snapshots:
 
   html-escaper@3.0.3: {}
 
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-assert@1.5.0:
     dependencies:
@@ -21900,6 +22618,8 @@ snapshots:
 
   is-unicode-supported@1.3.0: {}
 
+  is-unicode-supported@2.1.0: {}
+
   is-upper-case@1.1.2:
     dependencies:
       upper-case: 1.1.3
@@ -22273,6 +22993,8 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema-typed@8.0.2: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -22371,6 +23093,8 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  leac@0.6.0: {}
 
   level-supports@6.2.0: {}
 
@@ -22598,6 +23322,16 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
@@ -22698,6 +23432,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@15.0.12: {}
 
   marked@16.4.2: {}
 
@@ -23604,6 +24340,32 @@ snapshots:
 
   next-tick@1.1.0: {}
 
+  next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2):
+    dependencies:
+      '@next/env': 16.1.1
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.9.11
+      caniuse-lite: 1.0.30001762
+      postcss: 8.4.31
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.1.1
+      '@next/swc-darwin-x64': 16.1.1
+      '@next/swc-linux-arm64-gnu': 16.1.1
+      '@next/swc-linux-arm64-musl': 16.1.1
+      '@next/swc-linux-x64-gnu': 16.1.1
+      '@next/swc-linux-x64-musl': 16.1.1
+      '@next/swc-win32-arm64-msvc': 16.1.1
+      '@next/swc-win32-x64-msvc': 16.1.1
+      '@playwright/test': 1.57.0
+      sass: 1.97.2
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   nice-try@1.0.5: {}
 
   nimma@0.2.3:
@@ -23718,12 +24480,21 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuqs@2.8.6(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  nuqs@2.8.6(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.3
     optionalDependencies:
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2)
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
+  nypm@0.6.2:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      tinyexec: 1.0.2
 
   oas-kit-common@1.0.8:
     dependencies:
@@ -23904,6 +24675,18 @@ snapshots:
       log-symbols: 5.1.0
       stdin-discarder: 0.1.0
       string-width: 6.1.0
+      strip-ansi: 7.1.2
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
       strip-ansi: 7.1.2
 
   orval@7.18.0(openapi-types@12.1.3)(typescript@5.9.3):
@@ -24090,6 +24873,11 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   parseurl@1.3.3: {}
 
   pascal-case@2.0.1:
@@ -24134,6 +24922,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  peberminta@0.9.0: {}
+
   performance-now@2.1.0: {}
 
   piccolore@0.1.3: {}
@@ -24162,6 +24952,12 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.8.0
+      pathe: 2.0.3
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.8
       pathe: 2.0.3
 
   playwright-core@1.57.0: {}
@@ -24228,6 +25024,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.4.49:
     dependencies:
@@ -24539,6 +25341,30 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-email@5.2.2:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/traverse': 7.28.5
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.0.2
+      debounce: 2.2.0
+      esbuild: 0.25.12
+      glob: 11.1.0
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.2
+      ora: 8.2.0
+      prompts: 2.4.2
+      socket.io: 4.8.3
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   react-error-boundary@6.0.3(react@19.2.3):
     dependencies:
@@ -25322,6 +26148,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -25561,6 +26391,36 @@ snapshots:
     dependencies:
       no-case: 2.3.2
 
+  socket.io-adapter@2.5.6:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.5:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.4.3
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
@@ -25630,6 +26490,8 @@ snapshots:
   stdin-discarder@0.1.0:
     dependencies:
       bl: 5.1.0
+
+  stdin-discarder@0.2.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -25791,6 +26653,12 @@ snapshots:
 
   strnum@1.1.2: {}
 
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   stubs@3.0.0: {}
 
   style-to-js@1.1.21:
@@ -25800,6 +26668,13 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.28.5
 
   stylis@4.3.6: {}
 
@@ -26359,6 +27234,8 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  uint8array-extras@1.5.0: {}
+
   uint8arraylist@2.4.8:
     dependencies:
       uint8arrays: 5.1.0
@@ -26888,7 +27765,7 @@ snapshots:
 
   vlq@1.0.1: {}
 
-  vocs@1.4.1(@types/node@25.0.6)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3):
+  vocs@1.4.1(@types/node@25.0.6)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(sass-embedded@1.97.2)(sass@1.97.2)(terser@5.44.1)(typescript@5.9.3):
     dependencies:
       '@floating-ui/react': 0.27.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@hono/node-server': 1.19.7(hono@4.11.3)
@@ -26932,7 +27809,7 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       mdast-util-to-markdown: 2.1.2
       minisearch: 7.2.0
-      nuqs: 2.8.6(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      nuqs: 2.8.6(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2))(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       ora: 7.0.1
       p-limit: 5.0.0
       picomatch: 4.0.3
@@ -27054,6 +27931,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  when-exit@2.1.5: {}
 
   wherearewe@2.0.1:
     dependencies:


### PR DESCRIPTION
- Add comprehensive Go template component library (`@lumeweb/rego`)
- Supports GoVar, GoIf, GoRange, GoWith, GoDefine, GoUseTemplate, GoBlock
- Add data transformation helpers (GoDate, GoCurrency, GoTruncate)
- Add string transformations (GoUpperCase, GoLowerCase, GoTrim)
- Add pipeline chaining and variable assignment (GoPipe, GoLet, GoFormat)
- Add URL generation (GoUrl) and array operations (GoChunk)
- Add conditional helpers (GoEqual, GoEmpty) and comments (GoComment)
- Include comprehensive documentation and examples
- Add full test coverage


---

<!-- kody-pr-summary:start -->
This pull request introduces the `@lumeweb/rego` library, a React-to-Go Template DSL designed for email generation. The library provides a set of React components that wrap React Email elements and output HTML embedded with Go template syntax. This enables developers to design and style emails using React while allowing Go backends to execute the templates with runtime data.

Key functional capabilities include:
*   **Core Template Logic:** Components for variable interpolation (`GoVar`), conditional rendering (`GoIf`, `GoElse`, `GoEqual`, `GoEmpty`), loop iteration (`GoRange`), and context switching (`GoWith`).
*   **Template Composition:** Support for defining reusable template blocks (`GoDefine`, `GoUseTemplate`, `GoBlock`) to create modular email layouts.
*   **Data Transformation:** Helpers for formatting data such as dates (`GoDate`), currency (`GoCurrency`), and text truncation (`GoTruncate`).
*   **String Manipulation:** Components for transforming text case and trimming whitespace (`GoUpperCase`, `GoLowerCase`, `GoTrim`).
*   **Helper Functions:** Utilities for embedding Go template syntax directly into JSX attributes (e.g., `goVar`, `goUrl`, `goDate`) to handle dynamic links and inline content.
<!-- kody-pr-summary:end -->