### PR TITLE
feat(portal-analytics): add user identification hook

### DIFF
--- a/libs/portal-analytics/package.json
+++ b/libs/portal-analytics/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@lumeweb/portal-analytics",
+  "version": "0.1.0",
+  "description": "Analytics integration hooks for Lumeweb portal — bridges @lumeweb/analytics with @refinedev/core",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "lint": "tsc --noEmit",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@lumeweb/analytics": "workspace:*"
+  },
+  "peerDependencies": {
+    "@refinedev/core": "catalog:",
+    "react": "catalog:"
+  },
+  "devDependencies": {
+    "@lumeweb/tsdown-config": "workspace:*",
+    "@refinedev/core": "catalog:",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LumeWeb/web"
+  }
+}

--- a/libs/portal-analytics/src/__tests__/setup.ts
+++ b/libs/portal-analytics/src/__tests__/setup.ts
@@ -1,0 +1,6 @@
+import { vi } from "vitest";
+
+Object.defineProperty(window, "posthog", {
+  writable: true,
+  value: undefined,
+});

--- a/libs/portal-analytics/src/__tests__/useIdentifyUser.test.tsx
+++ b/libs/portal-analytics/src/__tests__/useIdentifyUser.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useIdentifyUser } from "../useIdentifyUser";
+
+const mockUseGetIdentity = vi.fn();
+vi.mock("@refinedev/core", () => ({
+  useGetIdentity: () => mockUseGetIdentity(),
+}));
+
+const mockIdentify = vi.fn();
+const mockReset = vi.fn();
+vi.mock("@lumeweb/analytics", () => ({
+  useAnalytics: () => ({
+    identify: mockIdentify,
+    reset: mockReset,
+    capture: vi.fn(),
+  }),
+}));
+
+describe("useIdentifyUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGetIdentity.mockReturnValue({ data: undefined });
+  });
+
+  it("should call identify with user id only", () => {
+    mockUseGetIdentity.mockReturnValue({
+      data: {
+        id: "user-123",
+        email: "test@example.com",
+        firstName: "John",
+        lastName: "Doe",
+      },
+    });
+
+    renderHook(() => useIdentifyUser());
+
+    expect(mockIdentify).toHaveBeenCalledWith("user-123");
+  });
+
+  it("should not call identify twice for same user", () => {
+    const identity = {
+      data: {
+        id: "user-123",
+        email: "test@example.com",
+        firstName: "John",
+        lastName: "Doe",
+      },
+    };
+    mockUseGetIdentity.mockReturnValue(identity);
+
+    const { rerender } = renderHook(() => useIdentifyUser());
+    rerender();
+    rerender();
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call reset when identity is cleared (logout)", () => {
+    const { rerender } = renderHook(() => useIdentifyUser());
+
+    mockUseGetIdentity.mockReturnValue({
+      data: { id: "user-123", email: "test@example.com", firstName: "John" },
+    });
+    rerender();
+    expect(mockIdentify).toHaveBeenCalledWith("user-123");
+
+    mockUseGetIdentity.mockReturnValue({ data: null });
+    rerender();
+    expect(mockReset).toHaveBeenCalled();
+  });
+
+  it("should not call identify when identity has no id", () => {
+    mockUseGetIdentity.mockReturnValue({
+      data: { email: "test@example.com" },
+    });
+
+    renderHook(() => useIdentifyUser());
+
+    expect(mockIdentify).not.toHaveBeenCalled();
+  });
+
+  it("should handle undefined identity gracefully", () => {
+    mockUseGetIdentity.mockReturnValue({ data: undefined });
+
+    renderHook(() => useIdentifyUser());
+
+    expect(mockIdentify).not.toHaveBeenCalled();
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+});

--- a/libs/portal-analytics/src/index.ts
+++ b/libs/portal-analytics/src/index.ts
@@ -1,0 +1,1 @@
+export { useIdentifyUser } from "./useIdentifyUser";

--- a/libs/portal-analytics/src/useIdentifyUser.ts
+++ b/libs/portal-analytics/src/useIdentifyUser.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+import { useGetIdentity } from "@refinedev/core";
+import { useAnalytics } from "@lumeweb/analytics";
+
+/**
+ * Bridges Refine's identity system with PostHog analytics.
+ *
+ * Call this hook ONCE inside the `<Refine>` boundary (where `useGetIdentity` works)
+ * and inside `<AnalyticsProvider>` (where `useAnalytics` works).
+ *
+ * - When identity is available: calls `identify(userId)` once per user
+ * - When identity becomes null (logout): calls `reset()` to clear the PostHog identity
+ */
+export function useIdentifyUser(): void {
+  const { data: identity } = useGetIdentity<Record<string, unknown>>();
+  const { identify, reset } = useAnalytics();
+  const lastIdentifiedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    const userId = identity?.id as string | undefined;
+
+    if (userId && userId !== lastIdentifiedId.current) {
+      lastIdentifiedId.current = userId;
+      identify(userId);
+    } else if (!userId && lastIdentifiedId.current !== null) {
+      lastIdentifiedId.current = null;
+      reset();
+    }
+  }, [identity?.id, identify, reset]);
+}

--- a/libs/portal-analytics/tsconfig.json
+++ b/libs/portal-analytics/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/portal-analytics/tsdown.config.ts
+++ b/libs/portal-analytics/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { createLibraryConfig, entryPatterns } from "@lumeweb/tsdown-config";
+
+export default createLibraryConfig(entryPatterns.withoutTests);

--- a/libs/portal-analytics/vitest.config.ts
+++ b/libs/portal-analytics/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/__tests__/setup.ts"],
+  },
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add `useIdentifyUser` hook to bridge Refine identity with PostHog analytics

This PR introduces the `portal-analytics` library with a `useIdentifyUser` hook that connects the Refine authentication system to the PostHog analytics system. The hook automatically identifies users in analytics when they log in and resets the analytics identity when they log out, while preventing duplicate identify calls for the same user.

Key behaviors:
- Calls `identify(userId)` once when a user with an `id` is detected
- Skips re-identification if the user ID hasn't changed
- Calls `reset()` when the identity is cleared (logout)
- Gracefully handles missing IDs and undefined identity data
<!-- kody-pr-summary:end -->