### PR TITLE
feat: migrate advanced-rest to ky v1 API (prefixUrl -> prefix)

### DIFF
--- a/libs/advanced-rest/src/utils/generateUrl.spec.ts
+++ b/libs/advanced-rest/src/utils/generateUrl.spec.ts
@@ -104,7 +104,7 @@ describe("generateNestedUrl", () => {
     ).toThrow(TemplateResolutionError);
   });
 
-  test("ignores apiBase - returns relative path for ky's prefixUrl", () => {
+  test("ignores apiBase - returns relative path for ky's prefix", () => {
     const result = generateNestedUrl({
       apiBase: "https://api.example.com",
       meta: {
@@ -113,7 +113,7 @@ describe("generateNestedUrl", () => {
       },
       resource: "cases",
     });
-    // apiBase is ignored because ky uses prefixUrl configuration
+    // apiBase is ignored because ky uses prefix configuration
     expect(result).toBe("cases");
   });
 

--- a/libs/advanced-rest/src/utils/generateUrl.ts
+++ b/libs/advanced-rest/src/utils/generateUrl.ts
@@ -81,6 +81,6 @@ export function generateNestedUrl({
     resolvedPath = `${resolvedPath}/${operation}`.replace(/\/\/+/g, "/");
   }
 
-  // Return relative path without leading slash for ky's prefixUrl
+  // Return relative path without leading slash for ky's prefix
   return `${resolvedPath.replace(/^\/+/, "")}`;
 }

--- a/libs/advanced-rest/src/utils/kyInstance.ts
+++ b/libs/advanced-rest/src/utils/kyInstance.ts
@@ -8,9 +8,8 @@ export const httpClient = (apiBase?: string) =>
   ky.extend({
     hooks: {
       afterResponse: [
-        async (request, options, response) => {
+        async ({ response }) => {
           if (!response.ok) {
-            // Clone response before reading body to avoid locking the stream
             const errorBody = await response
               .clone()
               .json()
@@ -28,7 +27,7 @@ export const httpClient = (apiBase?: string) =>
         },
       ],
       beforeRequest: [
-        (request) => {
+        ({ request }) => {
           const url = new URL(request.url);
           if (/{\w+}/.exec(url.pathname)) {
             throw new NestedParamError(
@@ -38,5 +37,5 @@ export const httpClient = (apiBase?: string) =>
         },
       ],
     },
-    prefixUrl: apiBase,
+    prefix: apiBase,
   });

--- a/libs/portal-plugin-admin/package.json
+++ b/libs/portal-plugin-admin/package.json
@@ -10,6 +10,7 @@
     "lint": "oxlint ."
   },
   "dependencies": {
+    "@lumeweb/advanced-rest-provider": "workspace:*",
     "@lumeweb/portal-framework-auth": "workspace:*",
     "@lumeweb/portal-framework-core": "workspace:*",
     "@lumeweb/portal-framework-ui": "workspace:*",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Migrate `advanced-rest` library to the `ky` v1 API

This PR updates the `advanced-rest` library to be compatible with the `ky` HTTP client v1 API, which introduced breaking changes to option names and hook callback signatures:

- **Renamed `prefixUrl` option to `prefix`** in the ky instance configuration, reflecting the v1 API rename.
- **Updated hook callback signatures** to use destructured object parameters instead of positional parameters:
  - `afterResponse`: changed from `(request, options, response)` to `({ response })`
  - `beforeRequest`: changed from `(request)` to `({ request })`
- **Updated related comments and test descriptions** to reference `prefix` instead of `prefixUrl`.
<!-- kody-pr-summary:end -->