### PR TITLE
ci: update changeset script for new workflow-based configuration

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -1,98 +1,97 @@
 [packages."@lumeweb/advanced-rest"]
 versioned_files = ["libs/advanced-rest/package.json"]
 changelog = "libs/advanced-rest/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/docs.lumeweb.com"]
 versioned_files = ["apps/docs.lumeweb.com/package.json"]
 changelog = "apps/docs.lumeweb.com/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/lumeweb.com"]
 versioned_files = ["apps/lumeweb.com/package.json"]
 changelog = "apps/lumeweb.com/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/pinner"]
 versioned_files = ["libs/pinner/package.json"]
 changelog = "libs/pinner/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-app-shell"]
 versioned_files = ["apps/portal-app-shell/package.json"]
 changelog = "apps/portal-app-shell/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-framework-auth"]
 versioned_files = ["libs/portal-framework-auth/package.json"]
 changelog = "libs/portal-framework-auth/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-framework-core"]
 versioned_files = ["libs/portal-framework-core/package.json"]
 changelog = "libs/portal-framework-core/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-framework-ui"]
 versioned_files = ["libs/portal-framework-ui/package.json"]
 changelog = "libs/portal-framework-ui/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-framework-ui-core"]
 versioned_files = ["libs/portal-framework-ui-core/package.json"]
 changelog = "libs/portal-framework-ui-core/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-frontend"]
 versioned_files = ["apps/portal-frontend/package.json"]
 changelog = "apps/portal-frontend/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-generators"]
 versioned_files = ["libs/portal-generators/package.json"]
 changelog = "libs/portal-generators/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-plugin-admin"]
 versioned_files = ["libs/portal-plugin-admin/package.json"]
 changelog = "libs/portal-plugin-admin/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-plugin-core"]
 versioned_files = ["libs/portal-plugin-core/package.json"]
 changelog = "libs/portal-plugin-core/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-plugin-dashboard"]
 versioned_files = ["libs/portal-plugin-dashboard/package.json"]
 changelog = "libs/portal-plugin-dashboard/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-plugin-ipfs"]
 versioned_files = ["libs/portal-plugin-ipfs/package.json"]
 changelog = "libs/portal-plugin-ipfs/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/portal-sdk"]
 versioned_files = ["libs/portal-sdk/package.json"]
 changelog = "libs/portal-sdk/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/query-builder"]
 versioned_files = ["libs/query-builder/package.json"]
 changelog = "libs/query-builder/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/rego"]
 versioned_files = ["libs/rego/package.json"]
 changelog = "libs/rego/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [packages."@lumeweb/uppy-post-upload"]
 versioned_files = ["libs/uppy-post-upload/package.json"]
 changelog = "libs/uppy-post-upload/CHANGELOG.md"
-ignore_conventional_commits = true
 
 [github]
 owner = "LumeWeb"
 repo = "web"
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+ignore_conventional_commits = true
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare releases\""
+
+[[workflows.steps]]
+type = "Command"
+command = "git push"
+
+[[workflows.steps]]
+type = "Release"

--- a/scripts/generate-changesets-from-release.js
+++ b/scripts/generate-changesets-from-release.js
@@ -79,7 +79,14 @@ class ChangesetGenerator {
     this.originalKnopeConfig = configContent;
     const config = parse(configContent);
     modifier(config);
-    const newContent = stringify(config);
+    const newContent = stringify(config, { 
+      indent: 2,
+      arrayIndent: 2,
+      align: false,
+      keyQuote: false,
+      inlineTuples: false,
+      sortKeys: false
+    });
     fs.copyFileSync(this.knopeConfigFile, `${this.knopeConfigFile}.bak`);
     fs.writeFileSync(this.knopeConfigFile, newContent, "utf-8");
   }
@@ -338,10 +345,21 @@ class ChangesetGenerator {
       return "dry-run-" + Date.now();
     }
 
-    return await writeChangeset(
+    const changesetID = await writeChangeset(
       { summary: summary.trim(), releases },
       this.packagesDir,
     );
+
+    // Remove quotes from package names in the generated changeset file
+    const changesetPath = path.join(this.changesetsDir, `${changesetID}.md`);
+    let changesetContent = fs.readFileSync(changesetPath, "utf-8");
+    
+    // Remove quotes around package names (but keep quotes for other values if any)
+    changesetContent = changesetContent.replace(/^"([^"]+)":/gm, "$1:");
+    
+    fs.writeFileSync(changesetPath, changesetContent, "utf-8");
+    
+    return changesetID;
   }
 
   async generate() {
@@ -354,8 +372,12 @@ class ChangesetGenerator {
     try {
       console.log("Temporarily modifying knope.toml...");
       await this.modifyKnopeConfig((config) => {
-        for (const pkgKey of Object.keys(config.packages || {})) {
-          config.packages[pkgKey].ignore_conventional_commits = false;
+        for (const workflow of config.workflows || []) {
+          for (const step of workflow.steps || []) {
+            if (step.type === "PrepareRelease") {
+              step.ignore_conventional_commits = false;
+            }
+          }
         }
       });
 


### PR DESCRIPTION
- Remove deprecated `ignore_conventional_commits` from package sections
- Add new `[[workflows]]` structure with release workflow steps
- Update `modifyKnopeConfig` to target `workflows.steps.PrepareRelease` instead of packages
- Add TOML formatting options to preserve structure when modifying config
- Post-process changeset files to remove quotes from package names


---

<!-- kody-pr-summary:start -->
This pull request updates the release configuration and associated scripts to support a workflow-based approach.

**Key Changes:**

*   **Refactored `knope.toml`:** Migrated the configuration from package-level settings to a centralized `[[workflows]]` structure. The `ignore_conventional_commits` setting was removed from all individual package definitions and moved to the `PrepareRelease` step within the new `release` workflow. This workflow now also includes steps to automatically commit and push changes.
*   **Updated Changeset Generation Script:** Modified `scripts/generate-changesets-from-release.js` to interact with the new workflow configuration. The script now targets the `PrepareRelease` step within workflows when toggling the `ignore_conventional_commits` setting, rather than modifying package definitions directly.
*   **Formatting Improvements:** Updated the script to apply specific formatting options when generating TOML content and to remove quotes from package names in generated changeset files.
<!-- kody-pr-summary:end -->