### PR TITLE
fix(ci): prefix turbo command with pnpm for proper execution

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -310,7 +310,7 @@ def build_packages(
             print(f"Will build plugin: {package_name}")
 
     # Build all packages in a single turbo command with all tasks
-    cmd = ["turbo", "run"] + tasks + filters
+    cmd = ["pnpm", "turbo", "run"] + tasks + filters
 
     if verbose:
         print(f"Running: {' '.join(cmd)}")


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the release script to prefix the `turbo` command with `pnpm`. This change ensures that the build process correctly invokes the task runner within the project's package manager environment.
<!-- kody-pr-summary:end -->