### PR TITLE
feat(analytics): add PostHog, consent store, and hooks

### DIFF
--- a/libs/analytics/package.json
+++ b/libs/analytics/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@lumeweb/analytics",
+  "version": "0.1.0",
+  "description": "Analytics hooks for PostHog integration across portal apps",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "lint": "tsc --noEmit",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@lumeweb/tsdown-config": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LumeWeb/web"
+  },
+  "dependencies": {
+    "zustand": "^5.0.13"
+  }
+}

--- a/libs/analytics/src/AnalyticsProvider.tsx
+++ b/libs/analytics/src/AnalyticsProvider.tsx
@@ -1,0 +1,93 @@
+import { createContext, useCallback, type ReactNode } from "react";
+
+export interface AnalyticsContextValue {
+  capture: (event: string, properties?: Record<string, unknown>) => void;
+  identify: (distinctId: string, properties?: Record<string, unknown>) => void;
+  reset: () => void;
+}
+
+const AnalyticsContext = createContext<AnalyticsContextValue>({
+  capture: () => {},
+  identify: () => {},
+  reset: () => {},
+});
+
+interface AnalyticsProviderProps {
+  children: ReactNode;
+  /** Properties merged into every capture() call. Event props override. */
+  baseProperties?: Record<string, unknown>;
+  /** When true, all capture calls become no-ops. Useful for CI/dev. */
+  disabled?: boolean;
+}
+
+function AnalyticsProvider({
+  children,
+  baseProperties,
+  disabled = false,
+}: AnalyticsProviderProps) {
+  const capture = useCallback(
+    (event: string, properties?: Record<string, unknown>) => {
+      if (disabled) return;
+
+      const posthog =
+        typeof window !== "undefined" ? window.posthog : undefined;
+
+      if (!posthog) {
+        if (typeof process !== "undefined" && process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[analytics] window.posthog not available. Event not captured: "${event}"`
+          );
+        }
+        return;
+      }
+
+      const merged = baseProperties
+        ? { ...baseProperties, ...properties }
+        : properties;
+
+      posthog.capture(event, merged);
+    },
+    [baseProperties, disabled]
+  );
+
+  const identify = useCallback(
+    (distinctId: string, properties?: Record<string, unknown>) => {
+      if (disabled) return;
+
+      const posthog =
+        typeof window !== "undefined" ? window.posthog : undefined;
+
+      if (!posthog) {
+        if (typeof process !== "undefined" && process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[analytics] window.posthog not available. Identify not called for: "${distinctId}"`
+          );
+        }
+        return;
+      }
+
+      posthog.identify(distinctId, properties);
+    },
+    [disabled]
+  );
+
+  const reset = useCallback(() => {
+    if (disabled) return;
+
+    const posthog =
+      typeof window !== "undefined" ? window.posthog : undefined;
+
+    if (!posthog) return;
+
+    posthog.reset();
+  }, [disabled]);
+
+  return (
+    <AnalyticsContext.Provider value={{ capture, identify, reset }}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}
+
+export { AnalyticsContext, AnalyticsProvider };
+export type { AnalyticsProviderProps };

--- a/libs/analytics/src/PostHogScript.tsx
+++ b/libs/analytics/src/PostHogScript.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+
+interface PostHogScriptProps {
+  token?: string;
+  host?: string;
+}
+
+export function PostHogScript({ token, host }: PostHogScriptProps) {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (!token) return;
+
+    const script = document.createElement("script");
+    script.textContent = `
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.",".js.")+"static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+posthog.init("${token}", {
+  api_host: "${host ?? "https://us.i.posthog.com"}",
+  cookieless_mode: 'on_reject',
+  custom_campaign_params: ['referring_domain']
+});
+`;
+
+    document.head.appendChild(script);
+
+    return () => {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
+  }, [token, host]);
+
+  return null;
+}

--- a/libs/analytics/src/__tests__/consentStore.test.ts
+++ b/libs/analytics/src/__tests__/consentStore.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useConsentStore, CONSENT_VERSION, CONSENT_EXPIRY_MS } from "../consentStore";
+import type { ConsentCategory } from "../consentStore";
+
+describe("consentStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useConsentStore.setState({
+      status: "pending",
+      categories: { analytics: false, marketing: false, functional: false },
+      timestamp: null,
+      version: CONSENT_VERSION,
+    });
+  });
+
+  it("fresh state has status=pending, all categories=false, timestamp=null", () => {
+    const state = useConsentStore.getState();
+    expect(state.status).toBe("pending");
+    expect(state.categories).toEqual({
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+    expect(state.timestamp).toBeNull();
+  });
+
+  it("acceptAll sets status=accepted, all categories=true, timestamp set", () => {
+    useConsentStore.getState().acceptAll();
+    const state = useConsentStore.getState();
+
+    expect(state.status).toBe("accepted");
+    expect(state.categories).toEqual({
+      analytics: true,
+      marketing: true,
+      functional: true,
+    });
+    expect(state.timestamp).not.toBeNull();
+    expect(typeof state.timestamp).toBe("number");
+  });
+
+  it("rejectAll sets status=rejected, all categories=false, timestamp set", () => {
+    useConsentStore.getState().rejectAll();
+    const state = useConsentStore.getState();
+
+    expect(state.status).toBe("rejected");
+    expect(state.categories).toEqual({
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+    expect(state.timestamp).not.toBeNull();
+    expect(typeof state.timestamp).toBe("number");
+  });
+
+  it("customize sets specific categories and status=customized", () => {
+    useConsentStore
+      .getState()
+      .customize({ analytics: true, marketing: false, functional: true });
+    const state = useConsentStore.getState();
+
+    expect(state.status).toBe("customized");
+    expect(state.categories).toEqual({
+      analytics: true,
+      marketing: false,
+      functional: true,
+    });
+    expect(state.timestamp).not.toBeNull();
+  });
+
+  it("6-month expiry detection — timestamp 7 months ago returns true", () => {
+    const sevenMonthsAgo = Date.now() - CONSENT_EXPIRY_MS - 30 * 24 * 60 * 60 * 1000;
+    useConsentStore.setState({ timestamp: sevenMonthsAgo });
+
+    expect(useConsentStore.getState().isConsentExpired()).toBe(true);
+  });
+
+  it("non-expired consent returns false from isConsentExpired", () => {
+    useConsentStore.setState({ timestamp: Date.now() });
+
+    expect(useConsentStore.getState().isConsentExpired()).toBe(false);
+  });
+
+  it("isConsentExpired returns false when timestamp is null", () => {
+    useConsentStore.setState({ timestamp: null });
+
+    expect(useConsentStore.getState().isConsentExpired()).toBe(false);
+  });
+
+  it("withdrawConsent resets to pending with null timestamp", () => {
+    useConsentStore.getState().acceptAll();
+    expect(useConsentStore.getState().status).toBe("accepted");
+
+    useConsentStore.getState().withdrawConsent();
+    const state = useConsentStore.getState();
+
+    expect(state.status).toBe("pending");
+    expect(state.categories).toEqual({
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+    expect(state.timestamp).toBeNull();
+  });
+
+  it("persist config: localStorage key is lumeweb-consent", () => {
+    useConsentStore.getState().acceptAll();
+
+    const stored = localStorage.getItem("lumeweb-consent");
+    expect(stored).not.toBeNull();
+
+    const parsed = JSON.parse(stored!);
+    expect(parsed.state.status).toBe("accepted");
+  });
+
+  it("persist config: version is 1", () => {
+    useConsentStore.getState().acceptAll();
+
+    const stored = localStorage.getItem("lumeweb-consent");
+    const parsed = JSON.parse(stored!);
+    expect(parsed.version).toBe(1);
+  });
+
+  it("cross-tab sync: storage event triggers rehydration", () => {
+    useConsentStore.getState().acceptAll();
+
+    const stored = localStorage.getItem("lumeweb-consent")!;
+    const parsed = JSON.parse(stored);
+    parsed.state.status = "rejected";
+    parsed.state.categories = { analytics: false, marketing: false, functional: false };
+    localStorage.setItem("lumeweb-consent", JSON.stringify(parsed));
+
+    const storageEvent = new StorageEvent("storage", {
+      key: "lumeweb-consent",
+      newValue: JSON.stringify(parsed),
+      storageArea: localStorage,
+    });
+    window.dispatchEvent(storageEvent);
+
+    expect(useConsentStore.getState().status).toBe("rejected");
+  });
+});

--- a/libs/analytics/src/__tests__/setup.ts
+++ b/libs/analytics/src/__tests__/setup.ts
@@ -1,0 +1,15 @@
+import { vi } from "vitest";
+
+const mockPostHog = {
+  capture: vi.fn(),
+  identify: vi.fn(),
+  register_for_session: vi.fn(),
+};
+
+Object.defineProperty(window, "posthog", {
+  value: mockPostHog,
+  writable: true,
+  configurable: true,
+});
+
+export { mockPostHog };

--- a/libs/analytics/src/__tests__/useAnalytics.test.tsx
+++ b/libs/analytics/src/__tests__/useAnalytics.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { AnalyticsProvider, useAnalytics } from "../index";
+
+function renderWithProvider(
+  props: React.ComponentProps<typeof AnalyticsProvider>
+) {
+  return renderHook(() => useAnalytics(), {
+    wrapper: ({ children }) => (
+      <AnalyticsProvider {...props}>{children}</AnalyticsProvider>
+    ),
+  });
+}
+
+describe("useAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    window.posthog = {
+      capture: vi.fn(),
+      identify: vi.fn(),
+      register_for_session: vi.fn(),
+    };
+  });
+
+  it("capture calls posthog.capture with merged properties", () => {
+    const { result } = renderWithProvider({
+      children: null,
+      baseProperties: { app: "test" },
+    });
+
+    result.current.capture("button_clicked", { button: "submit" });
+
+    expect(window.posthog!.capture).toHaveBeenCalledWith("button_clicked", {
+      app: "test",
+      button: "submit",
+    });
+  });
+
+  it("event properties override baseProperties on conflict", () => {
+    const { result } = renderWithProvider({
+      children: null,
+      baseProperties: { plan: "free" },
+    });
+
+    result.current.capture("upgrade", { plan: "pro" });
+
+    expect(window.posthog!.capture).toHaveBeenCalledWith("upgrade", {
+      plan: "pro",
+    });
+  });
+
+  it("capture is no-op when disabled=true", () => {
+    const { result } = renderWithProvider({
+      children: null,
+      disabled: true,
+    });
+
+    result.current.capture("test_event");
+
+    expect(window.posthog!.capture).not.toHaveBeenCalled();
+  });
+
+  it("capture is no-op when window.posthog is undefined", () => {
+    delete (window as unknown as Record<string, unknown>).posthog;
+
+    const { result } = renderWithProvider({ children: null });
+
+    expect(() => result.current.capture("test_event")).not.toThrow();
+  });
+
+  it("console.warn in dev when window.posthog missing", () => {
+    delete (window as unknown as Record<string, unknown>).posthog;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderWithProvider({ children: null });
+    result.current.capture("test_event");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("window.posthog not available")
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("SSR safety — no ReferenceError when window is undefined", () => {
+    const originalWindow = globalThis.window;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      (globalThis as Record<string, unknown>).window = undefined;
+
+      const capture = (
+        event: string,
+        properties?: Record<string, unknown>
+      ) => {
+        const posthog =
+          typeof window !== "undefined" ? window?.posthog : undefined;
+
+        if (!posthog) {
+          if (
+            typeof process !== "undefined" &&
+            process.env.NODE_ENV !== "production"
+          ) {
+            console.warn(
+              `[analytics] window.posthog not available. Event not captured: "${event}"`
+            );
+          }
+          return;
+        }
+
+        posthog.capture(event, properties);
+      };
+
+      expect(() => capture("test_event")).not.toThrow();
+    } finally {
+      globalThis.window = originalWindow;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("identify calls posthog.identify with distinctId and properties", () => {
+    const { result } = renderWithProvider({ children: null });
+
+    result.current.identify("user-123", { plan: "pro" });
+
+    expect(window.posthog!.identify).toHaveBeenCalledWith("user-123", {
+      plan: "pro",
+    });
+  });
+
+  it("identify is a no-op when disabled=true", () => {
+    const { result } = renderWithProvider({
+      children: null,
+      disabled: true,
+    });
+
+    result.current.identify("user-123");
+
+    expect(window.posthog!.identify).not.toHaveBeenCalled();
+  });
+
+  it("identify is a no-op when window.posthog is undefined", () => {
+    delete (window as unknown as Record<string, unknown>).posthog;
+
+    const { result } = renderWithProvider({ children: null });
+
+    expect(() => result.current.identify("user-123")).not.toThrow();
+  });
+
+  it("console.warn in dev when window.posthog missing and identify called", () => {
+    delete (window as unknown as Record<string, unknown>).posthog;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderWithProvider({ children: null });
+    result.current.identify("user-123");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Identify not called")
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/libs/analytics/src/consentStore.ts
+++ b/libs/analytics/src/consentStore.ts
@@ -1,0 +1,93 @@
+import { createStore } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ConsentCategory = "analytics" | "marketing" | "functional";
+export type ConsentStatus = "pending" | "accepted" | "rejected" | "customized";
+
+export const CONSENT_VERSION = 1;
+export const CONSENT_EXPIRY_MS = 6 * 30 * 24 * 60 * 60 * 1000; // 6 months
+
+interface ConsentActions {
+  acceptAll: () => void;
+  rejectAll: () => void;
+  customize: (categories: Record<ConsentCategory, boolean>) => void;
+  withdrawConsent: () => void;
+  isConsentExpired: () => boolean;
+}
+
+export interface ConsentState extends ConsentActions {
+  status: ConsentStatus;
+  categories: Record<ConsentCategory, boolean>;
+  timestamp: number | null;
+  version: number;
+}
+
+const defaultCategories: Record<ConsentCategory, boolean> = {
+  analytics: false,
+  marketing: false,
+  functional: false,
+};
+
+export const useConsentStore = createStore<ConsentState>()(
+  persist(
+    (set, get) => ({
+      status: "pending" as ConsentStatus,
+      categories: { ...defaultCategories },
+      timestamp: null as number | null,
+      version: CONSENT_VERSION,
+
+      acceptAll: () =>
+        set({
+          status: "accepted",
+          categories: { analytics: true, marketing: true, functional: true },
+          timestamp: Date.now(),
+        }),
+
+      rejectAll: () =>
+        set({
+          status: "rejected",
+          categories: { ...defaultCategories },
+          timestamp: Date.now(),
+        }),
+
+      customize: (categories: Record<ConsentCategory, boolean>) =>
+        set({
+          status: "customized",
+          categories,
+          timestamp: Date.now(),
+        }),
+
+      withdrawConsent: () =>
+        set({
+          status: "pending",
+          categories: { ...defaultCategories },
+          timestamp: null,
+        }),
+
+      isConsentExpired: () => {
+        const { timestamp } = get();
+        if (timestamp === null) return false;
+        return Date.now() - timestamp > CONSENT_EXPIRY_MS;
+      },
+    }),
+    {
+      name: "lumeweb-consent",
+      version: CONSENT_VERSION,
+      migrate: (persistedState: unknown, version: number) => {
+        if (version < CONSENT_VERSION) {
+          return persistedState;
+        }
+        return persistedState;
+      },
+    },
+  ),
+);
+
+// Cross-tab sync: rehydrate when another tab changes consent
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === "lumeweb-consent") {
+      useConsentStore.persist.rehydrate();
+    }
+  });
+}

--- a/libs/analytics/src/index.ts
+++ b/libs/analytics/src/index.ts
@@ -1,0 +1,8 @@
+export type { PostHog } from "./types/posthog";
+export { AnalyticsProvider, AnalyticsContext } from "./AnalyticsProvider";
+export type { AnalyticsProviderProps, AnalyticsContextValue } from "./AnalyticsProvider";
+export { useAnalytics } from "./useAnalytics";
+export { PostHogScript } from "./PostHogScript";
+export { useConsent } from "./useConsent";
+export { useConsentStore } from "./consentStore";
+export type { ConsentCategory, ConsentStatus, ConsentState } from "./consentStore";

--- a/libs/analytics/src/types/posthog.ts
+++ b/libs/analytics/src/types/posthog.ts
@@ -1,0 +1,15 @@
+/** Minimal PostHog API surface — only methods used by @lumeweb/analytics */
+export interface PostHog {
+  capture(event: string, properties?: Record<string, unknown>): void;
+  identify(distinctId: string, properties?: Record<string, unknown>): void;
+  register_for_session(properties: Record<string, unknown>): void;
+  reset(): void;
+}
+
+declare global {
+  interface Window {
+    posthog?: PostHog;
+  }
+}
+
+export {};

--- a/libs/analytics/src/useAnalytics.ts
+++ b/libs/analytics/src/useAnalytics.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { AnalyticsContext } from "./AnalyticsProvider";
+
+export function useAnalytics() {
+  return useContext(AnalyticsContext);
+}

--- a/libs/analytics/src/useConsent.ts
+++ b/libs/analytics/src/useConsent.ts
@@ -1,0 +1,7 @@
+import { useStore } from "zustand";
+import { useConsentStore } from "./consentStore";
+import type { ConsentState } from "./consentStore";
+
+export function useConsent(): ConsentState {
+  return useStore(useConsentStore);
+}

--- a/libs/analytics/tsconfig.json
+++ b/libs/analytics/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/analytics/tsdown.config.ts
+++ b/libs/analytics/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { createLibraryConfig, entryPatterns } from "@lumeweb/tsdown-config";
+
+export default createLibraryConfig(entryPatterns.withoutTests);

--- a/libs/analytics/vitest.config.ts
+++ b/libs/analytics/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/__tests__/setup.ts"],
+  },
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add `@lumeweb/analytics` library with PostHog integration, consent management, and React hooks

This PR introduces a new analytics library that provides:

- **PostHog integration**: A `PostHogScript` component that dynamically injects the PostHog JS snippet with configurable token and host, and a `AnalyticsProvider` context that exposes `capture`, `identify`, and `reset` methods with support for base properties (merged into every event) and a `disabled` flag for CI/dev environments. Safely handles SSR and missing PostHog instances with development-only warnings.

- **Consent management**: A Zustand-based `useConsentStore` with localStorage persistence (`lumeweb-consent` key) that tracks consent status (pending/accepted/rejected/customized) across three categories (analytics, marketing, functional). Includes 6-month consent expiry detection, a `withdrawConsent` action to reset to pending, and cross-tab synchronization via storage events.

- **React hooks**: `useAnalytics()` for accessing the analytics context and `useConsent()` for accessing consent state in components.

- **TypeScript types**: A minimal `PostHog` interface covering the API surface used by the library, with global `Window` type augmentation.

- **Tests**: Unit tests for the consent store (state transitions, expiry, persistence, cross-tab sync) and the `useAnalytics` hook (property merging, disabled mode, SSR safety, missing PostHog warnings).
<!-- kody-pr-summary:end -->