### PR TITLE
ci: add lbry plugin to release build config

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -37,7 +37,7 @@ DEFAULT_APPS = ["portal-frontend", APP_SHELL]
 
 # Default plugins to build and release
 # Used when --plugins=all is specified
-DEFAULT_PLUGINS = ["dashboard", "admin", "ipfs", "core"]
+DEFAULT_PLUGINS = ["dashboard", "admin", "ipfs", "core", "lbry"]
 
 
 def parse_csv_list(value: Optional[str]) -> List[str]:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the release build configuration to include the 'lbry' plugin in the default list of plugins to build and release. By adding 'lbry' to the `DEFAULT_PLUGINS` list in the release script, it ensures that this plugin is automatically included when the build process is run with the default settings.
<!-- kody-pr-summary:end -->