### PR TITLE
fix(tsdown-config): properly exclude all test files from build config

### DIFF
--- a/libs/tsdown-config/index.ts
+++ b/libs/tsdown-config/index.ts
@@ -181,5 +181,5 @@ export const entryPatterns = {
     "!**/*.webp",
     "!**/*.gif",
   ],
-  withoutTests: ["src/**/*", "!**/__tests__/**", "!**/*.test.ts", "!**/*.spec.ts", "!**/*.md", "!**/*.png", "!**/*.jpg", "!**/*.jpeg", "!**/*.svg", "!**/*.webp", "!**/*.gif"],
+  withoutTests: ["src/**/*", "!**/__tests__/**", "!**/*.test.{ts,tsx}", "!**/*.spec.{ts,tsx}", "!**/*.spec.disabled.{ts,tsx}", "!**/*.md", "!**/*.png", "!**/*.jpg", "!**/*.jpeg", "!**/*.svg", "!**/*.webp", "!**/*.gif"],
 };


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the test file exclusion patterns in the TypeScript build configuration to properly exclude all test files from the build process. The changes expand the pattern matching to include both TypeScript and TypeScript React files (.ts and .tsx extensions) for test files, and adds support for disabled test files with the .spec.disabled pattern. This ensures that test files are correctly excluded from the build output regardless of their file extension or disabled status.
<!-- kody-pr-summary:end -->