### PR TITLE
ci: ensure @lumeweb/portal-generators relies on @lumeweb/tsdown-config for building and use turbo build as the prepare hook

### DIFF
--- a/libs/portal-generators/package.json
+++ b/libs/portal-generators/package.json
@@ -13,10 +13,12 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepare": "pnpm run build"
+    "prepare": "turbo build --filter=@lumeweb/portal-generators"
+  },
+  "dependencies": {
+    "@lumeweb/tsdown-config": "workspace:*"
   },
   "devDependencies": {
-    "@lumeweb/tsdown-config": "workspace:*",
     "@turbo/gen": "catalog:",
     "@types/node": "catalog:",
     "tsdown": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1075,10 +1075,11 @@ importers:
         version: 0.19.0-beta.5(typescript@5.9.3)
 
   libs/portal-generators:
-    devDependencies:
+    dependencies:
       '@lumeweb/tsdown-config':
         specifier: workspace:*
         version: link:../tsdown-config
+    devDependencies:
       '@turbo/gen':
         specifier: 'catalog:'
         version: 2.7.4(@types/node@25.0.6)(typescript@5.9.3)


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the dependency configuration for `@lumeweb/portal-generators` by moving `@lumeweb/tsdown-config` from `devDependencies` to `dependencies`. This change ensures that the package correctly relies on the shared build configuration during the build lifecycle, specifically to support the use of turbo build as the prepare hook.
<!-- kody-pr-summary:end -->