### PR TITLE
chore: changeset

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -17,6 +17,7 @@ ignore_conventional_commits = true
 versioned_files = ["libs/pinner/package.json"]
 changelog = "libs/pinner/CHANGELOG.md"
 ignore_conventional_commits = true
+scopes = ["pinata"]
 
 [packages."@lumeweb/portal-app-shell"]
 versioned_files = ["apps/portal-app-shell/package.json"]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `knope.toml` configuration to add "pinata" to the list of scopes for the `@lumeweb/pinner` package. This change ensures that commits with the "pinata" scope are included in the changelog generation for the pinner library.
<!-- kody-pr-summary:end -->