### PR TITLE
ci: strip quotes from CSV list items to handle quoted workflow inputs

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -47,7 +47,7 @@ DEFAULT_PLUGINS = ["ipfs", "core", "lbry"]
 
 def parse_csv_list(value: Optional[str]) -> List[str]:
     """
-    Parse a comma-separated string into a list, trimming whitespace.
+    Parse a comma-separated string into a list, trimming whitespace and quotes.
 
     Args:
         value: CSV string or None
@@ -58,7 +58,17 @@ def parse_csv_list(value: Optional[str]) -> List[str]:
     if not value or value.lower() == "none":
         return []
 
-    return [item.strip() for item in value.split(",") if item.strip()]
+    # Split by comma, strip whitespace, and remove surrounding quotes
+    items = []
+    for item in value.split(","):
+        item = item.strip()
+        if item:
+            # Remove surrounding quotes (single or double)
+            if (item.startswith("'") and item.endswith("'")) or \
+               (item.startswith('"') and item.endswith('"')):
+                item = item[1:-1]
+            items.append(item)
+    return items
 
 
 def get_app_package_name(app_name: str) -> str:


### PR DESCRIPTION
Updated `parse_csv_list()` to remove surrounding single or double quotes from comma-separated values. This ensures proper handling when GitHub Actions workflow inputs are passed with quotes for best practices.


---

<!-- kody-pr-summary:start -->
This pull request updates the CSV parsing functionality in the release script to handle quoted workflow inputs. The `parse_csv_list` function in `scripts/release-go.py` has been enhanced to strip surrounding quotes (both single and double) from list items in addition to trimming whitespace. This change ensures that comma-separated inputs containing quoted values are properly processed, preventing quotes from being included in the final parsed values.
<!-- kody-pr-summary:end -->