### PR TITLE
docs: add README documentation for portal-generators and query-builder

### DIFF
--- a/libs/portal-generators/README.md
+++ b/libs/portal-generators/README.md
@@ -1,0 +1,168 @@
+# @lumeweb/portal-generators
+
+Code generators for creating new portal plugins and utility libraries in the Lume Web monorepo. Powered by Turbo Gen and Plop.js.
+
+## Features
+
+- **Portal Plugin Generator** - Scaffold complete portal plugins with Module Federation, routes, widgets, and optional API client setup
+- **Library Generator** - Create utility libraries with optional test setup and coverage configuration
+- **Automatic Port Assignment** - Automatically assigns available dev ports for new plugins
+- **Template-Based** - Uses Handlebars templates for consistent project structure
+- **TypeScript Ready** - All generated code includes proper TS configuration
+
+## Installation
+
+This package is used as a development dependency in the monorepo. It's automatically available when running generator commands.
+
+## Usage
+
+### Generate a Portal Plugin
+
+The portal plugin generator creates a full-featured plugin with:
+
+- Module Federation configuration
+- Vite dev server with automatic port assignment
+- Tailwind CSS setup
+- Optional route templates
+- Optional src-lib for library interface
+- Optional Orval API client generation
+- Widget registration support
+
+```bash
+pnpm turbo gen portal-plugin
+```
+
+**Prompts:**
+
+- **Plugin name** - Enter the name (e.g., `my-plugin`)
+- **Include route templates?** - Add route files (default: yes)
+- **Routes** - Comma-separated route names (default: dashboard,settings)
+- **Include src-lib for library interface?** - Add src-lib directory (default: no)
+- **Include Orval for API client generation?** - Add Orval config (default: no)
+- **Include widget registrations?** - Add widget setup (default: no)
+
+**Generated Structure:**
+
+```
+libs/portal-plugin-my-plugin/
+├── package.json
+├── plugin.config.ts
+├── vite.config.ts
+├── tsconfig.json
+├── tsdown.config.ts
+├── tailwind.config.ts
+├── postcss.config.cjs
+├── orval.config.ts          (if Orval enabled)
+├── src/
+│   └── index.ts
+│   └── capabilities/
+│       └── refineConfig.ts
+│   └── routes.tsx          (if routes enabled)
+│   └── widgetRegistrations.ts
+│   └── ui/
+│       └── components/
+│           └── index.ts
+│       └── hooks/
+│           └── index.ts
+│       └── util/
+│           └── index.ts
+└── src-lib/                (if src-lib enabled)
+    └── index.ts
+    └── types/
+        └── index.ts
+    └── util/
+        └── index.ts
+```
+
+### Generate a Utility Library
+
+The library generator creates a reusable utility library:
+
+```bash
+pnpm turbo gen lib
+```
+
+**Prompts:**
+
+- **Library name** - Enter the name (e.g., `my-util`)
+- **Library description** - Optional description
+- **Include test setup?** - Add Vitest configuration (default: yes)
+- **Include test coverage configuration?** - Add coverage config (default: no)
+- **Catalog dependencies** - Comma-separated catalog dependencies
+- **Module exports** - Comma-separated export paths
+
+**Generated Structure:**
+
+```
+libs/my-util/
+├── package.json
+├── tsconfig.json
+├── tsdown.config.ts
+├── vitest.config.ts        (if tests enabled)
+└── src/
+    └── index.ts
+    └── __tests__/
+        └── setup.ts        (if tests enabled)
+```
+
+## Automatic Port Assignment
+
+The portal plugin generator automatically finds the next available dev port starting from 4178. It scans existing plugins in `libs/portal-plugin-*` to determine used ports and assigns the next available one.
+
+## Templates
+
+Generator templates are located in `src/templates/`:
+
+**Portal Plugin:**
+- `portal-plugin-package.json.hbs`
+- `portal-plugin-config.ts.hbs`
+- `portal-plugin-vite.config.ts.hbs`
+- `portal-plugin-tsconfig.json.hbs`
+- `portal-plugin-tsdown.config.ts.hbs`
+- `portal-plugin-tailwind.config.ts.hbs`
+- `portal-plugin-postcss.config.cjs.hbs`
+- `portal-plugin-src-index.ts.hbs`
+- `portal-plugin-src-capabilities-refineConfig.ts.hbs`
+- `portal-plugin-src-routes.tsx.hbs`
+- `portal-plugin-src-widgetRegistrations.ts.hbs`
+
+**Library:**
+- `lib-package.json.hbs`
+- `lib-src-index.ts.hbs`
+- `lib-vitest.config.ts.hbs`
+- `lib-tsconfig.json.hbs`
+- `lib-tsdown.config.ts.hbs`
+
+## Development
+
+Generators are automatically built as part of the monorepo's prepare script:
+
+```bash
+pnpm run prepare
+```
+
+## API
+
+### `genPortalPlugin()`
+
+Returns a Plop generator configuration for creating portal plugins.
+
+### `genLib()`
+
+Returns a Plop generator configuration for creating utility libraries.
+
+### `default(plop)`
+
+Main entry point that registers generators with Plop.js.
+
+## Contributing
+
+When adding new features to generators:
+
+1. Create or update Handlebars templates in `src/templates/`
+2. Update generator functions in `src/index.ts`
+3. Test thoroughly with `pnpm turbo gen`
+
+## License
+
+See LICENSE file for details.

--- a/libs/query-builder/README.md
+++ b/libs/query-builder/README.md
@@ -1,0 +1,202 @@
+# @lumeweb/query-builder
+
+A flexible query parameter parser and serializer for building complex filters, sorting, and pagination in web applications. Extended from Refine's CRUD operators to support Go backend compatibility.
+
+## Features
+
+- **Query Parsing** - Parse URL query parameters into structured filter, sort, and pagination objects
+- **Query Serialization** - Convert structured query objects back to URL-friendly parameters
+- **Rich Filter Operators** - Support for comparison operators (eq, ne, lt, gt, contains, etc.) and logical operators (and, or, not)
+- **Type-Safe** - Full TypeScript support with exported types
+- **Refine Compatible** - Works seamlessly with @refinedev/core types
+- **Go Backend Compatible** - Extended operators include "not" for Go queryutil compatibility
+
+## Installation
+
+```bash
+pnpm add @lumeweb/query-builder
+```
+
+## Usage
+
+### Parsing Query Parameters
+
+```typescript
+import { parseQueryParams } from "@lumeweb/query-builder";
+
+const params = {
+  "filters[0][field]": "name",
+  "filters[0][operator]": "contains",
+  "filters[0][value]": ["John", "Doe"],
+  "filters[1][field]": "status",
+  "filters[1][operator]": "eq",
+  "filters[1][value]": "active",
+  "filters[2][operator]": "or",
+  "filters[2][value][0][field]": "department",
+  "filters[2][value][0][operator]": "eq",
+  "filters[2][value][0][value]": "sales",
+  "filters[2][value][1][field]": "engineering",
+  "filters[2][value][1][operator]": "eq",
+  "filters[2][value][1][value]": true,
+  "_sort": "createdAt",
+  "_order": "desc",
+  "_start": "0",
+  "_end": "20"
+};
+
+const parsed = parseQueryParams(params);
+// Returns ParsedQuery with filters, sorters, and pagination
+```
+
+### Serializing Query Parameters
+
+```typescript
+import { serializeQueryParams } from "@lumeweb/query-builder";
+
+const query = {
+  filters: [
+    {
+      field: "status",
+      operator: "eq",
+      value: "active"
+    }
+  ],
+  sorters: [
+    {
+      field: "createdAt",
+      order: "desc"
+    }
+  ],
+  pagination: {
+    start: 0,
+    end: 20
+  }
+};
+
+const params = serializeQueryParams(query);
+// Returns URL-friendly query parameters
+```
+
+### Filter Operations
+
+```typescript
+import {
+  createEqFilter,
+  createContainsFilter,
+  createInFilter,
+  addFilter,
+  mergeFilters
+} from "@lumeweb/query-builder";
+
+// Create individual filters
+const nameFilter = createEqFilter("name", "John");
+const titleFilter = createContainsFilter("title", "Manager");
+const statusFilter = createInFilter("status", ["active", "pending"]);
+
+// Add filters to a collection
+let filters: CrudFilter[] = [];
+filters = addFilter(filters, nameFilter);
+
+// Merge multiple filters
+const merged = mergeFilters([nameFilter, statusFilter]);
+```
+
+### Sort Operations
+
+```typescript
+import {
+  createAscSort,
+  createDescSort,
+  toggleSort,
+  addSorter
+} from "@lumeweb/query-builder";
+
+// Create sort configurations
+const nameAsc = createAscSort("name");
+const createdDesc = createDescSort("createdAt");
+
+// Toggle sort direction
+const toggled = toggleSort(nameAsc); // becomes desc
+
+// Add to sorters array
+let sorters: CrudSort[] = [];
+sorters = addSorter(sorters, nameAsc);
+```
+
+### Pagination
+
+```typescript
+import {
+  calculatePagination,
+  getTotalPages,
+  getNextPage,
+  getPrevPage,
+  hasNextPage,
+  hasPrevPage
+} from "@lumeweb/query-builder";
+
+const pagination = calculatePagination(2, 25); // page 2, 25 per page
+// Returns: { start: 25, end: 50, page: 2, pageSize: 25 }
+
+const totalItems = 100;
+const pageSize = 20;
+
+// Get total pages
+const total = getTotalPages(totalItems, pageSize); // 5
+
+// Navigate using pagination object
+const next = getNextPage(pagination); // 3 (next page number)
+const prev = getPrevPage(pagination); // 1 (previous page number)
+
+// Check if more pages exist
+const hasNext = hasNextPage(totalItems, pagination); // true
+const hasPrev = hasPrevPage(pagination); // true
+```
+
+## API Documentation
+
+### Types
+
+- `QueryParams` - URL query parameter structure
+- `ParsedQuery` - Parsed result with filters, sorters, and pagination
+- `CrudFilter` - Union type for LogicalFilter and ConditionalFilter
+- `LogicalOperator` - "and" | "or" | "not"
+- `FieldOperator` - Comparison operators (eq, ne, lt, lte, gt, gte, contains, etc.)
+- `Pagination` - Pagination parameters
+- `CrudSort` - Sort configuration (re-exported from @refinedev/core)
+
+### Constants
+
+- `GLOBAL_SEARCH_FIELD` - "q"
+- `FILTER_PREFIX` - "filters"
+- `SORT_PARAM` - "_sort"
+- `ORDER_PARAM` - "_order"
+- `START_PARAM` - "_start"
+- `END_PARAM` - "_end"
+
+### Operators
+
+Comparison operators: `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `in`, `nin`, `ina`, `nina`, `contains`, `ncontains`, `containss`, `ncontainss`, `between`, `nbetween`, `null`, `nnull`, `startswith`, `nstartswith`, `startswiths`, `nstartswiths`, `endswith`, `nendswith`, `endswiths`, `nendswiths`
+
+Logical operators: `and`, `or`, `not`
+
+## Development
+
+```bash
+# Build
+pnpm run build
+
+# Run tests
+pnpm run test
+
+# Type check
+pnpm run lint
+```
+
+## Contributing
+
+Contributions are welcome! Please submit pull requests to the main repository.
+
+## License
+
+See LICENSE file for details.


### PR DESCRIPTION
- Added comprehensive README for @lumeweb/portal-generators documenting generators, templates, and usage
- Added comprehensive README for @lumeweb/query-builder documenting query parsing, filtering, sorting, and pagination APIs


---

<!-- kody-pr-summary:start -->
This pull request adds comprehensive documentation for two libraries within the monorepo.

It introduces a README for `@lumeweb/portal-generators` that details the usage of code generators for scaffolding portal plugins and utility libraries. The documentation covers features such as automatic port assignment, template-based generation, and specific commands for creating plugins with Module Federation, routes, and widgets.

Additionally, it adds a README for `@lumeweb/query-builder` that documents the query parameter parser and serializer. This includes usage examples for parsing and serializing complex filters, sorting, and pagination, as well as details on supported operators and API compatibility with Refine and Go backends.
<!-- kody-pr-summary:end -->