### PR TITLE
ci(release): add id-token permission for OIDC authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the release workflow configuration to grant the `id-token: write` permission. This change enables OpenID Connect (OIDC) authentication for the workflow.
<!-- kody-pr-summary:end -->