### PR TITLE
ci: add verbose output option to release-go workflow

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: false
         type: boolean
+      verbose:
+        description: 'Enable verbose output'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare:
@@ -66,6 +71,9 @@ jobs:
             fi
             if [ "${{ inputs.no_push }}" = "true" ]; then
               args="$args --no-push"
+            fi
+            if [ "${{ inputs.verbose }}" = "true" ]; then
+              args="$args --verbose"
             fi
           fi
           


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds a new optional `verbose` input parameter to the release-go GitHub Actions workflow. When enabled, this parameter passes a `--verbose` flag to the underlying release script, enabling more detailed output during the release process. The change allows users to control the verbosity of the workflow execution for better debugging and visibility.
<!-- kody-pr-summary:end -->