### PR TITLE
ci: fix app shell variation repository mappings and add manual workflow trigger support

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -6,6 +6,27 @@ on:
   repository_dispatch:
     types: [release-go]
   workflow_dispatch:
+    inputs:
+      apps:
+        description: 'Apps to build and release (CSV format, "all" for defaults, "none" to skip)'
+        required: false
+        default: 'all'
+        type: string
+      plugins:
+        description: 'Plugins to build and release (CSV format, "all" for defaults, "none" to skip)'
+        required: false
+        default: 'all'
+        type: string
+      force:
+        description: 'Force release even if no git changes detected'
+        required: false
+        default: false
+        type: boolean
+      no_push:
+        description: 'Create commit but do not push to remote'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare:
@@ -31,7 +52,25 @@ jobs:
       - name: Release
         id: release
         run: |
-          python scripts/release-go.py
+          args=""
+          
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.apps }}" != "all" ]; then
+              args="$args --apps '${{ inputs.apps }}'"
+            fi
+            if [ "${{ inputs.plugins }}" != "all" ]; then
+              args="$args --plugins '${{ inputs.plugins }}'"
+            fi
+            if [ "${{ inputs.force }}" = "true" ]; then
+              args="$args --force"
+            fi
+            if [ "${{ inputs.no_push }}" = "true" ]; then
+              args="$args --no-push"
+            fi
+          fi
+          
+          echo "Running: python scripts/release-go.py $args"
+          python scripts/release-go.py $args
 
       - name: Get modified apps info
         id: get_modified_apps

--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -22,7 +22,7 @@ APP_SHELL = "portal-app-shell"
 # App shell variations (each built to a separate dist subdirectory)
 # Maps variation names to their target Go repository names
 APP_SHELL_VARIATIONS = {
-    "dashboard": "portal-dashboard",
+    "dashboard": "portal-plugin-dashboard",
     "admin": "portal-plugin-admin"
 }
 
@@ -496,6 +496,9 @@ Examples:
 
   # Create commit but don't push
   python scripts/release-go.py --no-push
+
+  # Force release even if no changes detected (useful for initial releases)
+  python scripts/release-go.py --plugins lbry --force
         """
     )
 
@@ -535,6 +538,12 @@ Examples:
         "--no-push",
         action="store_true",
         help="Create commit but do not push to remote"
+    )
+
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force release even if no git changes detected (useful for initial releases)"
     )
 
     args = parser.parse_args()
@@ -663,15 +672,24 @@ Examples:
     go_paths = [f"go/{app_name}/build" for app_name in apps_to_build if app_name != APP_SHELL]
     go_paths.extend([f"go/{variation}/build" for variation in app_shell_variations])
     go_paths.extend([f"go/{PLUGIN_PREFIX}{plugin_name}/build" for plugin_name in plugins_to_build])
+    
+    # Track which paths were actually staged for --force warning
+    staged_paths = []
     for go_path in go_paths:
         go_dir = repo_root / go_path
         if go_dir.exists():
             run_command(["git", "add", str(go_dir)], cwd=repo_root)
+            staged_paths.append(go_path)
+        elif args.force:
+            print(f"Warning: {go_path} does not exist, but --force is set", file=sys.stderr)
 
     # Check if there are actual changes via git diff
     has_changes = get_git_diff(repo_root, go_paths)
 
-    if has_changes:
+    if has_changes or args.force:
+        if args.force and not has_changes:
+            print(f"Warning: --force flag set, proceeding despite no git changes detected", file=sys.stderr)
+        
         # Get list of changed files for reporting
         changed_files = get_git_diff_files(repo_root, go_paths)
         if args.verbose:


### PR DESCRIPTION
- Map dashboard to portal-plugin-dashboard instead of non-existent portal-dashboard
- Keep admin mapped to portal-plugin-admin
- Add workflow_dispatch inputs: apps, plugins, force, no_push
- Add --force flag to bypass git change detection for initial releases
- Add warnings when force is used with missing paths or no changes


---

<!-- kody-pr-summary:start -->
This pull request enhances the release workflow by adding manual trigger support and fixing app shell variation repository mappings. The changes include:

1. **Manual Workflow Trigger**: Added support for manually triggering the release workflow through GitHub's `workflow_dispatch` event with configurable inputs for:
   - Selecting specific apps and plugins to build/release
   - Forcing releases even when no git changes are detected
   - Creating commits without pushing to remote

2. **Repository Mapping Fix**: Corrected the app shell variation mapping for "dashboard" from "portal-dashboard" to "portal-plugin-dashboard" to ensure proper repository targeting.

3. **Force Release Option**: Added a `--force` flag to the release script that allows proceeding with releases even when no git changes are detected, useful for initial releases or manual overrides.

These changes provide more flexibility in the release process, allowing developers to manually trigger and control releases while fixing a repository mapping issue that could have caused incorrect deployment targets.
<!-- kody-pr-summary:end -->