### PR TITLE
feat(portal-framework-ui-core): add cookie consent banner

### DIFF
--- a/libs/portal-framework-ui-core/package.json
+++ b/libs/portal-framework-ui-core/package.json
@@ -33,6 +33,7 @@
     "tsdown": "catalog:"
   },
   "peerDependencies": {
+    "@lumeweb/analytics": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
+++ b/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+import { useConsent } from "@lumeweb/analytics";
+import type { ConsentCategory } from "@lumeweb/analytics";
+
+import { cn } from "../../lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+
+function getPortalUrl(path: string): string {
+  const domain = import.meta.env.VITE_PORTAL_DOMAIN;
+  if (!domain) return path;
+  return `https://${domain}${path}`;
+}
+
+interface CookieCategoryConfig {
+  key: ConsentCategory;
+  label: string;
+  description: string;
+}
+
+const COOKIE_CATEGORIES: CookieCategoryConfig[] = [
+  {
+    key: "analytics",
+    label: "Analytics",
+    description: "Help us improve by tracking page visits and interactions",
+  },
+  {
+    key: "marketing",
+    label: "Marketing",
+    description: "Receive targeted advertisements based on your activity",
+  },
+  {
+    key: "functional",
+    label: "Functional",
+    description: "Remember your preferences and settings",
+  },
+];
+
+function CookieBanner({ className, ...props }: React.ComponentProps<typeof Sheet>) {
+  const { status, categories, acceptAll, rejectAll, customize, isConsentExpired } =
+    useConsent();
+
+  const [customizing, setCustomizing] = React.useState(false);
+  const [localCategories, setLocalCategories] = React.useState<
+    Record<ConsentCategory, boolean>
+  >(() => ({ ...categories }));
+
+  // Show banner when consent is pending or expired
+  const open = status === "pending" || isConsentExpired();
+
+  // Sync local categories when banner opens
+  React.useEffect(() => {
+    if (open) {
+      setLocalCategories({ ...categories });
+      setCustomizing(false);
+    }
+  }, [open, categories]);
+
+  const handleCategoryToggle = (key: ConsentCategory) => {
+    setLocalCategories((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleSavePreferences = () => {
+    customize(localCategories);
+  };
+
+  return (
+    <Sheet open={open} {...props}>
+      <SheetContent
+        side="bottom"
+        className={cn(
+          "mx-auto max-w-3xl rounded-t-lg border-b-0",
+          className,
+        )}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <SheetHeader className="text-left">
+          <SheetTitle className="text-xl">We value your privacy</SheetTitle>
+          <SheetDescription>
+            We use cookies to enhance your browsing experience, serve personalized
+            content, and analyze our traffic. You can choose which categories to
+            allow.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4 flex gap-3">
+          <Button
+            onClick={acceptAll}
+            variant="default"
+            className="flex-1 h-10 font-medium"
+          >
+            Accept All
+          </Button>
+          <Button
+            onClick={rejectAll}
+            variant="outline"
+            className="flex-1 h-10 font-medium"
+          >
+            Reject All
+          </Button>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setCustomizing((prev) => !prev)}
+          className="mt-3 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
+        >
+          {customizing ? "Hide options" : "Customize"}
+        </button>
+
+        {customizing && (
+          <div className="mt-4 space-y-4">
+            {COOKIE_CATEGORIES.map(({ key, label, description }) => (
+              <div
+                key={key}
+                className="flex items-start justify-between gap-4 rounded-lg border p-4"
+              >
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium leading-none">{label}</p>
+                  <p className="text-sm text-muted-foreground">{description}</p>
+                </div>
+                <Switch
+                  checked={localCategories[key]}
+                  onCheckedChange={() => handleCategoryToggle(key)}
+                />
+              </div>
+            ))}
+
+            <Button
+              onClick={handleSavePreferences}
+              variant="default"
+              className="w-full h-10 font-medium"
+            >
+              Save Preferences
+            </Button>
+          </div>
+        )}
+
+        <div className="mt-4 border-t pt-3 flex gap-4">
+          <a
+            href={getPortalUrl("/privacy-policy")}
+            className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
+          >
+            Privacy Policy
+          </a>
+          <a
+            href={getPortalUrl("/terms-of-service")}
+            className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
+          >
+            Terms of Service
+          </a>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+CookieBanner.displayName = "CookieBanner";
+
+export { CookieBanner };

--- a/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
+++ b/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
@@ -72,7 +72,7 @@ function CookieBanner({ className, ...props }: React.ComponentProps<typeof Sheet
   };
 
   return (
-    <Sheet open={open} {...props}>
+    <Sheet open={open} onOpenChange={() => {}} {...props}>
       <SheetContent
         side="bottom"
         className={cn(

--- a/libs/portal-framework-ui-core/src/index.ts
+++ b/libs/portal-framework-ui-core/src/index.ts
@@ -10,6 +10,7 @@ export * from "@/components/ui/calendar";
 export * from "@/components/ui/card";
 export * from "@/components/ui/carousel";
 export * from "@/components/ui/chart";
+export * from "@/components/ui/cookie-banner";
 export * from "@/components/ui/checkbox";
 export * from "@/components/ui/collapsible";
 export * from "@/components/ui/command";

--- a/libs/portal-framework-ui-core/src/vite-env.d.ts
+++ b/libs/portal-framework-ui-core/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/shared-modules.ts
+++ b/shared-modules.ts
@@ -1,22 +1,27 @@
-import type { ModuleFederationOptions } from "@module-federation/vite/lib/utils/normalizeModuleFederationOptions";
+import type { ModuleFederationOptions } from "@module-federation/vite";
 
 const modules = [
   "@lumeweb/portal-framework-core",
   "@lumeweb/portal-framework-ui",
   "@lumeweb/portal-framework-ui-core",
+  "@lumeweb/advanced-rest-provider",
   "@refinedev/core",
   "@tanstack/react-query",
   "react",
   "react-dom",
   "react-router",
   "react-hook-form",
+  "@lumeweb/analytics",
 ];
 
 export function getSharedModules(): ModuleFederationOptions["shared"] {
-  return modules.reduce((acc, module) => {
-    acc[module] = {
-      singleton: true,
-    };
-    return acc;
-  }, {}) satisfies ModuleFederationOptions["shared"];
+  return modules.reduce<Record<string, { singleton: boolean }>>(
+    (acc, module) => {
+      acc[module] = {
+        singleton: true,
+      };
+      return acc;
+    },
+    {}
+  ) satisfies ModuleFederationOptions["shared"];
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add a cookie consent banner component to the portal framework UI library

This PR introduces a `CookieBanner` component that integrates with `@lumeweb/analytics` to manage user cookie consent. The banner automatically displays when consent is pending or expired, and provides users with the ability to:

- **Accept All** cookies
- **Reject All** cookies
- **Customize** preferences by individually toggling three cookie categories: Analytics, Marketing, and Functional
- **Save** their customized preferences

The banner also includes links to the Privacy Policy and Terms of Service pages, and prevents dismissal by clicking outside to ensure explicit consent is given.

Additionally, `@lumeweb/analytics` and `@lumeweb/advanced-rest-provider` are registered as shared modules in the module federation configuration, and a Vite client type reference is added to support `import.meta.env` usage.
<!-- kody-pr-summary:end -->