### PR TITLE
ci: fix empty matrix error by using placeholder entry

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -76,7 +76,8 @@ jobs:
         id: get_modified_apps
         run: |
           if [ ! -f "/tmp/modified_apps.txt" ] || [ ! -s "/tmp/modified_apps.txt" ]; then
-            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            # Use a placeholder when no changes to avoid empty matrix error
+            echo "matrix={\"include\":[{\"repo\":\"__placeholder__\"}]}" >> "$GITHUB_OUTPUT"
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -96,7 +97,12 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
+      - name: Skip placeholder
+        if: matrix.repo == '__placeholder__'
+        run: echo "No changes to dispatch"
+
       - name: Dispatch UI update
+        if: matrix.repo != '__placeholder__'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Replace empty matrix with placeholder entry to prevent GitHub Actions "matrix must define at least one vector" error when no apps are modified. Added conditional step to skip dispatch for placeholder entries.


---

<!-- kody-pr-summary:start -->
This pull request fixes an issue with empty matrix errors in the GitHub Actions workflow. When no application changes are detected, the workflow now uses a placeholder entry in the matrix to prevent the error, and includes a conditional step to skip processing for this placeholder. This ensures the workflow runs successfully even when there are no changes to dispatch.
<!-- kody-pr-summary:end -->