### PR TITLE
ci: remove explicit version parameters from setup-all action

### DIFF
--- a/.github/workflows/deploy-docs.lumeweb.com.yml
+++ b/.github/workflows/deploy-docs.lumeweb.com.yml
@@ -3,14 +3,14 @@ name: Deploy docs.lumeweb.com
 on:
   push:
     branches:
-      - '**'
+      - "**"
     paths:
-      - 'apps/docs.lumeweb.com/**'
+      - "apps/docs.lumeweb.com/**"
   pull_request:
     branches:
-      - '**'
+      - "**"
     paths:
-      - 'apps/docs.lumeweb.com/**'
+      - "apps/docs.lumeweb.com/**"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +18,6 @@ permissions:
   pull-requests: write
   deployments: write
   contents: read
-
 
 jobs:
   build:
@@ -29,9 +28,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
-        with:
-          node_version: 20.10.0
-          go_version: 1.23.0
       - name: Build
         run: pnpm build:docs.lumeweb.com
       - name: Publish to Cloudflare Pages

--- a/.github/workflows/deploy-docs.pinner.xyz.yml
+++ b/.github/workflows/deploy-docs.pinner.xyz.yml
@@ -29,9 +29,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
-        with:
-          node_version: 20.10.0
-          go_version: 1.23.0
       - name: Build
         run: pnpm build:docs.pinner.xyz
       - name: Publish to Cloudflare Pages

--- a/.github/workflows/deploy-lumeweb.com.yml
+++ b/.github/workflows/deploy-lumeweb.com.yml
@@ -29,9 +29,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
-        with:
-          node_version: 20.10.0
-          go_version: 1.23.0
       - name: Build
         run: pnpm build:lumeweb.com
       - name: Publish to Cloudflare Pages

--- a/.github/workflows/deploy-portal-dashboard.yml
+++ b/.github/workflows/deploy-portal-dashboard.yml
@@ -29,9 +29,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
-        with:
-          node_version: 20.10.0
-          go_version: 1.23.0
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v2.0
         with:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the CI/CD deployment workflows to remove explicit version parameters for Node.js and Go. The `node_version` and `go_version` inputs have been removed from the `setup-all` action step in the workflows for `docs.lumeweb.com`, `docs.pinner.xyz`, `lumeweb.com`, and `portal-dashboard`. Consequently, these workflows will now rely on the default versions defined within the shared `setup-all` action rather than using hardcoded values. Additionally, minor quote normalization was applied to the `deploy-docs.lumeweb.com.yml` file.
<!-- kody-pr-summary:end -->