### PR TITLE
chore: changesets

### DIFF
--- a/.changeset/all-tables-switch.md
+++ b/.changeset/all-tables-switch.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/portal-plugin-template: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- remove unused cjsDir param and remove stale require exports from package.jsons
+- add a portal plugin template as an example and scaffolding reference
+- formatting
+- correct format check in tsdown.config.ts to use "esm" instead of "es"

--- a/.changeset/beige-showers-stop.md
+++ b/.changeset/beige-showers-stop.md
@@ -1,0 +1,9 @@
+---
+@lumeweb/uppy-post-upload: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- add new isomorphic Uppy upload plugin

--- a/.changeset/clever-lights-hide.md
+++ b/.changeset/clever-lights-hide.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/libs5-crypto: minor
+---
+
+## Features
+
+- add libs5-crypto package

--- a/.changeset/cold-ghosts-double.md
+++ b/.changeset/cold-ghosts-double.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-analytics: minor
+---
+
+## Features
+
+- add user identification hook
+- add analytics

--- a/.changeset/cold-hornets-wink.md
+++ b/.changeset/cold-hornets-wink.md
@@ -1,0 +1,16 @@
+---
+@lumeweb/portal-plugin-ipfs: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- add missing @lumeweb/analytics and other shared federation deps to all vite-built packages
+- replace file with stream to enable large file uploads
+- formatting
+- fix api url
+- add missing button type attributes to breadcrumb components
+- fix file download handling with credentials support
+- handle directory download errors and improve file download logic
+- bind processor and cancelAll methods in constructor

--- a/.changeset/cute-humans-report.md
+++ b/.changeset/cute-humans-report.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/rego: minor
+---
+
+## Features
+
+- remove baseUrl from all tsconfigs
+- add React-to-Go Template DSL for email generation

--- a/.changeset/cyan-forks-flow.md
+++ b/.changeset/cyan-forks-flow.md
@@ -1,0 +1,14 @@
+---
+@lumeweb/portal-app-shell: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- add gateway-agnostic billing plugin
+- add missing @lumeweb/analytics and other shared federation deps to all vite-built packages
+- add analytics
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration
+- implement bootup and page loading screens with animations
+- formatting

--- a/.changeset/empty-clowns-train.md
+++ b/.changeset/empty-clowns-train.md
@@ -1,0 +1,14 @@
+---
+@lumeweb/portal-frontend: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- rename style prop to buttonStyle and fix component attributes
+- correct about page section styling
+- correct className syntax and remove no-op wrapper classes
+- add leading slash to brand logo image paths
+- extract contact data to JSON and use in contact page
+- remove baseUrl from all tsconfigs

--- a/.changeset/famous-bikes-bathe.md
+++ b/.changeset/famous-bikes-bathe.md
@@ -1,0 +1,10 @@
+---
+@lumeweb/portal-plugin-abuse-common: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- implement portal framework with module federation, Refine integration, and abuse management
+- fix block API URLs and reason value

--- a/.changeset/fast-monkeys-doubt.md
+++ b/.changeset/fast-monkeys-doubt.md
@@ -1,0 +1,27 @@
+---
+@lumeweb/portal-plugin-dashboard: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- add gateway-agnostic billing plugin
+- typo
+- remove baseUrl from all tsconfigs
+- remove unused cjsDir param and remove stale require exports from package.jsons
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- add pnpm overrides for module-federation typescript peer, add @lumeweb/analytics to dashboard deps
+- add missing @lumeweb/analytics and other shared federation deps to all vite-built packages
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration
+- implement remember me functionality and various UI enhancements
+- add auto-login option after email verification
+- implement bootup and page loading screens with animations
+- add visibility hook and simplify widget definition
+- replace file with stream to enable large file uploads
+- add folder upload detection and conditional UI based on service support
+- formatting
+- need to import routes for plugin registration
+- add missing auth capabilities
+- typo on OTPGenerateResponse
+- safely handle CID object format in operations UI, as future proofing

--- a/.changeset/fiery-friends-serve.md
+++ b/.changeset/fiery-friends-serve.md
@@ -1,0 +1,25 @@
+---
+@lumeweb/libs5-encoding: minor
+---
+
+## Features
+
+- new library libs5-encoding
+- add byte types
+- add multibase
+- add multihash
+- add ed25519
+- add endian encoding utils
+- add types starting with SignedRegistryEntry
+- add cid
+- add EncryptedCID
+- registry encoding
+- nodeId
+- export modules
+- update cid hash bytes import
+- use base64url not base64urlpad
+- don't replace u with U internally for base64url
+- ensure CID size is always set
+- add details const to metadata bytes, and start with media
+- add extensions const to metadata bytes
+- base64url test case should not have = padding

--- a/.changeset/forty-humans-buy.md
+++ b/.changeset/forty-humans-buy.md
@@ -1,0 +1,15 @@
+---
+@lumeweb/portal-admin: minor
+---
+
+## Features
+
+- Relocated shared code from portal-dashboard to new portal-shared library
+- Moved components, hooks, utilities, and types to libs/portal-shared/src
+- Updated import paths across portal-dashboard to use new shared library
+- Refactored app store into baseStore and dashboardStore
+- Removed duplicate files and consolidated shared logic
+- Updated tsconfig paths to include new shared library
+- add skeleton for portal admin app
+- add settings and cron pages, refactor shared components
+- formatting

--- a/.changeset/fuzzy-fans-join.md
+++ b/.changeset/fuzzy-fans-join.md
@@ -1,0 +1,52 @@
+---
+@lumeweb/portal-dashboard: minor
+---
+
+## Features
+
+- typo
+- Relocated shared code from portal-dashboard to new portal-shared library
+- Moved components, hooks, utilities, and types to libs/portal-shared/src
+- Updated import paths across portal-dashboard to use new shared library
+- Refactored app store into baseStore and dashboardStore
+- Removed duplicate files and consolidated shared logic
+- Updated tsconfig paths to include new shared library
+- implement t3-env
+- add theming support
+- adds NavigationMenu components to create 2-layer-deep nested navigation components
+- initial iteration of subscriptions
+- initial file manager support
+- implement social login functionality
+- implement 2FA flows and login
+- implement API keys support
+- implement account deletion functionality
+- implement usage tracking and display
+- add settings and cron pages, refactor shared components
+- update import
+- update import path
+- formatting
+- pnpm not fully installing and adding patches
+- use import.meta.env not process as this is client side
+- make VITE_PORTAL_URL optional
+- update Tailwind theme colors and resolve component conflicts
+- resolve color inconsistencies, typos and enhance user interface experience
+- Adjust component colors to align with theme
+- finalize mobile responsiveness and component updates
+- last color updates
+- theme for file upload and add horizontal scroll snap
+- conflicts and styles
+- issues with reavt
+- more issues with react
+- now auth checking should properly work
+- solves #113. Proper spacing on verification screen
+- done setting up theme switcher for images too. now images are also themeable
+- final styling for the table
+- trash icon
+- wrong imports
+- resolve upload management issues and improve error handling
+- add missing reset password route
+- only prefix https if portalUrl is set but not starting with a proto
+- bad parsing of FQDN in getApiBaseUrl, need to better handle subdomains
+- adjust condition for payment skeleton display
+- new layout for billing
+- using tabs for different parts of the billing

--- a/.changeset/happy-paths-jam.md
+++ b/.changeset/happy-paths-jam.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/lumeweb.com: minor
+---
+
+## Features
+
+- migrate to content-driven React architecture
+- add LLMs.txt, SEO integration, refactor navigation and fix issues
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- remove baseUrl from all tsconfigs
+- implement portal framework with module federation, Refine integration, and abuse management

--- a/.changeset/happy-times-give.md
+++ b/.changeset/happy-times-give.md
@@ -1,0 +1,7 @@
+---
+portal-storybook: minor
+---
+
+## Features
+
+- implement portal framework with module federation, Refine integration, and abuse management

--- a/.changeset/honest-eels-stay.md
+++ b/.changeset/honest-eels-stay.md
@@ -1,0 +1,14 @@
+---
+@lumeweb/portal-plugin-lbry: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- add missing @lumeweb/analytics and other shared federation deps to all vite-built packages
+- add core LBRY plugin structure with protocol, upload, and data provider capabilities
+- add streams page and route
+- add devices management page
+- add stream pinning/unpinning functionality
+- formatting

--- a/.changeset/late-poets-smell.md
+++ b/.changeset/late-poets-smell.md
@@ -1,0 +1,21 @@
+---
+portal-shared: minor
+---
+
+## Features
+
+- typo
+- Relocated shared code from portal-dashboard to new portal-shared library
+- Moved components, hooks, utilities, and types to libs/portal-shared/src
+- Updated import paths across portal-dashboard to use new shared library
+- Refactored app store into baseStore and dashboardStore
+- Removed duplicate files and consolidated shared logic
+- Updated tsconfig paths to include new shared library
+- add settings and cron pages, refactor shared components
+- implement portal framework with module federation, Refine integration, and abuse management
+- formatting
+- new layout for billing
+- using tabs for different parts of the billing
+- proper navigation highlight
+- need to use arrayMoveImmutable
+- typo on OTPGenerateResponse

--- a/.changeset/moody-animals-study.md
+++ b/.changeset/moody-animals-study.md
@@ -1,0 +1,16 @@
+---
+web3.news: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- add MVP community notice and link to the forums
+- add forum link to menu
+- implement portal framework with module federation, Refine integration, and abuse management
+- update remix vite plugin import
+- siteKey is now site
+- change slug to cid
+- update isbot import
+- set path of patch-package to monorepo root

--- a/.changeset/ninety-ends-camp.md
+++ b/.changeset/ninety-ends-camp.md
@@ -1,0 +1,10 @@
+---
+@lumeweb/query-builder: minor
+---
+
+## Features
+
+- remove baseUrl from all tsconfigs
+- add new query builder library for Refine integration
+- improve robustness and handle edge cases
+- update provider and tests for @refinedev/core v5 compatibility

--- a/.changeset/puny-eagles-make.md
+++ b/.changeset/puny-eagles-make.md
@@ -1,0 +1,26 @@
+---
+@lumeweb/portal-plugin-abuse: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- implement portal framework with module federation, Refine integration, and abuse management
+- update import
+- formatting
+- update imports
+- fix typo in subjects blocked endpoint
+- subjects blocked endpoint is inverted
+- subjects blocked endpoint missing abuse prefix
+- fix UserInfoCard data query access
+- correct case priority and status enum casing
+- use apiUrl for blocklist endpoints
+- update search field and case response field names
+- fix block API URLs and reason value
+- blocklist created at is snake case
+- replace ComplexBadge with ThemedBadge and update imports
+- use ThemedBadge not ComplexBadge
+- fix word break formatting on description

--- a/.changeset/quick-donkeys-sneeze.md
+++ b/.changeset/quick-donkeys-sneeze.md
@@ -1,0 +1,14 @@
+---
+@lumeweb/portal-plugin-abuse-report: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- bump @uppy/screen-capture and @uppy/webcam to resolve peer dep warnings
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- implement portal framework with module federation, Refine integration, and abuse management
+- formatting
+- update case status checks to use lowercase values
+- access view doesn't need to be nested in ReportLayout since we are using nested routes

--- a/.changeset/ready-crabs-joke.md
+++ b/.changeset/ready-crabs-joke.md
@@ -1,0 +1,10 @@
+---
+lume: minor
+---
+
+## Features
+
+- UI improvements and replace GSAP animation
+- convert SVG to HTML5
+- hero banner animation repeating issue fixed
+- resolve responsive issues and replace SVG logo, heart icon with PNG

--- a/.changeset/ripe-geckos-rule.md
+++ b/.changeset/ripe-geckos-rule.md
@@ -1,0 +1,19 @@
+---
+@lumeweb/portal-framework-ui-core: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- add cookie consent banner
+- remove baseUrl from all tsconfigs
+- suppress Sheet close button flicker on cookie banner
+- replace external with deps.neverBundle in all tsdown configs, remove dead CJS builds, add type:module to portal-generators
+- use format object for per-format ESM/CJS config output
+- add analytics
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration
+- implement bootup and page loading screens with animations
+- only allow space and enter to toggle the password visibility
+- add explicit type annotations to UI component primitives
+- correct VisuallyHidden component implementation

--- a/.changeset/seven-socks-stare.md
+++ b/.changeset/seven-socks-stare.md
@@ -1,0 +1,22 @@
+---
+@lumeweb/portal-framework-core: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- add DevTools support, react compiler, and module-federation catalog
+- remove patch dependencies and update lockfile
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration
+- Implement widget area layout using bin packing
+- implement bootup and page loading screens with animations
+- add visibility hook and simplify widget definition
+- formatting
+- don't compare to a string true
+- correct syntax errors in meta endpoint middleware
+- remove redundant paddingFactor declaration in WidgetArea
+- fix type import
+- refine data provider configuration and disable route change handler
+- bundle all CSS in module federation builds
+- configure tsconfig-paths to use project's tsconfig.json

--- a/.changeset/sharp-bars-play.md
+++ b/.changeset/sharp-bars-play.md
@@ -1,0 +1,13 @@
+---
+@lumeweb/advanced-rest-provider: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- migrate advanced-rest to ky v1 API (prefixUrl -> prefix)
+- remove CJS output and fix tsconfig paths
+- remove baseUrl from all tsconfigs
+- implement portal framework with module federation, Refine integration, and abuse management
+- update provider and tests for @refinedev/core v5 compatibility
+- use type-only import for UserConfig

--- a/.changeset/silly-hats-win.md
+++ b/.changeset/silly-hats-win.md
@@ -1,0 +1,13 @@
+---
+@lumeweb/tsdown-config: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- properly exclude all test files from build config
+- remove CJS output and fix tsconfig paths
+- remove unused cjsDir param and remove stale require exports from package.jsons
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- replace external with deps.neverBundle in own config, remove dead CJS build from portal-generators
+- exclude non-code files from build entry patterns

--- a/.changeset/silver-olives-see.md
+++ b/.changeset/silver-olives-see.md
@@ -1,0 +1,9 @@
+---
+@lumeweb/analytics: minor
+---
+
+## Features
+
+- add PostHog, consent store, and hooks
+- remove stale CJS require export from package.json
+- add analytics

--- a/.changeset/silver-shoes-fold.md
+++ b/.changeset/silver-shoes-fold.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/docs.pinner.xyz: minor
+---
+
+## Features
+
+- add docs.pinner.xyz documentation site
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- domain typo
+- remove baseUrl from all tsconfigs

--- a/.changeset/smart-regions-run.md
+++ b/.changeset/smart-regions-run.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-plugin-billing: minor
+---
+
+## Features
+
+- add gateway-agnostic billing plugin
+- AND-combine enabled guard in useCheckoutSessionStatus

--- a/.changeset/solid-banks-go.md
+++ b/.changeset/solid-banks-go.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/portal-plugin-core: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- add missing @lumeweb/analytics and other shared federation deps to all vite-built packages
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration
+- formatting

--- a/.changeset/spicy-queens-invent.md
+++ b/.changeset/spicy-queens-invent.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/portal-plugin-admin: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- migrate advanced-rest to ky v1 API (prefixUrl -> prefix)
+- remove baseUrl from all tsconfigs
+- add missing @lumeweb/analytics and other shared federation deps to all vite-built packages
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration

--- a/.changeset/stale-suns-tickle.md
+++ b/.changeset/stale-suns-tickle.md
@@ -1,0 +1,7 @@
+---
+portal-storybook-config: minor
+---
+
+## Features
+
+- implement portal framework with module federation, Refine integration, and abuse management

--- a/.changeset/strict-comics-fail.md
+++ b/.changeset/strict-comics-fail.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/s5-js: minor
+---
+
+## Features
+
+- implement portal framework with module federation, Refine integration, and abuse management
+- update beforeRedirect arg types
+- update task pipelines
+- orval needs to run twice due to quirks
+- lock file

--- a/.changeset/sweet-jeans-sort.md
+++ b/.changeset/sweet-jeans-sort.md
@@ -1,0 +1,16 @@
+---
+@lumeweb/libs5-metadata: minor
+---
+
+## Features
+
+- add bones of libs5-metadata library
+- add msgpack encode/decode libraries
+- add metadata utility class and interfaces
+- add web_app metadata
+- add maybeConvertObjectToIntMap
+- add to/fromJSON to extra
+- add to/fromJSON to WebApp
+- add fromJSON to WebAppFile
+- add media metadata support
+- update preprocess logic

--- a/.changeset/tall-baths-clap.md
+++ b/.changeset/tall-baths-clap.md
@@ -1,0 +1,17 @@
+---
+@lumeweb/pinner: minor
+---
+
+## Features
+
+- add Websites and IPNS API support
+- add SSL status monitoring for websites with watch functionality
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- sync IpnsClient and WebsitesClient with server swagger
+- update default endpoint and gateway URLs
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- implement core pinning and upload library
+- enhance SSRF protection with comprehensive IP validation
+- correct operation list response handling and csv formatter
+- make setDriverFactory actually work

--- a/.changeset/tangy-loops-kick.md
+++ b/.changeset/tangy-loops-kick.md
@@ -1,0 +1,9 @@
+---
+@lumeweb/portal-test-util: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- use vitest-browser-react, add to catalog, remove testing-library
+- implement portal framework with module federation, Refine integration, and abuse management

--- a/.changeset/thin-nights-tickle.md
+++ b/.changeset/thin-nights-tickle.md
@@ -1,0 +1,18 @@
+---
+@lumeweb/portal-framework-auth: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- remove baseUrl from all tsconfigs
+- replace external with deps.neverBundle in all tsdown configs, remove dead CJS builds, add type:module to portal-generators
+- implement portal framework with module federation, Refine integration, and abuse management
+- refactor portal app shell and core libraries for improved module federation and configuration
+- add form grouping functionality
+- implement remember me functionality and various UI enhancements
+- add autocomplete support to forms and fields
+- implement bootup and page loading screens with animations
+- formatting
+- typo on OTPGenerateResponse

--- a/.changeset/twelve-symbols-film.md
+++ b/.changeset/twelve-symbols-film.md
@@ -1,0 +1,33 @@
+---
+@lumeweb/portal-framework-ui: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- lazy-load Editor component with Suspense boundary
+- add gateway-agnostic billing plugin
+- typo
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- replace external with deps.neverBundle in all tsdown configs, remove dead CJS builds, add type:module to portal-generators
+- implement portal framework with module federation, Refine integration, and abuse management
+- add form grouping functionality
+- implement remember me functionality and various UI enhancements
+- add autocomplete support to forms and fields
+- implement bootup and page loading screens with animations
+- fix import
+- formatting
+- add return type
+- correct link handling in collapsible menu
+- adjust sidebar widths
+- correct invalid import in autocomplete rules
+- add explicit JSX.Element return type to Loading component
+- improve footer environment type guards and handle undefined form context
+- widen toolbar renderer types to accept ExtendedToolbarItem
+- prevent layout shift and memoize hidden columns Set
+- move mobile column hiding logic to top level and update toolbar renderer
+- expand coreSupported breakpoints to include all ComponentSize values
+- add return type to `useMobileDetection` hook
+- simplify RefineTable context and update property access
+- add default values to required label parameters

--- a/.changeset/two-onions-tell.md
+++ b/.changeset/two-onions-tell.md
@@ -1,0 +1,26 @@
+---
+@lumeweb/portal-sdk: minor
+---
+
+## Features
+
+- add Websites and IPNS API support
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- add gateway-agnostic billing plugin
+- fix YAML syntax errors in account swagger.yaml
+- remove baseUrl from all tsconfigs
+- implement 2FA flows and login
+- implement account deletion functionality
+- implement portal framework with module federation, Refine integration, and abuse management
+- add auto-login option after email verification
+- implement bootup and page loading screens with animations
+- add operations API, polling utilities, and comprehensive test suite
+- add query builder integration and update tests
+- update task pipelines
+- lock file
+- need to pass withCredentials to all account requests
+- pass buildOptions to login to ensure withCredentials is set
+- improve response handling and error parsing in AccountApi
+- recalculate elapsed time after fetch to account for network latency
+- correctly serialize array filters with indexed keys
+- correct operation list response handling and csv formatter

--- a/.changeset/wet-animals-cross.md
+++ b/.changeset/wet-animals-cross.md
@@ -1,0 +1,16 @@
+---
+@lumeweb/libs5: minor
+---
+
+## Features
+
+- value is a map
+- add override modifier
+- streams is a map, not object
+- add return type
+- add type hint
+- hack: disable ts errors on ws
+- import EventEmitter as a default package export
+- update task pipelines
+- use default export for EventEmitter
+- lock file

--- a/.changeset/young-dolls-repair.md
+++ b/.changeset/young-dolls-repair.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/docs.lumeweb.com: minor
+---
+
+## Features
+
+- add docs.pinner.xyz documentation site
+- implement portal framework with module federation, Refine integration, and abuse management
+- use list not br tags
+- wrong editUrl
+- wrong editUrl, again
+- remove text from ai help

--- a/.changeset/young-insects-hide.md
+++ b/.changeset/young-insects-hide.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/portal-generators: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- remove baseUrl from all tsconfigs
+- remove unused cjsDir param and remove stale require exports from package.jsons
+- replace external with deps.neverBundle in own config, remove dead CJS build from portal-generators
+- replace external with deps.neverBundle in all tsdown configs, remove dead CJS builds, add type:module to portal-generators
+- add portal-generators package with scaffolding templates


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset files to document version bumps and changelogs across the LumeWeb monorepo in preparation for a release. The changesets cover minor version bumps for numerous packages, reflecting a broad set of changes including:

- **Vite 8 Migration**: Widespread migration to Vite 8 with tunnel plugins and build tooling overhaul across most packages
- **Portal Framework Implementation**: New portal framework with module federation, Refine integration, and abuse management capabilities
- **Build Tooling Improvements**: Removal of `baseUrl` from tsconfigs, removal of stale CJS builds and require exports, replacement of `external` with `deps.neverBundle` in tsdown configs, and use of `@/` alias imports
- **New Packages**: Introduction of `libs5-crypto`, `libs5-encoding`, `libs5-metadata`, `portal-shared`, `portal-admin`, `@lumeweb/analytics`, `@lumeweb/query-builder`, `@lumeweb/uppy-post-upload`, `portal-plugin-template`, and `@lumeweb/rego`
- **Portal Dashboard Enhancements**: Theming support, social login, 2FA flows, API keys, account deletion, usage tracking, subscriptions, file manager, and billing UI overhaul
- **Portal Plugin Updates**: Improvements to IPFS, LBRY, abuse, billing, dashboard, admin, and core plugins
- **Bug Fixes**: Various fixes including API URLs, import paths, type errors, formatting, and response handling
- **Documentation Sites**: New documentation sites for pinner.xyz and lumeweb.com
- **LumeWeb.com**: Migration to content-driven React architecture with SEO integration
- **UI/UX Improvements**: Bootup/loading screens, cookie consent banner, mobile responsiveness, and color theming
<!-- kody-pr-summary:end -->