### PR TITLE
ci: remove unused verbose parameter from build_packages call

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
@@ -840,7 +841,7 @@ Examples:
 
     # Build all apps and plugins in a single turbo command
     try:
-        build_packages(apps_to_build, plugins_to_build, repo_root, args.verbose)
+        build_packages(apps_to_build, plugins_to_build, repo_root)
     except Exception as e:
         logger.error(f"Error building packages: {e}")
         if args.verbose:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the code changes provided, here's a precise description for this pull request:

**PR Description:**
This pull request removes the unused `verbose` parameter from the `build_packages` function call in the release script. The change simplifies the function invocation by removing a parameter that was not being utilized, while maintaining the core functionality of building packages. Additionally, a traceback import was added to the script, though it's not used in the visible changes.

**Key Changes:**
- Modified the `build_packages` function call to remove the `args.verbose` parameter
- Added `traceback` import to the script's imports section

The change aligns with the PR title's intent to clean up unused parameters from the build process.
<!-- kody-pr-summary:end -->