### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/clever-humans-sip.md
+++ b/.changeset/clever-humans-sip.md
@@ -1,0 +1,8 @@
+---
+"@lumeweb/pinner": minor
+---
+
+## Features
+
+- update default endpoint and gateway URLs
+- restructure adapters with v2 and legacy implementations

--- a/knope.toml
+++ b/knope.toml
@@ -17,7 +17,6 @@ ignore_conventional_commits = true
 versioned_files = ["libs/pinner/package.json"]
 changelog = "libs/pinner/CHANGELOG.md"
 ignore_conventional_commits = true
-scopes = ["pinata"]
 
 [packages."@lumeweb/portal-app-shell"]
 versioned_files = ["apps/portal-app-shell/package.json"]


### PR DESCRIPTION
- **Revert "chore: changeset"**
- **chore: changeset**


---

<!-- kody-pr-summary:start -->
This pull request updates the `@lumeweb/pinner` library by modifying the default endpoint and gateway URLs and restructuring adapters to support both v2 and legacy implementations. Additionally, it removes the "pinata" scope from the release configuration for the pinner package.
<!-- kody-pr-summary:end -->