### PR TITLE
fix(docs.pinner.xyz): typo

### DIFF
--- a/apps/docs.pinner.xyz/docs/partials/_cli-installation-content.mdx
+++ b/apps/docs.pinner.xyz/docs/partials/_cli-installation-content.mdx
@@ -1,9 +1,9 @@
 ### go install
 
 ```zsh
-go install go.lumeweb.com/pinner-clii/cmd/pinner@latest
+go install go.lumeweb.com/pinner-cli/cmd/pinner@latest
 ```
 
 ### Download Binary
 
-Download the latest binary from the [releases page](https://github.com/lumeweb.com/pinner-clii/releases).
+Download the latest binary from the [releases page](https://github.com/lumeweb.com/pinner-cli/releases).


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request corrects a typo in the CLI installation documentation. It updates the repository path from `pinner-clii` to `pinner-cli` in both the `go install` command and the GitHub releases URL to ensure users can successfully install the tool and access the correct download page.
<!-- kody-pr-summary:end -->