### PR TITLE
fix(docs.pinner.xyz): domain typo

### DIFF
--- a/apps/docs.pinner.xyz/docs/partials/_api-token-setup.mdx
+++ b/apps/docs.pinner.xyz/docs/partials/_api-token-setup.mdx
@@ -1,6 +1,6 @@
 ## Getting Your API Token
 
-1. Sign up at [account.pinner.info](https://account.pinner.info)
+1. Sign up at [account.pinner.xyz](https://account.pinner.xyz)
 2. Navigate to your account settings
 3. Generate a new API token
 

--- a/apps/docs.pinner.xyz/docs/partials/_prerequisites.mdx
+++ b/apps/docs.pinner.xyz/docs/partials/_prerequisites.mdx
@@ -1,5 +1,5 @@
 ## Prerequisites
 
-- API key from [account.pinner.info](https://account.pinner.info)
+- API key from [account.pinner.xyz](https://account.pinner.xyz)
 - Node.js 20+ or browser environment
 - ~5 minutes


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes a domain typo in the documentation for docs.pinner.xyz. The changes update the domain from "account.pinner.info" to "account.pinner.xyz" in two documentation files: "_api-token-setup.mdx" and "_prerequisites.mdx". This ensures that users are directed to the correct domain when signing up and obtaining their API key.
<!-- kody-pr-summary:end -->