### PR TITLE
ci: use constants for all/none argument values

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -50,6 +50,10 @@ DEFAULT_APPS = ["portal-frontend", APP_SHELL]
 # Note: dashboard and admin are built via APP_SHELL variations, not standalone plugins
 DEFAULT_PLUGINS = ["ipfs", "core", "lbry"]
 
+# Special values for apps/plugins arguments
+VALUE_ALL = "all"
+VALUE_NONE = "none"
+
 
 def parse_csv_list(value: Optional[str]) -> List[str]:
     """
@@ -728,15 +732,19 @@ Examples:
     repo_root = Path(__file__).parent.parent.resolve()
 
     # Parse apps and plugins arguments
-    if args.apps.lower() == "all":
+    if args.apps.lower() == VALUE_ALL:
         apps_to_build = DEFAULT_APPS
+    elif args.apps.lower() == VALUE_NONE:
+        apps_to_build = []
     else:
         apps_to_build = parse_csv_list(args.apps)
         # Validate app names
         apps_to_build = sanitize_package_names(apps_to_build, repo_root, APPS_DIR, verbose=args.verbose)
 
-    if args.plugins.lower() == "all":
+    if args.plugins.lower() == VALUE_ALL:
         plugins_to_build = DEFAULT_PLUGINS
+    elif args.plugins.lower() == VALUE_NONE:
+        plugins_to_build = []
     else:
         plugins_to_build = parse_csv_list(args.plugins)
         # Validate plugin names


### PR DESCRIPTION
- Add VALUE_ALL and VALUE_NONE constants
- Replace hardcoded "all" and "none" strings with constants
- Add explicit handling for VALUE_NONE to return empty list


---

<!-- kody-pr-summary:start -->
This pull request introduces constants for the special argument values "all" and "none" in the release script. The changes replace hardcoded string literals with predefined constants (VALUE_ALL and VALUE_NONE) when checking the apps and plugins arguments. This improves code maintainability by centralizing these special values and makes the code more readable and less prone to typos. The functional behavior remains the same - when "all" is specified, the default apps/plugins are used, and when "none" is specified, an empty list is used.
<!-- kody-pr-summary:end -->