### PR TITLE
ci: simplify build copy logic to always use clean builds

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -105,7 +105,7 @@ def app_shell_template(variant_name: str, **overrides) -> Dict[str, Any]:
     return {
         "name": variant_name,
         "variants": [variant_name],
-        "build_from": "portal-app-shell/dist/{variant}",
+        "build_from": "apps/portal-app-shell/dist/{variant}",
         "deploy_to": "go/portal-{variant}/build",
         "repo_target": "portal-plugin-{variant}",
         "content_type": "ui_application",
@@ -528,14 +528,14 @@ class SafeBuildCopier:
         if self.verbose:
             logger.info(f"Copying {target.name} to {target.target_path}")
         
-        if not self._copy_merge_target(target):
+        if not self._copy_target_files(target):
             return
         
         # Track successful copies for metadata
         self.successfully_copied.append(target.repo_target)
     
-    def _copy_merge_target(self, target: BuildTarget) -> bool:
-        """Copy target with merge support"""
+    def _copy_target_files(self, target: BuildTarget) -> bool:
+        """Copy target files to destination (always clean copy)"""
         if not target.source_path.exists():
             logger.warning(f"Source path does not exist: {target.source_path}")
             return False
@@ -544,21 +544,19 @@ class SafeBuildCopier:
         if self.verbose:
             logger.debug(f"Copying {target.name} to {target.target_path}")
         
-        # For merge targets, don't remove existing directory - merge into it
-        if not target_dir.exists():
-            target_dir.mkdir(parents=True, exist_ok=True)
+        # Always delete and recreate target directory for clean builds
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        target_dir.mkdir(parents=True, exist_ok=True)
         
-        # Copy files (merge mode - don't overwrite existing files)
+        # Copy all files from source to target
         for item in target.source_path.iterdir():
             dest_path = target_dir / item.name
             
             if item.is_dir():
-                # Use copytree with dirs_exist_ok to merge directories
-                shutil.copytree(item, dest_path, dirs_exist_ok=True)
+                shutil.copytree(item, dest_path)
             else:
-                # Don't overwrite existing files in merge mode
-                if not dest_path.exists():
-                    shutil.copy2(item, dest_path)
+                shutil.copy2(item, dest_path)
         
         # Remove .vite directories
         vite_dir = target_dir / ".vite"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the code changes provided, here's a precise description of the pull request:

**ci: simplify build copy logic to always use clean builds**

This pull request modifies the build copy process in `scripts/release-go.py` to always perform clean builds by removing existing target directories before copying. The key changes include:

1. Updated the `build_from` path for app shell templates to use the correct source directory (`apps/portal-app-shell/dist/{variant}`)

2. Renamed the copy method from `_copy_merge_target` to `_copy_target_files` to reflect its simplified purpose

3. Changed the copy logic to always delete and recreate the target directory before copying, ensuring clean builds

4. Simplified the file copying process by removing the merge mode logic that previously avoided overwriting existing files

5. Updated the method documentation to reflect that it now always performs clean copies

These changes ensure that each build starts with a clean slate, preventing potential issues from leftover files from previous builds.
<!-- kody-pr-summary:end -->