### PR TITLE
fix(pinner): update default endpoint and gateway URLs

### DIFF
--- a/libs/pinner/src/adapters/pinata/legacy/__tests__/adapter.spec.ts
+++ b/libs/pinner/src/adapters/pinata/legacy/__tests__/adapter.spec.ts
@@ -377,7 +377,7 @@ describe("PinataLegacyAdapter", () => {
         expires: 3600,
       });
 
-      expect(result).toBe("https://gateway.lumeweb.com/ipfs/QmHash");
+      expect(result).toBe("https://dweb.link/ipfs/QmHash");
     });
 
     it("should create signed URL with config gateway", async () => {

--- a/libs/pinner/src/types/constants.ts
+++ b/libs/pinner/src/types/constants.ts
@@ -1,12 +1,12 @@
 /**
  * Default API endpoint URL for the pinning service.
  */
-export const DEFAULT_ENDPOINT = "https://api.lumeweb.com";
+export const DEFAULT_ENDPOINT = "https://ipfs.pinner.xyz";
 
 /**
  * Default IPFS gateway URL for content retrieval.
  */
-export const DEFAULT_GATEWAY = "https://gateway.lumeweb.com";
+export const DEFAULT_GATEWAY = "https://dweb.link";
 
 /**
  * Default TUS upload size threshold (100MB).


### PR DESCRIPTION
- Change DEFAULT_ENDPOINT from api.lumeweb.com to ipfs.pinner.xyz
- Change DEFAULT_GATEWAY from gateway.lumeweb.com to dweb.link


---

<!-- kody-pr-summary:start -->
This pull request updates the default configuration URLs for the pinner library. Specifically, it changes the default API endpoint from `api.lumeweb.com` to `ipfs.pinner.xyz` and the default IPFS gateway from `gateway.lumeweb.com` to `dweb.link`. Unit tests have been updated to reflect the new default gateway URL.
<!-- kody-pr-summary:end -->