### PR TITLE
ci: move commit hash retrieval after git commit operation

### DIFF
--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -964,21 +964,8 @@ def main():
         # Write metadata for downstream workflows
         modified_apps = copier.get_modified_apps_list(targets)
         
-        # Get current commit hash for metadata
-        try:
-            commit_result = subprocess.run(
-                ["git", "rev-parse", "HEAD"],
-                cwd=repo_root,
-                capture_output=True,
-                text=True
-            )
-            commit_hash = commit_result.stdout.strip() if commit_result.returncode == 0 else None
-        except:
-            commit_hash = None
-        
-        write_metadata_files(modified_apps, commit_hash, args.verbose)
-        
         # Git operations
+        commit_hash = None
         if not args.no_push:
             # Stage and commit changes
             result = subprocess.run(
@@ -1012,6 +999,17 @@ def main():
                 if commit_result.returncode != 0:
                     logger.error(f"Failed to commit changes: {commit_result.stderr}")
                     return 1
+                
+                try:
+                    hash_result = subprocess.run(
+                        ["git", "rev-parse", "HEAD"],
+                        cwd=repo_root,
+                        capture_output=True,
+                        text=True
+                    )
+                    commit_hash = hash_result.stdout.strip() if hash_result.returncode == 0 else None
+                except:
+                    commit_hash = None
                 
                 # Push changes
                 push_result = subprocess.run(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request moves the retrieval of the Git commit hash to occur after the Git commit operation in the release script. Previously, the commit hash was captured before any Git operations were performed. The change ensures that the hash retrieved corresponds to the actual commit that was just created, rather than potentially capturing a different commit state. This modification improves the accuracy of metadata tracking by associating the correct commit hash with the release changes.
<!-- kody-pr-summary:end -->