### PR TITLE
ci: remove unused verbose parameter from copy_build_to_go call

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -901,7 +901,7 @@ Examples:
                 logger.debug(f"Build directory: {build_dir}")
 
             # Copy to Go directory (always replace)
-            copy_build_to_go(f"{PLUGIN_PREFIX}{plugin_name}", build_dir, repo_root, args.verbose)
+            copy_build_to_go(f"{PLUGIN_PREFIX}{plugin_name}", build_dir, repo_root)
 
         except Exception as e:
             logger.error(f"Error processing plugin {plugin_name}: {e}")


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request removes an unused `verbose` parameter from the `copy_build_to_go` function call within the `release-go.py` script. The change simplifies the function call by eliminating a parameter that was not being utilized.
<!-- kody-pr-summary:end -->