### PR TITLE
chore/build config cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ node_modules
 /.sass-cache
 /connect.lock
 /coverage
+.vitest-attachments
+__screenshots__
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log
@@ -41,6 +43,7 @@ Thumbs.db
 
 .nx/cache
 libs/*/**/generated
+!libs/portal-sdk/src/account/generated
 libs/*/**/pnpm-lock.yaml
 apps/*/**/pnpm-lock.yaml
 apps/*/.astro

--- a/apps/docs.pinner.xyz/tsconfig.json
+++ b/apps/docs.pinner.xyz/tsconfig.json
@@ -15,7 +15,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },

--- a/apps/lumeweb.com/tsconfig.json
+++ b/apps/lumeweb.com/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "astro/tsconfigs/base",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/portal-frontend/tsconfig.json
+++ b/apps/portal-frontend/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"]
 		}

--- a/apps/web3.news/tsconfig.json
+++ b/apps/web3.news/tsconfig.json
@@ -20,7 +20,6 @@
         "strict": true,
         "allowJs": true,
         "forceConsistentCasingInFileNames": true,
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./app/*"

--- a/libs/advanced-rest/package.json
+++ b/libs/advanced-rest/package.json
@@ -19,8 +19,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/advanced-rest/tsconfig.json
+++ b/libs/advanced-rest/tsconfig.json
@@ -6,7 +6,6 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/pinner/tsconfig.json
+++ b/libs/pinner/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-framework-auth/tsconfig.json
+++ b/libs/portal-framework-auth/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-framework-ui-core/tsconfig.json
+++ b/libs/portal-framework-ui-core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-framework-ui/tsconfig.json
+++ b/libs/portal-framework-ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-generators/package.json
+++ b/libs/portal-generators/package.json
@@ -5,13 +5,12 @@
     "dist",
     "package.json"
   ],
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/portal-generators/tsconfig.json
+++ b/libs/portal-generators/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "module": "commonjs",
     "paths": {
       "@/*": ["./src/*"]

--- a/libs/portal-plugin-abuse-common/tsconfig.json
+++ b/libs/portal-plugin-abuse-common/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-abuse-report/tsconfig.json
+++ b/libs/portal-plugin-abuse-report/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-abuse/tsconfig.json
+++ b/libs/portal-plugin-abuse/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-admin/tsconfig.json
+++ b/libs/portal-plugin-admin/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-core/tsconfig.json
+++ b/libs/portal-plugin-core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-dashboard/package.json
+++ b/libs/portal-plugin-dashboard/package.json
@@ -11,8 +11,7 @@
   "exports": {
     ".": {
       "types": "./lib-dist/esm/index.d.ts",
-      "import": "./lib-dist/esm/index.js",
-      "require": "./lib-dist/cjs/index.cjs"
+      "import": "./lib-dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/portal-plugin-dashboard/tsconfig.json
+++ b/libs/portal-plugin-dashboard/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@e2e/*": ["./e2e/*"],

--- a/libs/portal-plugin-dashboard/tsdown.config.ts
+++ b/libs/portal-plugin-dashboard/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 import { createLibraryConfigWithDirs } from "@lumeweb/tsdown-config";
 
 export default defineConfig(
-  createLibraryConfigWithDirs("./src-lib/index.ts", "lib-dist/esm", "lib-dist/cjs", {
+  createLibraryConfigWithDirs("./src-lib/index.ts", "lib-dist/esm", {
     target: "es2022",
     platform: "node",
   })

--- a/libs/portal-plugin-ipfs/tsconfig.json
+++ b/libs/portal-plugin-ipfs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-lbry/tsconfig.json
+++ b/libs/portal-plugin-lbry/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/portal-plugin-template/package.json
+++ b/libs/portal-plugin-template/package.json
@@ -8,8 +8,7 @@
   "exports": {
     ".": {
       "types": "./lib-dist/esm/index.d.ts",
-      "import": "./lib-dist/esm/index.js",
-      "require": "./lib-dist/cjs/index.cjs"
+      "import": "./lib-dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/portal-plugin-template/tsconfig.json
+++ b/libs/portal-plugin-template/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@e2e/*": ["./e2e/*"],

--- a/libs/portal-plugin-template/tsdown.config.ts
+++ b/libs/portal-plugin-template/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 import { createLibraryConfigWithDirs } from "@lumeweb/tsdown-config";
 
 export default defineConfig(
-  createLibraryConfigWithDirs("./src-lib/index.ts", "lib-dist/esm", "lib-dist/cjs", {
+  createLibraryConfigWithDirs("./src-lib/index.ts", "lib-dist/esm", {
     target: "es2022",
     platform: "node",
   })

--- a/libs/portal-sdk/tsconfig.json
+++ b/libs/portal-sdk/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/query-builder/tsconfig.json
+++ b/libs/query-builder/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,

--- a/libs/rego/tsconfig.json
+++ b/libs/rego/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/libs/tsdown-config/index.ts
+++ b/libs/tsdown-config/index.ts
@@ -44,7 +44,6 @@ export function createLibraryConfig(
 export function createLibraryConfigWithDirs(
   entry: string | string[],
   esmDir: string,
-  cjsDir: string,
   options: Partial<UserConfig> = {}
 ): UserConfig {
   return {

--- a/libs/tsdown-config/index.ts
+++ b/libs/tsdown-config/index.ts
@@ -32,12 +32,7 @@ export function createLibraryConfig(
           dir: "dist/esm",
           entryFileNames: "[name].js",
         },
-      },
-      cjs: {
-        outputOptions: {
-          dir: "dist/cjs",
-        },
-      },
+      }
     },
     ...options,
   };
@@ -60,11 +55,6 @@ export function createLibraryConfigWithDirs(
         outputOptions: {
           dir: esmDir,
           entryFileNames: "[name].js",
-        },
-      },
-      cjs: {
-        outputOptions: {
-          dir: cjsDir,
         },
       },
     },
@@ -113,12 +103,7 @@ export function createLibraryConfigWithPlugins(
           dir: "dist/esm",
           entryFileNames: "[name].js",
         },
-      },
-      cjs: {
-        outputOptions: {
-          dir: "dist/cjs",
-        },
-      },
+      }
     },
     plugins,
     ...options,

--- a/libs/uppy-post-upload/tsconfig.json
+++ b/libs/uppy-post-upload/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,11 +15,10 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
     "allowImportingTsExtensions": true,
     "paths": {
-      "@shared-assets/*": ["shared/assets/*"],
-      "@lumeweb/portal-generators": ["libs/portal-generators/src/index.ts"]
+      "@shared-assets/*": ["./shared/assets/*"],
+      "@lumeweb/portal-generators": ["./libs/portal-generators/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
- **fix: remove CJS output, fix tsconfig baseUrl and paths**
- **fix: remove baseUrl from all tsconfigs**

---

<!-- kody-pr-summary:start -->
This pull request cleans up the build configuration and updates the `.gitignore` file:

- **Removes CommonJS (CJS) output from library build configs**: The CJS output options (`dist/cjs` directory) have been removed from all three `createLibraryConfig*` functions in `libs/tsdown-config/index.ts`, simplifying the build to produce only ESM output.

- **Updates `.gitignore`**: Adds `.vitest-attachments` and `__screenshots__` directories (test-related artifacts), and adds an exclusion (`!libs/portal-sdk/src/account/generated`) so that the portal-sdk's account generated code is tracked despite the broader `libs/*/**/generated` ignore pattern.
<!-- kody-pr-summary:end -->