### PR TITLE
ci: update Pages deployment workflows to use wrangler-action@v3

### DIFF
--- a/.github/workflows/deploy-docs.lumeweb.com.yml
+++ b/.github/workflows/deploy-docs.lumeweb.com.yml
@@ -30,17 +30,16 @@ jobs:
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
       - name: Build
         run: pnpm build:docs.lumeweb.com
-      - name: Publish to Cloudflare Pages
+      - name: Deploy to Cloudflare Pages
         id: deploy_cf
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: docs-lumeweb-com
-          directory: apps/docs.lumeweb.com/docs/dist
+          command: pages deploy apps/docs.lumeweb.com/docs/dist --project-name=docs-lumeweb-com
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       - uses: mshick/add-pr-comment@v2
         if: github.event_name == 'pull_request'
         with:
           message: |
-            The docs.lumeweb.com has been deployed to [Staging](${{ steps.deploy_cf.outputs.url }}).
+            The docs.lumeweb.com has been deployed to [Staging](${{ steps.deploy_cf.outputs.deployment-url }}).

--- a/.github/workflows/deploy-docs.pinner.xyz.yml
+++ b/.github/workflows/deploy-docs.pinner.xyz.yml
@@ -31,17 +31,16 @@ jobs:
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
       - name: Build
         run: pnpm build:docs.pinner.xyz
-      - name: Publish to Cloudflare Pages
+      - name: Deploy to Cloudflare Pages
         id: deploy_cf
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: docs-pinner-xyz
-          directory: apps/docs.pinner.xyz/docs/dist
+          command: pages deploy apps/docs.pinner.xyz/docs/dist --project-name=docs-pinner-xyz
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       - uses: mshick/add-pr-comment@v2
         if: github.event_name == 'pull_request'
         with:
           message: |
-            The docs.pinner.xyz has been deployed to [Staging](${{ steps.deploy_cf.outputs.url }}).
+            The docs.pinner.xyz has been deployed to [Staging](${{ steps.deploy_cf.outputs.deployment-url }}).

--- a/.github/workflows/deploy-lumeweb.com.yml
+++ b/.github/workflows/deploy-lumeweb.com.yml
@@ -31,17 +31,16 @@ jobs:
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
       - name: Build
         run: pnpm build:lumeweb.com
-      - name: Publish to Cloudflare Pages
+      - name: Deploy to Cloudflare Pages
         id: deploy_cf
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: lumeweb-com
-          directory: apps/lumeweb.com/dist
+          command: pages deploy apps/lumeweb.com/dist --project-name=lumeweb-com
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       - uses: mshick/add-pr-comment@v2
         if: github.event_name == 'pull_request'
         with:
           message: |
-            lumeweb.com has been deployed to [Staging](${{ steps.deploy_cf.outputs.url }}).
+            lumeweb.com has been deployed to [Staging](${{ steps.deploy_cf.outputs.deployment-url }}).

--- a/.github/workflows/deploy-portal-dashboard.yml
+++ b/.github/workflows/deploy-portal-dashboard.yml
@@ -37,17 +37,16 @@ jobs:
           directory: apps/portal-dashboard
       - name: Build
         run: pnpm build:portal-dashboard
-      - name: Publish to Cloudflare Pages
+      - name: Deploy to Cloudflare Pages
         id: deploy_cf
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: lume-web-portal-dashboard-staging
-          directory: apps/portal-dashboard/build/client
+          command: pages deploy apps/portal-dashboard/build/client --project-name=lume-web-portal-dashboard-staging
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       - uses: mshick/add-pr-comment@v2
         if: github.event_name == 'pull_request'
         with:
           message: |
-            The Portal Dashboard has been deployed to [Staging](${{ steps.deploy_cf.outputs.url }}).
+            The Portal Dashboard has been deployed to [Staging](${{ steps.deploy_cf.outputs.deployment-url }}).


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the Cloudflare Pages deployment workflows for `docs.lumeweb.com`, `docs.pinner.xyz`, `lumeweb.com`, and `portal-dashboard`. The workflows are migrated from using `cloudflare/pages-action@v1` to `cloudflare/wrangler-action@v3`. This change updates the deployment configuration to pass parameters via a command string and adjusts the output variable reference used to display the staging URL in pull request comments.
<!-- kody-pr-summary:end -->