### PR TITLE
feat(pinner): sync IpnsClient and WebsitesClient with server swagger

### DIFF
--- a/libs/pinner/src/__tests__/msw-websites-ipns-handlers.ts
+++ b/libs/pinner/src/__tests__/msw-websites-ipns-handlers.ts
@@ -24,6 +24,7 @@ interface Website {
   target_hash: string;
   status: string;
   validation_token: string;
+  dns_hosting_enabled: boolean;
   created: Date;
   updated: Date;
   expired: boolean;
@@ -62,6 +63,7 @@ let websites: Website[] = [
     target_hash: "QmTest1",
     status: "active",
     validation_token: "valid-token-123",
+    dns_hosting_enabled: false,
     created: new Date("2024-01-01T00:00:00Z"),
     updated: new Date("2024-01-01T00:00:00Z"),
     expired: false,
@@ -75,6 +77,7 @@ let websites: Website[] = [
     target_hash: "k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e",
     status: "pending",
     validation_token: "valid-token-456",
+    dns_hosting_enabled: false,
     created: new Date("2024-01-02T00:00:00Z"),
     updated: new Date("2024-01-02T00:00:00Z"),
     expired: false,
@@ -112,6 +115,7 @@ export function resetWebsitesIPNSState() {
       target_hash: "QmTest1",
       status: "active",
       validation_token: "valid-token-123",
+      dns_hosting_enabled: false,
       created: new Date("2024-01-01T00:00:00Z"),
       updated: new Date("2024-01-01T00:00:00Z"),
       expired: false,
@@ -125,6 +129,7 @@ export function resetWebsitesIPNSState() {
       target_hash: "k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e",
       status: SSLStatus.PENDING,
       validation_token: "valid-token-456",
+      dns_hosting_enabled: false,
       created: new Date("2024-01-02T00:00:00Z"),
       updated: new Date("2024-01-02T00:00:00Z"),
       expired: false,
@@ -144,12 +149,18 @@ export function resetWebsitesIPNSState() {
 export const listIPNSKeysHandler = http.get(
   `${testConfig.apiUrl}/ipns/keys`,
   async () => {
-    return HttpResponse.json(ipnsKeys, {
-      status: 200,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
+    return HttpResponse.json(
+      {
+        data: ipnsKeys,
+        total: ipnsKeys.length,
       },
-    });
+      {
+        status: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
   },
 );
 
@@ -313,6 +324,24 @@ export const ipnsHandlers = [
 // WEBSITES HANDLERS
 // ============================================================================
 
+export const getWebsiteConfigHandler = http.get(
+  `${testConfig.apiUrl}/websites/config`,
+  async () => {
+    return HttpResponse.json(
+      {
+        gateway_domain: "ipfs.pinner.xyz",
+        nameservers: ["ns1.pinner.xyz", "ns2.pinner.xyz"],
+      },
+      {
+        status: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
+  },
+);
+
 export const listWebsitesHandler = http.get(
   `${testConfig.apiUrl}/websites`,
   async () => {
@@ -338,6 +367,7 @@ export const createWebsiteHandler = http.post(
       domain: string;
       target_type: string;
       target_hash: string;
+      dns_hosting_enabled?: boolean;
     };
 
     const newWebsite: Website = {
@@ -347,6 +377,7 @@ export const createWebsiteHandler = http.post(
       target_hash: body.target_hash,
       status: SSLStatus.PENDING,
       validation_token: `valid-token-${nextWebsiteId}`,
+      dns_hosting_enabled: body.dns_hosting_enabled ?? false,
       created: new Date(),
       updated: new Date(),
       expired: false,
@@ -392,9 +423,10 @@ export const updateWebsiteHandler = http.put(
   async ({ params, request }) => {
     const id = parseInt(params.id as string);
     const body = (await request.json()) as {
-      domain: string;
-      target_type: string;
-      target_hash: string;
+      domain?: string;
+      target_type?: string;
+      target_hash?: string;
+      dns_hosting_enabled?: boolean;
     };
 
     const website = websites.find((w) => w.id === id);
@@ -405,9 +437,10 @@ export const updateWebsiteHandler = http.put(
       );
     }
 
-    website.domain = body.domain;
-    website.target_type = body.target_type;
-    website.target_hash = body.target_hash;
+    if (body.domain !== undefined) website.domain = body.domain;
+    if (body.target_type !== undefined) website.target_type = body.target_type;
+    if (body.target_hash !== undefined) website.target_hash = body.target_hash;
+    if (body.dns_hosting_enabled !== undefined) website.dns_hosting_enabled = body.dns_hosting_enabled;
     website.updated = new Date();
     website.status = "pending";
 
@@ -532,9 +565,12 @@ export function resetSSLStatuses(): void {
 }
 
 // Combine all Websites handlers
+// Note: getWebsiteConfigHandler MUST come before getWebsiteHandler to avoid 
+// /websites/:id matching /websites/config
 export const websitesHandlers = [
   listWebsitesHandler,
   createWebsiteHandler,
+  getWebsiteConfigHandler,
   getWebsiteHandler,
   updateWebsiteHandler,
   deleteWebsiteHandler,

--- a/libs/pinner/src/api/__tests__/ipns.spec.ts
+++ b/libs/pinner/src/api/__tests__/ipns.spec.ts
@@ -44,14 +44,15 @@ describe("IpnsClient", () => {
       worker.use(...ipnsHandlers);
       const client = new IpnsClient(mockConfig);
 
-      const keys = await client.listKeys();
+      const result = await client.listKeys();
 
-      expect(keys).toHaveLength(2);
-      expect(keys[0]).toHaveProperty("id");
-      expect(keys[0]).toHaveProperty("name");
-      expect(keys[0]).toHaveProperty("ipns_name");
-      expect(keys[0]).toHaveProperty("peer_id");
-      expect(keys[0]).toHaveProperty("created");
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.data[0]).toHaveProperty("id");
+      expect(result.data[0]).toHaveProperty("name");
+      expect(result.data[0]).toHaveProperty("ipns_name");
+      expect(result.data[0]).toHaveProperty("peer_id");
+      expect(result.data[0]).toHaveProperty("created");
     });
 
     it("should handle authentication errors", async ({ worker }) => {
@@ -78,8 +79,31 @@ describe("IpnsClient", () => {
 
       // For now, just test normal case
       const client = new IpnsClient(mockConfig);
-      const keys = await client.listKeys();
-      expect(keys).toBeDefined();
+      const result = await client.listKeys();
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe("getKey", () => {
+    it("should get a specific IPNS key", async ({ worker }) => {
+      worker.use(...ipnsHandlers);
+      const client = new IpnsClient(mockConfig);
+
+      const key = await client.getKey(1);
+
+      expect(key).toHaveProperty("id");
+      expect(key.id).toBe(1);
+      expect(key).toHaveProperty("name");
+      expect(key).toHaveProperty("ipns_name");
+      expect(key).toHaveProperty("peer_id");
+      expect(key).toHaveProperty("created");
+    });
+
+    it("should throw NotFoundError for non-existent key", async ({ worker }) => {
+      worker.use(ipnsNotFoundHandler);
+      const client = new IpnsClient(mockConfig);
+
+      await expect(client.getKey(999)).rejects.toThrow(NotFoundError);
     });
   });
 
@@ -121,11 +145,9 @@ describe("IpnsClient", () => {
       const client = new IpnsClient(mockConfig);
 
       const request: IPNSKeyRequest = {
-        name: "", // Invalid: empty name
+        name: "",
       };
 
-      // Note: The MSW handler doesn't validate, so this will succeed
-      // In real scenario, this would throw ValidationError
       const key = await client.createKey(request);
       expect(key).toBeDefined();
     });
@@ -144,8 +166,6 @@ describe("IpnsClient", () => {
       await expect(client.createKey(request)).rejects.toThrow(AuthenticationError);
     });
   });
-
-  // getKey method not implemented in current API
 
   describe("deleteKey", () => {
     it("should delete an IPNS key", async ({ worker }) => {
@@ -312,8 +332,8 @@ describe("IpnsClient", () => {
       const client = new IpnsClient(mockConfig);
 
       // Test normal operation
-      const keys = await client.listKeys();
-      expect(keys).toBeDefined();
+      const result = await client.listKeys();
+      expect(result).toBeDefined();
     });
 
     it("should handle malformed responses", async ({ worker }) => {
@@ -321,8 +341,8 @@ describe("IpnsClient", () => {
       const client = new IpnsClient(mockConfig);
 
       // Test normal operation
-      const keys = await client.listKeys();
-      expect(keys).toBeDefined();
+      const result = await client.listKeys();
+      expect(result).toBeDefined();
     });
   });
 });

--- a/libs/pinner/src/api/__tests__/websites.spec.ts
+++ b/libs/pinner/src/api/__tests__/websites.spec.ts
@@ -1,11 +1,13 @@
 import { test as it } from "../../__tests__/int-test";
 import { describe, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
 import { WebsitesClient } from "../websites";
 import { SSLStatus } from "../websites";
 import type { PinnerConfig } from "@/config";
 import type {
   WebsiteRequest,
   WebsiteResponse,
+  WebsiteUpdateRequest,
   WebsiteValidateResponse,
 } from "../generated/schemas/index";
 import {
@@ -28,6 +30,7 @@ import {
   setSSLStatus,
   resetSSLStatuses,
 } from "@/__tests__/msw-websites-ipns-handlers";
+import { testConfig } from "@/__tests__/setup";
 
 describe("WebsitesClient", () => {
   const mockConfig: PinnerConfig = {
@@ -191,7 +194,7 @@ describe("WebsitesClient", () => {
       worker.use(...websitesHandlers);
       const client = new WebsitesClient(mockConfig);
 
-      const request: WebsiteRequest = {
+      const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
         target_type: "ipfs",
         target_hash: "QmUpdatedCID123",
@@ -205,11 +208,25 @@ describe("WebsitesClient", () => {
       expect(website.target_hash).toBe("QmUpdatedCID123");
     });
 
+    it("should update partial fields on a website", async ({ worker }) => {
+      worker.use(...websitesHandlers);
+      const client = new WebsitesClient(mockConfig);
+
+      const request: WebsiteUpdateRequest = {
+        target_hash: "QmUpdatedOnlyCID",
+      };
+
+      const website: WebsiteResponse = await client.updateWebsite(1, request);
+
+      expect(website).toHaveProperty("id");
+      expect(website.target_hash).toBe("QmUpdatedOnlyCID");
+    });
+
     it("should throw NotFoundError for non-existent website", async ({ worker }) => {
       worker.use(websiteNotFoundHandler);
       const client = new WebsitesClient(mockConfig);
 
-      const request: WebsiteRequest = {
+      const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
         target_type: "ipfs",
         target_hash: "QmTestCID",
@@ -225,7 +242,7 @@ describe("WebsitesClient", () => {
         endpoint: "https://test.pinner.xyz",
       });
 
-      const request: WebsiteRequest = {
+      const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
         target_type: "ipfs",
         target_hash: "QmTestCID",
@@ -329,6 +346,37 @@ describe("WebsitesClient", () => {
       await expect(
         client.getSSLStatus("example.com", { signal: controller.signal }),
       ).rejects.toThrow();
+    });
+  });
+
+  describe("getWebsiteConfig", () => {
+    it("should get website hosting configuration", async ({ worker }) => {
+      worker.use(...websitesHandlers);
+      const client = new WebsitesClient(mockConfig);
+
+      const config = await client.getWebsiteConfig();
+
+      expect(config).toHaveProperty("gateway_domain");
+      expect(config).toHaveProperty("nameservers");
+      expect(config.gateway_domain).toBe("ipfs.pinner.xyz");
+      expect(config.nameservers).toHaveLength(2);
+    });
+
+    it("should handle authentication errors", async ({ worker }) => {
+      worker.use(
+        http.get(`${testConfig.apiUrl}/websites/config`, async () => {
+          return HttpResponse.json(
+            { error: "Unauthorized" },
+            { status: 401 },
+          );
+        }),
+      );
+      const client = new WebsitesClient({
+        jwt: "invalid-jwt",
+        endpoint: "https://test.pinner.xyz",
+      });
+
+      await expect(client.getWebsiteConfig()).rejects.toThrow(AuthenticationError);
     });
   });
 

--- a/libs/pinner/src/api/ipns.ts
+++ b/libs/pinner/src/api/ipns.ts
@@ -1,7 +1,7 @@
 import ky, { HTTPError } from "ky";
 import type { PinnerConfig } from "../config";
 import type {
-  ErrorResponse,
+  IPNSKeyListResponseResponse,
   IPNSKeyRequest,
   IPNSKeyResponse,
   IPNSPublishRequest,
@@ -44,15 +44,24 @@ export class IpnsClient {
 
     try {
       const response = await ky(path, {
-        prefixUrl: this.getEndpoint(),
+        prefix: this.getEndpoint(),
         headers: {
           Authorization: `Bearer ${this.config.jwt}`,
           "Content-Type": "application/json",
         },
         ...options,
-      }).json<T>();
+      });
 
-      return response;
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const text = await response.text();
+      if (!text) {
+        return undefined as T;
+      }
+
+      return JSON.parse(text) as T;
     } catch (error) {
       if (error instanceof HTTPError) {
         const status = error.response.status;
@@ -89,8 +98,14 @@ export class IpnsClient {
     }
   }
 
-  async listKeys(options?: IpnsClientOptions): Promise<IPNSKeyResponse[]> {
-    return this.request<IPNSKeyResponse[]>("api/ipns/keys", {
+  async listKeys(options?: IpnsClientOptions): Promise<IPNSKeyListResponseResponse> {
+    return this.request<IPNSKeyListResponseResponse>("api/ipns/keys", {
+      signal: options?.signal,
+    });
+  }
+
+  async getKey(id: number, options?: IpnsClientOptions): Promise<IPNSKeyResponse> {
+    return this.request<IPNSKeyResponse>(`api/ipns/keys/${id}`, {
       signal: options?.signal,
     });
   }

--- a/libs/pinner/src/api/swagger.yaml
+++ b/libs/pinner/src/api/swagger.yaml
@@ -13,11 +13,56 @@ components:
           type: string
         type:
           type: integer
+        unixfs_size:
+          type: integer
       required:
       - name
       - type
       - block_size
+      - unixfs_size
       - child_cid
+      type: object
+    BulkDeleteRequest:
+      additionalProperties: false
+      properties:
+        dry_run:
+          type: boolean
+        records:
+          items:
+            $ref: '#/components/schemas/RecordIdentifier'
+          type: array
+      required:
+      - records
+      type: object
+    BulkDeleteResponse:
+      additionalProperties: false
+      properties:
+        results:
+          items:
+            $ref: '#/components/schemas/RecordResult'
+          type: array
+      required:
+      - results
+      type: object
+    BulkRecordRequest:
+      additionalProperties: false
+      properties:
+        records:
+          items:
+            $ref: '#/components/schemas/RecordRequest'
+          type: array
+      required:
+      - records
+      type: object
+    BulkRecordsResponse:
+      additionalProperties: false
+      properties:
+        records:
+          items:
+            $ref: '#/components/schemas/RecordResponse'
+          type: array
+      required:
+      - records
       type: object
     Component:
       additionalProperties: false
@@ -71,7 +116,9 @@ components:
       additionalProperties: false
       properties:
         data:
-          $ref: '#/components/schemas/FileManagerItem'
+          items:
+            $ref: '#/components/schemas/FileManagerItem'
+          type: array
         total:
           type: integer
       required:
@@ -120,6 +167,40 @@ components:
           type: array
       required:
       - cid
+      type: object
+    IPNSKeyListResponse:
+      additionalProperties: false
+      properties:
+        created:
+          format: date-time
+          type: string
+        id:
+          type: integer
+        ipns_name:
+          type: string
+        name:
+          type: string
+        peer_id:
+          type: string
+      required:
+      - id
+      - name
+      - ipns_name
+      - peer_id
+      - created
+      type: object
+    IPNSKeyListResponseResponse:
+      additionalProperties: false
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/IPNSKeyListResponse'
+          type: array
+        total:
+          type: integer
+      required:
+      - data
+      - total
       type: object
     IPNSKeyRequest:
       additionalProperties: false
@@ -291,6 +372,87 @@ components:
       - pin
       - delegates
       type: object
+    RecordIdentifier:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+      required:
+      - name
+      - type
+      type: object
+    RecordRequest:
+      additionalProperties: false
+      properties:
+        content:
+          type: string
+        disabled:
+          type: boolean
+        name:
+          type: string
+        ttl:
+          type: integer
+        type:
+          type: string
+      required:
+      - name
+      - type
+      - content
+      type: object
+    RecordResponse:
+      additionalProperties: false
+      properties:
+        content:
+          type: string
+        disabled:
+          type: boolean
+        name:
+          type: string
+        ttl:
+          type: integer
+        type:
+          type: string
+        zone_id:
+          type: integer
+      required:
+      - zone_id
+      - name
+      - type
+      - content
+      - ttl
+      - disabled
+      type: object
+    RecordResponseResponse:
+      additionalProperties: false
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/RecordResponse'
+          type: array
+        total:
+          type: integer
+      required:
+      - data
+      - total
+      type: object
+    RecordResult:
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+        type:
+          type: string
+      required:
+      - name
+      - type
+      - status
+      type: object
     SSLStatusInfo:
       additionalProperties: false
       properties:
@@ -319,16 +481,51 @@ components:
       required:
       - status
       type: object
+    ValidationResponse:
+      additionalProperties: false
+      properties:
+        checked_at:
+          format: date-time
+          type: string
+        message:
+          type: string
+        nameservers:
+          items:
+            type: string
+          type: array
+        valid:
+          type: boolean
+      required:
+      - valid
+      - message
+      - checked_at
+      type: object
+    WebsiteConfigResponse:
+      additionalProperties: false
+      properties:
+        gateway_domain:
+          type: string
+        nameservers:
+          items:
+            type: string
+          type: array
+      type: object
     WebsiteItem:
       additionalProperties: false
       properties:
         created:
           format: date-time
           type: string
+        dns_hosting_enabled:
+          type: boolean
+        dns_zone_id:
+          type: integer
         domain:
           type: string
         expired:
           type: boolean
+        gateway_domain:
+          type: string
         id:
           type: integer
         last_checked_at:
@@ -357,6 +554,7 @@ components:
       - target_hash
       - status
       - validation_token
+      - dns_hosting_enabled
       - created
       - updated
       - expired
@@ -365,7 +563,9 @@ components:
       additionalProperties: false
       properties:
         data:
-          $ref: '#/components/schemas/WebsiteItem'
+          items:
+            $ref: '#/components/schemas/WebsiteItem'
+          type: array
         total:
           type: integer
       required:
@@ -375,6 +575,8 @@ components:
     WebsiteRequest:
       additionalProperties: false
       properties:
+        dns_hosting_enabled:
+          type: boolean
         domain:
           type: string
         target_hash:
@@ -392,10 +594,16 @@ components:
         created:
           format: date-time
           type: string
+        dns_hosting_enabled:
+          type: boolean
+        dns_zone_id:
+          type: integer
         domain:
           type: string
         expired:
           type: boolean
+        gateway_domain:
+          type: string
         id:
           type: integer
         last_checked_at:
@@ -424,9 +632,22 @@ components:
       - target_hash
       - status
       - validation_token
+      - dns_hosting_enabled
       - created
       - updated
       - expired
+      type: object
+    WebsiteUpdateRequest:
+      additionalProperties: false
+      properties:
+        dns_hosting_enabled:
+          type: boolean
+        domain:
+          type: string
+        target_hash:
+          type: string
+        target_type:
+          type: string
       type: object
     WebsiteValidateResponse:
       additionalProperties: false
@@ -445,45 +666,132 @@ components:
       - valid
       - message
       type: object
+    ZoneListResponse:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
+          type: string
+        domain:
+          type: string
+        id:
+          type: integer
+        powerdns_zone_id:
+          type: string
+        status:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        user_id:
+          type: integer
+      required:
+      - id
+      - user_id
+      - domain
+      - status
+      - created_at
+      - updated_at
+      type: object
+    ZoneListResponseResponse:
+      additionalProperties: false
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/ZoneListResponse'
+          type: array
+        total:
+          type: integer
+      required:
+      - data
+      - total
+      type: object
+    ZoneRequest:
+      additionalProperties: false
+      properties:
+        domain:
+          type: string
+        nameservers:
+          items:
+            type: string
+          type: array
+      required:
+      - domain
+      type: object
+    ZoneResponse:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
+          type: string
+        domain:
+          type: string
+        id:
+          type: integer
+        powerdns_zone_id:
+          type: string
+        status:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+        user_id:
+          type: integer
+      required:
+      - id
+      - user_id
+      - domain
+      - status
+      - created_at
+      - updated_at
+      type: object
 info:
   description: |2
 
-    ## About this spec
+    ## Portal IPFS Plugin API
 
-    The IPFS Pinning Service API is intended to be an implementation-agnostic API:
+    A comprehensive API for IPFS content management, including pinning services, file operations, IPNS key management, and website hosting.
 
-    - For use and implementation by pinning service providers
+    ### IPFS Pinning Service API Compatibility
 
-    - For use in client mode by IPFS nodes and GUI-based applications
+    This API is fully compatible with the [IPFS Pinning Service API specification](https://github.com/ipfs/pinning-services-api-spec), an implementation-agnostic API standard for pinning service providers. This ensures interoperability with existing IPFS pinning clients and tools.
 
+    ### Features
 
-    ### Document scope and intended audience
+    - **Pinning**: Add, list, update, and remove pinned content
+    - **Content**: Upload files, retrieve IPFS content, and manage metadata
+    - **IPNS**: Manage IPNS keys and publish content
+    - **Files**: Browse and manage pinned files with directory navigation
+    - **Websites**: Create and manage website hosting with DNS and SSL automation
 
-    The intended audience of this document is **IPFS developers** building pinning service clients or servers compatible with this OpenAPI spec.
-    Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).
+    ### Authentication
 
+    All API endpoints require authentication using JWT tokens obtained from the Portal authentication service.
 
-    **IPFS users** should see the tutorial at [docs.ipfs.io/how-to/work-with-pinning-services/](https://docs.ipfs.io/how-to/work-with-pinning-services/) instead.
+    ### Rate Limiting
 
+    API requests are rate-limited based on user account tier. See Portal documentation for current limits.
 
-    ### Related resources
+    ### Documentation
 
-    The latest version of this spec and additional resources can be found at:
-
-    - Specification: https://github.com/ipfs/pinning-services-api-spec/raw/main/ipfs-pinning-service.yaml
-
-    - Docs: https://ipfs.github.io/pinning-services-api-spec/
-
-    - Clients and services: https://github.com/ipfs/pinning-services-api-spec#adoption
-  title: IPFS Pinning Service API
-  version: v0.1.6-0.20260226005938-954a7aa30d86
+    For detailed API usage examples and integration guides, visit the Portal documentation website.
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  title: Portal IPFS Plugin API
+  version: 1.0.0
 openapi: 3.0.0
 paths:
   /api/block/meta/{cid}:
     get:
-      description: Gets metadata for a block.
+      description: |-
+        Retrieves metadata for a specific IPFS block.
+
+        Returns block size, type, and child CIDs for the specified content identifier. Useful for inspecting IPFS data structures.
+
+        See also:.*
       parameters:
-      - description: The CID of the block.
+      - description: 'Content identifier (CID) of the IPFS block. Example: bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4'
         in: path
         name: cid
         required: true
@@ -526,12 +834,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Get block metadata
+      summary: Get block details
       tags:
-      - ipfs
+      - Content
   /api/block/meta/batch:
     post:
-      description: Gets metadata for multiple blocks in a single request.
+      description: |-
+        Retrieves metadata for multiple IPFS blocks efficiently.
+
+        Batch endpoint for getting block information for multiple CIDs in a single request, reducing API calls.
+
+        See also:.*
       requestBody:
         content:
           application/json:
@@ -576,12 +889,875 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Get block metadata in batch
+      summary: Get multiple block details
       tags:
-      - ipfs
+      - Content
+  /api/dns/zones:
+    get:
+      description: |-
+        Lists all DNS zones owned by the current user.
+
+        Returns paginated list of zones with filtering support.
+
+        See also:.*
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneListResponseResponse'
+          description: List of zones
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: List DNS zones
+      tags:
+      - DNS
+      - Zones
+    post:
+      description: |-
+        Creates a new DNS zone for a domain.
+
+        Creates a zone for managing DNS records. The domain must be valid and not already exist.
+
+        See also:.*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZoneRequest'
+        description: Zone request
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneResponse'
+          description: Zone created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Create DNS zone
+      tags:
+      - DNS
+      - Zones
+  /api/dns/zones/{id}:
+    delete:
+      description: |-
+        Deletes a DNS zone and all its records.
+
+        Performs a soft delete, marking the zone as deleted without removing it from the database.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "204":
+          description: Zone deleted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Delete DNS zone
+      tags:
+      - DNS
+      - Zones
+    get:
+      description: |-
+        Gets detailed information about a DNS zone.
+
+        Returns full zone configuration including domain and status.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneResponse'
+          description: Zone details
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get DNS zone
+      tags:
+      - DNS
+      - Zones
+    put:
+      description: |-
+        Updates a DNS zone configuration.
+
+        Only certain fields can be updated after creation.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ZoneRequest'
+        description: Zone request
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneResponse'
+          description: Zone updated
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Update DNS zone
+      tags:
+      - DNS
+      - Zones
+  /api/dns/zones/{id}/records:
+    get:
+      description: |-
+        Lists all DNS records for a zone.
+
+        Returns paginated list of records with filtering support.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordResponseResponse'
+          description: List of records
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: List DNS records
+      tags:
+      - DNS
+      - Records
+    post:
+      description: |-
+        Creates a new DNS record in a zone.
+
+        Creates a record with the specified name, type, and content.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordRequest'
+        description: Record request
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordResponse'
+          description: Record created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Create DNS record
+      tags:
+      - DNS
+      - Records
+  /api/dns/zones/{id}/records/{name}/{type}:
+    delete:
+      description: |-
+        Deletes a DNS record from a zone.
+
+        Removes the specified record from the zone.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Record name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: Record type (A, AAAA, CNAME, TXT, etc.)
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "204":
+          description: Record deleted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Delete DNS record
+      tags:
+      - DNS
+      - Records
+    get:
+      description: |-
+        Gets a specific DNS record by name and type.
+
+        Returns record details including content and TTL.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Record name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: Record type (A, AAAA, CNAME, TXT, etc.)
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordResponse'
+          description: Record details
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get DNS record
+      tags:
+      - DNS
+      - Records
+    put:
+      description: |-
+        Updates an existing DNS record.
+
+        Updates the content and TTL of a record.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Record name
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - description: Record type (A, AAAA, CNAME, TXT, etc.)
+        in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordRequest'
+        description: Record request
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordResponse'
+          description: Record updated
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Update DNS record
+      tags:
+      - DNS
+      - Records
+  /api/dns/zones/{id}/records/bulk:
+    post:
+      description: |-
+        Creates multiple DNS records in a zone.
+
+        Creates all records in the request. Errors are reported for individual records that fail.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkRecordRequest'
+        description: Bulk record request
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkRecordsResponse'
+          description: Bulk operation result
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Bulk create DNS records
+      tags:
+      - DNS
+      - Records
+  /api/dns/zones/{id}/records/bulk-delete:
+    post:
+      description: |-
+        Deletes multiple DNS records from a zone.
+
+        Deletes all records in the request. Can be run in dry-run mode to preview changes.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkDeleteRequest'
+        description: Bulk delete request
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkDeleteResponse'
+          description: Bulk delete result
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Bulk delete DNS records
+      tags:
+      - DNS
+      - Records
+  /api/dns/zones/{id}/status:
+    get:
+      description: |-
+        Gets the current status of a DNS zone.
+
+        Returns zone status and configuration details.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneResponse'
+          description: Zone status
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get DNS zone status
+      tags:
+      - DNS
+      - Zones
+  /api/dns/zones/{id}/validate:
+    post:
+      description: |-
+        Validates nameservers for a DNS zone.
+
+        Checks if the nameservers are properly configured for the zone.
+
+        See also:.*
+      parameters:
+      - description: Zone ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResponse'
+          description: Validation result
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Validate DNS zone
+      tags:
+      - DNS
+      - Zones
   /api/files:
     get:
-      description: List all pinned files with their metadata
+      description: |-
+        Browses all pinned files and directories.
+
+        Returns a paginated list of files and folders in the root of your pinned content. Each item includes metadata like size, type, and creation date.
+
+        See also:.*
       responses:
         "200":
           content:
@@ -619,12 +1795,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: List pinned files
+      summary: Browse pinned files
       tags:
-      - file-manager
+      - Files
   /api/files/breadcrumbs:
     get:
-      description: Retrieve breadcrumb navigation elements for a given file path
+      description: |-
+        Gets navigation breadcrumbs for a file path.
+
+        Returns an array of parent directories from root to the specified path, enabling breadcrumb navigation in file browsers.
+
+        See also:.*
       responses:
         "200":
           content:
@@ -662,13 +1843,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Get path breadcrumbs
+      summary: Get navigation breadcrumbs
       tags:
-      - file-manager
+      - Files
   /api/files/directory:
     get:
-      description: List files and subdirectories within a specified parent directory
-        path
+      description: |-
+        Lists contents of a specific directory.
+
+        Returns files and subdirectories within the specified path. Use for navigating through your pinned content hierarchy.
+
+        See also:.*
       responses:
         "200":
           content:
@@ -706,12 +1891,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: List directory contents
+      summary: List directory
       tags:
-      - file-manager
+      - Files
   /api/info:
     get:
-      description: Gets information about the IPFS node.
+      description: |-
+        Retrieves information about the IPFS node.
+
+        Returns node identity (peer ID) and network connection addresses. Useful for diagnostics and verifying node connectivity.
+
+        See also:.*
       responses:
         "200":
           content:
@@ -749,20 +1939,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Get IPFS node info
+      summary: Get node information
       tags:
-      - ipfs
+      - Content
   /api/ipns/keys:
     get:
-      description: Lists all IPNS keys for the current user.
+      description: |-
+        Lists all IPNS keys owned by the current user.
+
+        Returns metadata for all IPNS keys including peer IDs, names, and creation dates. Useful for managing your IPNS publishing keys.
+
+        See also:.*
       responses:
         "200":
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/IPNSKeyResponse'
-                type: array
+                $ref: '#/components/schemas/IPNSKeyListResponseResponse'
           description: List of IPNS keys
         "400":
           content:
@@ -796,10 +1989,14 @@ paths:
           description: Internal server error
       summary: List IPNS keys
       tags:
-      - ipns
+      - IPNS
     post:
-      description: Creates a new IPNS key or imports an existing one. If 'key' is
-        provided, it imports; otherwise creates a new key.
+      description: |-
+        Creates or imports an IPNS key for content publishing.
+
+        Generates a new IPNS key or imports an existing private key. IPNS keys allow publishing and updating mutable addresses that point to IPFS content.
+
+        See also:.*
       requestBody:
         content:
           application/json:
@@ -850,15 +2047,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Create or import IPNS key
+      summary: Create IPNS key
       tags:
-      - ipns
+      - IPNS
   /api/ipns/keys/{id}:
     delete:
-      description: Deletes an IPNS key (soft delete). Cannot delete keys referenced
-        by active websites.
+      description: |-
+        Deletes an IPNS key (soft delete).
+
+        Removes the IPNS key from your account. Keys referenced by active websites cannot be deleted. This is a soft delete that preserves records.
+
+        See also:.*
       parameters:
-      - description: IPNS key ID
+      - description: 'Numeric ID of the IPNS key. Example: 123'
         in: path
         name: id
         required: true
@@ -905,11 +2106,16 @@ paths:
           description: Internal server error
       summary: Delete IPNS key
       tags:
-      - ipns
+      - IPNS
     get:
-      description: Retrieves details of a specific IPNS key.
+      description: |-
+        Gets detailed information about an IPNS key.
+
+        Returns full key metadata including peer ID, name, and creation timestamp. Use to inspect key properties before publishing.
+
+        See also:.*
       parameters:
-      - description: IPNS key ID
+      - description: 'Numeric ID of the IPNS key. Example: 123'
         in: path
         name: id
         required: true
@@ -952,12 +2158,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Get IPNS key details
+      summary: Get IPNS key
       tags:
-      - ipns
+      - IPNS
   /api/ipns/publish:
     post:
-      description: Publishes a CID to an IPNS key.
+      description: |-
+        Publishes content to an IPNS key.
+
+        Updates an IPNS key to point to a new CID. Allows updating mutable addresses without changing the URL. Supports setting TTL for record validity.
+
+        See also:.*
       requestBody:
         content:
           application/json:
@@ -1002,12 +2213,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Publish CID to IPNS
+      summary: Publish to IPNS
       tags:
-      - ipns
+      - IPNS
   /api/ipns/republish:
     post:
-      description: Manually triggers IPNS record republishing for all keys.
+      description: |-
+        Triggers IPNS record republishing for all keys.
+
+        Forces all IPNS records to be republished to the network. Useful for ensuring content remains available and records are refreshed.
+
+        See also:.*
       responses:
         "200":
           content:
@@ -1049,15 +2265,26 @@ paths:
           description: Internal server error
       summary: Trigger IPNS republish
       tags:
-      - ipns
+      - IPNS
   /api/ipns/resolve/{name}:
     get:
-      description: Resolves an IPNS name to its current CID.
+      description: |-
+        Resolves an IPNS name to its current target CID.
+
+        Looks up the current CID that an IPNS name points to. Returns the resolved CID, validity information, and sequence number.
+
+        See also:.*
       parameters:
-      - description: IPNS name (peer ID)
+      - description: 'IPNS name (peer ID). Example: 12D3KooW...'
         in: path
         name: name
         required: true
+        schema:
+          type: string
+      - description: 'Whether to verify routing through the IPFS network. 1 = verify
+          (queries DHT), 0 = local only. Default: 0'
+        in: query
+        name: check_routing
         schema:
           type: string
       responses:
@@ -1097,319 +2324,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Resolve IPNS name
+      summary: Resolve IPNS
       tags:
-      - ipns
-  /api/pins:
-    get:
-      description: List all the pin objects, matching optional filters; when no filter
-        is provided, only successful pins are returned
-      parameters:
-      - description: Return results created (queued) after provided timestamp
-        in: query
-        name: after
-        schema:
-          type: string
-      - description: Return results created (queued) before provided timestamp
-        in: query
-        name: before
-        schema:
-          type: string
-      - description: Return pin objects responsible for pinning the specified CID(s)
-        in: query
-        name: cid
-        schema:
-          items:
-            type: string
-          type: array
-      - description: Max records to return
-        in: query
-        name: limit
-        schema:
-          type: integer
-      - description: Customize the text matching strategy
-        in: query
-        name: match
-        schema:
-          type: string
-      - description: Return pin objects that match specified metadata
-        in: query
-        name: meta
-        schema:
-          type: string
-      - description: Return pin objects with specified name
-        in: query
-        name: name
-        schema:
-          type: string
-      - description: Return pin objects for pins with the specified status
-        in: query
-        name: status
-        schema:
-          items:
-            type: string
-          type: array
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PinResultsResponse'
-          description: Successful response
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
-      summary: List pin objects
-      tags:
-      - pins
-    post:
-      description: Add a new pin object for the current access token
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PinRequest'
-        description: Pin object
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Success
-        "202":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PinStatusResponse'
-          description: Successful response
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
-      summary: Add pin object
-      tags:
-      - pins
-  /api/pins/{requestid}:
-    delete:
-      description: Remove a pin object
-      parameters:
-      - description: Unique identifier of a pin request
-        in: path
-        name: requestid
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Success
-        "202":
-          description: Successful response
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
-      summary: Remove pin object
-      tags:
-      - pins
-    get:
-      description: Get a pin object and its status
-      parameters:
-      - description: Unique identifier of a pin request
-        in: path
-        name: requestid
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PinStatusResponse'
-          description: Successful response
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
-      summary: Get pin object
-      tags:
-      - pins
-    post:
-      description: Replace an existing pin object
-      parameters:
-      - description: Unique identifier of a pin request
-        in: path
-        name: requestid
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PinRequest'
-        description: Pin object
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Success
-        "202":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PinStatusResponse'
-          description: Successful response
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
-      summary: Replace pin object
-      tags:
-      - pins
+      - IPNS
   /api/upload:
     post:
-      description: Uploads a file to IPFS.
+      description: |-
+        Uploads a file to IPFS and returns the content CID.
+
+        Supports single file uploads with automatic content verification. The uploaded file is added to IPFS and pinned for persistence.
+
+        See also:.*
       requestBody:
         content:
           multipart/form-data:
@@ -1457,9 +2382,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Upload a file
+      summary: Upload file to IPFS
       tags:
-      - ipfs
+      - Content
   /api/upload/tus:
     options:
       description: Retrieves information about the TUS server's supported versions,
@@ -1848,7 +2773,8 @@ paths:
       tags:
       - TUS
     options:
-      description: TUS protocol OPTIONS handler for /api/upload/tus/:id
+      description: Retrieves information about the TUS server's supported versions,
+        extensions, and limits.
       parameters:
       - description: The ID of the upload resource.
         in: path
@@ -1935,7 +2861,7 @@ paths:
               schema:
                 type: string
           description: Forbidden
-      summary: TUS OPTIONS /api/upload/tus/:id
+      summary: Get TUS Upload Capabilities
       tags:
       - TUS
     patch:
@@ -2088,7 +3014,12 @@ paths:
       - TUS
   /api/websites:
     get:
-      description: Lists all websites for the current user with optional filtering.
+      description: |-
+        Lists all websites owned by the current user.
+
+        Returns paginated list of website configurations with status, domain, and target information. Supports filtering by status and other criteria.
+
+        See also:.*
       responses:
         "200":
           content:
@@ -2128,10 +3059,16 @@ paths:
           description: Internal server error
       summary: List websites
       tags:
-      - websites
+      - Websites
     post:
-      description: Creates a new website configuration. Returns 410 Gone if target
-        is broken.
+      description: |-
+        Creates a new website configuration for IPFS content.
+
+        Sets up a website with a domain name pointing to IPFS content. Supports automatic DNS management and SSL certificate provisioning.
+
+        Prerequisites: Domain must be configured, target CID must exist
+
+        See also:.*
       requestBody:
         content:
           application/json:
@@ -2184,13 +3121,17 @@ paths:
           description: Internal server error
       summary: Create website
       tags:
-      - websites
+      - Websites
   /api/websites/{domain}/ssl-status:
     get:
-      description: Retrieves SSL certificate status for a website domain. Public endpoint
-        for developers.
+      description: |-
+        Gets SSL certificate status for a website.
+
+        Public endpoint for checking SSL certificate status. Returns the current state of SSL provisioning including issuance date, expiration, and any errors.
+
+        See also:.*
       parameters:
-      - description: The domain name of the website
+      - description: 'Domain name for the website. Example: example.com'
         in: path
         name: domain
         required: true
@@ -2208,7 +3149,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request - invalid domain
+          description: Invalid domain format or malformed request
         "401":
           content:
             application/json:
@@ -2226,19 +3167,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Website not found
+          description: Website not found or does not exist
         "500":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
+          description: Internal server error occurred
       summary: Get SSL status
       tags:
-      - websites
+      - Websites
   /api/websites/{id}:
     delete:
-      description: Deletes a website configuration (soft delete).
+      description: |-
+        Deletes a website configuration.
+
+        Performs a soft delete, marking the website as deleted without removing it from the database. Website remains accessible until garbage collection.
+
+        See also:.*
       parameters:
       - description: Website ID
         in: path
@@ -2287,10 +3233,14 @@ paths:
           description: Internal server error
       summary: Delete website
       tags:
-      - websites
+      - Websites
     get:
-      description: Retrieves details of a specific website. Returns 410 Gone if website
-        is broken.
+      description: |-
+        Gets detailed information about a website.
+
+        Returns full website configuration including domain, target CID, SSL status, and DNS settings. Returns 410 Gone if the target content is broken.
+
+        See also:.*
       parameters:
       - description: Website ID
         in: path
@@ -2337,9 +3287,14 @@ paths:
           description: Internal server error
       summary: Get website
       tags:
-      - websites
+      - Websites
     put:
-      description: Updates an existing website configuration.
+      description: |-
+        Updates an existing website configuration.
+
+        Modifies domain, target CID, DNS hosting, or other settings for a website. Only fields included in the request body will be updated; omitted fields remain unchanged. Changes take effect after validation and DNS propagation.
+
+        See also:.*
       parameters:
       - description: Website ID
         in: path
@@ -2351,8 +3306,8 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WebsiteRequest'
-        description: Website request
+              $ref: '#/components/schemas/WebsiteUpdateRequest'
+        description: Website update request
         required: true
       responses:
         "200":
@@ -2393,10 +3348,17 @@ paths:
           description: Internal server error
       summary: Update website
       tags:
-      - websites
+      - Websites
   /api/websites/{id}/validate:
     post:
-      description: Triggers DNS TXT record validation for a website domain.
+      description: |-
+        Triggers DNS TXT record validation for a website.
+
+        Initiates DNS validation to verify domain ownership. Required before SSL certificate issuance. Returns validation result and any errors.
+
+        Prerequisites: DNS TXT record must be configured
+
+        See also:.*
       parameters:
       - description: Website ID
         in: path
@@ -2443,13 +3405,65 @@ paths:
           description: Internal server error
       summary: Validate website DNS
       tags:
-      - websites
+      - Websites
+  /api/websites/config:
+    get:
+      description: |-
+        Returns website hosting configuration including the gateway domain.
+
+        Clients use this endpoint to discover the gateway domain they should point their custom domain's DNS records to when hosting a website. This is required when dns_hosting_enabled is false and the user manages their own DNS.
+
+        See also:.*
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebsiteConfigResponse'
+          description: Website configuration
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get website hosting configuration
+      tags:
+      - Websites
   /internal/websites/{domain}:
     get:
-      description: Retrieves website configuration for gateway to serve content. Requires
-        X-Gateway-Secret header.
+      description: |-
+        Gets website configuration for gateway content serving.
+
+        Internal endpoint used by the gateway to retrieve website configuration. Requires X-Gateway-Secret header for authentication.
+
+        See also:.*
       parameters:
-      - description: The domain name of the website
+      - description: 'Domain name for the website. Example: example.com'
         in: path
         name: domain
         required: true
@@ -2494,13 +3508,17 @@ paths:
           description: Internal server error
       summary: Get website configuration for gateway
       tags:
-      - internal
+      - Gateway
   /internal/websites/{domain}/ssl-status:
     post:
-      description: Webhook endpoint for Caddy plugin to update SSL certificate status.
-        Requires X-Gateway-Secret header for authentication.
+      description: |-
+        Webhook endpoint for Caddy plugin to update SSL status.
+
+        Internal webhook called by Caddy when SSL certificates are issued or updated. Requires X-Gateway-Secret header for authentication.
+
+        See also:.*
       parameters:
-      - description: The domain name of the website
+      - description: 'Domain name for the website. Example: example.com'
         in: path
         name: domain
         required: true
@@ -2525,13 +3543,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request - invalid domain or malformed request
+          description: Invalid domain format or malformed request body
         "401":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized - missing or invalid X-Gateway-Secret header
+          description: Missing or invalid X-Gateway-Secret header in request
         "403":
           content:
             application/json:
@@ -2543,29 +3561,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Website not found
+          description: Website domain not found
         "422":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Unprocessable entity - invalid status or timestamp format
+          description: Invalid status value or timestamp format in request
         "500":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
+          description: Internal server error occurred
       summary: Update SSL status
       tags:
       - internal
-      - webhooks
   /internal/websites/{domain}/status:
     get:
-      description: Retrieves website status information for gateway. Requires X-Gateway-Secret
-        header.
+      description: |-
+        Gets website status for gateway monitoring.
+
+        Internal endpoint used by the gateway to check website health and availability. Requires X-Gateway-Secret header for authentication.
+
+        See also:.*
       parameters:
-      - description: The domain name of the website
+      - description: 'Domain name for the website. Example: example.com'
         in: path
         name: domain
         required: true
@@ -2610,10 +3631,15 @@ paths:
           description: Internal server error
       summary: Get website status for gateway
       tags:
-      - internal
+      - Gateway
   /ipfs/{cid}:
     get:
-      description: Retrieves content from IPFS by CID.
+      description: |-
+        Retrieves IPFS content by CID.
+
+        Returns the raw content for the specified CID. Supports streaming for large files. Content is served directly from IPFS storage.
+
+        See also:.*
       parameters:
       - description: The CID of the content.
         in: path
@@ -2658,11 +3684,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Get IPFS content
+      summary: Retrieve IPFS content
       tags:
-      - ipfs
+      - Content
     head:
-      description: Checks if content exists on IPFS by CID.
+      description: |-
+        Checks if content exists on IPFS.
+
+        Performs a HEAD request to verify content availability without downloading the data. Returns 200 if content exists, 404 if not found.
+
+        See also:.*
       parameters:
       - description: The CID of the content.
         in: path
@@ -2707,13 +3738,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
-      summary: Check IPFS content existence
+      summary: Check content exists
       tags:
-      - ipfs
+      - Content
     options:
-      description: OPTIONS endpoint for IPFS content. CORS preflight requests are
-        handled by middleware; this handler serves as a fallback for non-preflight
-        OPTIONS requests.
+      description: |-
+        CORS preflight handler for IPFS content.
+
+        Handles OPTIONS requests for IPFS content endpoints. Most CORS preflight requests are handled by middleware, this serves as a fallback.
+
+        See also:.*
       parameters:
       - description: The CID of the content.
         in: path
@@ -2760,6 +3794,350 @@ paths:
           description: Internal server error
       summary: IPFS content OPTIONS
       tags:
-      - ipfs
+      - Content
+  /pins:
+    get:
+      description: |-
+        Lists all pinned content with optional filtering.
+
+        Returns paginated list of pin objects representing content pinned to IPFS. Supports filtering by CID, name, status, metadata, and time range. When no filters are provided, only successfully pinned items are shown.
+
+        Use this to:
+        - Audit pinned content
+        - Search for specific pins
+        - Monitor pinning status
+
+        See also: POST /pins (add pin), GET /pins/{id} (get pin details)
+      parameters:
+      - description: 'Filter for pins created after this ISO 8601 timestamp. Example:
+          2024-01-01T00:00:00Z'
+        in: query
+        name: after
+        schema:
+          type: string
+      - description: 'Filter for pins created before this ISO 8601 timestamp. Example:
+          2024-01-01T00:00:00Z'
+        in: query
+        name: before
+        schema:
+          type: string
+      - description: 'Filter by content identifier. Supports multiple CIDs for batch
+          queries. Example: QmHash1, QmHash2'
+        in: query
+        name: cid
+        schema:
+          items:
+            type: string
+          type: array
+      - description: 'Maximum number of records to return. Default: 10, Max: 100'
+        in: query
+        name: limit
+        schema:
+          type: integer
+      - description: 'Text matching strategy: ''exact'' for exact match, ''iexact''
+          for case-insensitive exact match, ''contains'' for partial match'
+        in: query
+        name: match
+        schema:
+          type: string
+      - description: 'Filter by metadata key-value pairs. Format: JSON string. Example:
+          {"type":"document"}'
+        in: query
+        name: meta
+        schema:
+          type: string
+      - description: Filter by pin name. Supports partial matching for search functionality.
+        in: query
+        name: name
+        schema:
+          type: string
+      - description: 'Filter by pin status: ''queued'', ''pinning'', ''pinned'', ''failed'',
+          ''unpinned''. Example: pinned,failed'
+        in: query
+        name: status
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinResultsResponse'
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: List pinned content
+      tags:
+      - Pinning
+    post:
+      description: |-
+        Pins content to IPFS with optional metadata.
+
+        Creates a new pin object for the specified CID. Content will be pinned to the IPFS network and made available for retrieval. Supports adding names, origins, and custom metadata for organization.
+
+        Prerequisites: CID must be valid IPFS content identifier
+
+        See also: GET /pins (list pins), GET /pins/{id} (get pin details)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PinRequest'
+        description: Pin object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatusResponse'
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Pin content to IPFS
+      tags:
+      - Pinning
+  /pins/{requestid}:
+    delete:
+      description: |-
+        Removes a pin object, unpins content from the network.
+
+        Deletes the pin object and unpins the content from IPFS storage. Content may still be retrievable from other nodes that have cached it.
+
+        See also:.*
+      parameters:
+      - description: 'Unique identifier for the pin operation. Example: bafkreiexample'
+        in: path
+        name: requestid
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "202":
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Remove pinned content
+      tags:
+      - Pinning
+    get:
+      description: |-
+        Retrieves detailed information about a specific pin.
+
+        Returns the current status, metadata, and progress for a pin object. Use this to monitor pinning operations and verify content availability.
+
+        See also:.*
+      parameters:
+      - description: 'Unique identifier for the pin operation. Example: bafkreiexample'
+        in: path
+        name: requestid
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatusResponse'
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get pin details
+      tags:
+      - Pinning
+    post:
+      description: |-
+        Updates metadata and settings for an existing pin.
+
+        Modifies the name, origins, or metadata of a pinned item without changing the CID. Useful for reorganizing or updating pin information.
+
+        See also:.*
+      parameters:
+      - description: 'Unique identifier for the pin operation. Example: bafkreiexample'
+        in: path
+        name: requestid
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PinRequest'
+        description: Pin object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatusResponse'
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Replace pinned content
+      tags:
+      - Pinning
 servers:
-- url: /api
+- url: /

--- a/libs/pinner/src/api/websites.ts
+++ b/libs/pinner/src/api/websites.ts
@@ -2,12 +2,12 @@ import ky, { HTTPError } from "ky";
 import { createNanoEvents } from "nanoevents";
 import type { PinnerConfig } from "../config";
 import type {
-  ErrorResponse,
-  WebsiteItem,
   WebsiteItemResponse,
   WebsiteRequest,
   WebsiteResponse,
+  WebsiteUpdateRequest,
   WebsiteValidateResponse,
+  WebsiteConfigResponse,
   SSLStatusInfo,
 } from "./generated/schemas/index";
 
@@ -58,15 +58,24 @@ export class WebsitesClient {
 
     try {
       const response = await ky(path, {
-        prefixUrl: this.getEndpoint(),
+        prefix: this.getEndpoint(),
         headers: {
           Authorization: `Bearer ${this.config.jwt}`,
           "Content-Type": "application/json",
         },
         ...options,
-      }).json<T>();
+      });
 
-      return response;
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const text = await response.text();
+      if (!text) {
+        return undefined as T;
+      }
+
+      return JSON.parse(text) as T;
     } catch (error) {
       if (error instanceof HTTPError) {
         const status = error.response.status;
@@ -133,7 +142,7 @@ export class WebsitesClient {
 
   async updateWebsite(
     id: number,
-    request: WebsiteRequest,
+    request: WebsiteUpdateRequest,
     options?: WebsitesClientOptions,
   ): Promise<WebsiteResponse> {
     return this.request<WebsiteResponse>(`api/websites/${id}`, {
@@ -176,6 +185,14 @@ export class WebsitesClient {
         signal: options?.signal,
       },
     );
+  }
+
+  async getWebsiteConfig(
+    options?: WebsitesClientOptions,
+  ): Promise<WebsiteConfigResponse> {
+    return this.request<WebsiteConfigResponse>("api/websites/config", {
+      signal: options?.signal,
+    });
   }
 
   watchSSL(


### PR DESCRIPTION
- Update swagger.yaml from remote API spec
- IpnsClient: listKeys() returns paginated IPNSKeyListResponseResponse instead of bare IPNSKeyResponse[]; add getKey(id) for GET /api/ipns/keys/{id}
- WebsitesClient: add getWebsiteConfig() for GET /api/websites/config; updateWebsite() accepts WebsiteUpdateRequest (partial updates) instead of WebsiteRequest; WebsiteRequest now supports dns_hosting_enabled
- Fix ky v2 compatibility: prefixUrl->prefix, handle empty 204/202 bodies
- Update MSW handlers for paginated listKeys, dns_hosting_enabled field, partial update support, and website config endpoint

---

<!-- kody-pr-summary:start -->
Sync IpnsClient and WebsitesClient with the server swagger specification. Key changes include:

- **IPNS Keys listing now returns a paginated response** (`{ data, total }`) instead of a plain array
- **Added `getKey(id)` method** to IpnsClient for retrieving a specific IPNS key by ID
- **Added `getWebsiteConfig()` method** to WebsitesClient for fetching website hosting configuration (gateway domain and nameservers)
- **Added `dns_hosting_enabled` field** to website creation and update operations
- **Website updates now support partial updates** via a new `WebsiteUpdateRequest` type with all optional fields, replacing the full `WebsiteRequest` type
- **Fixed HTTP client configuration** (`prefixUrl` → `prefix`) and improved response handling to properly support 204 No Content responses
<!-- kody-pr-summary:end -->