### PR TITLE
chore: changesets

### DIFF
--- a/.changeset/silver-shoes-fold.md
+++ b/.changeset/silver-shoes-fold.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/docs.pinner.xyz: minor
+---
+
+## Features
+
+- add docs.pinner.xyz documentation site
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- domain typo
+- remove baseUrl from all tsconfigs

--- a/.changeset/tall-baths-clap.md
+++ b/.changeset/tall-baths-clap.md
@@ -1,0 +1,17 @@
+---
+@lumeweb/pinner: minor
+---
+
+## Features
+
+- add Websites and IPNS API support
+- add SSL status monitoring for websites with watch functionality
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- sync IpnsClient and WebsitesClient with server swagger
+- update default endpoint and gateway URLs
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- implement core pinning and upload library
+- enhance SSRF protection with comprehensive IP validation
+- correct operation list response handling and csv formatter
+- make setDriverFactory actually work

--- a/apps/docs.pinner.xyz/CHANGELOG.md
+++ b/apps/docs.pinner.xyz/CHANGELOG.md
@@ -1,11 +1,1 @@
-## 0.6.1 (2026-05-21)
 
-### Features
-
-#### Features
-
-- add docs.pinner.xyz documentation site
-- migrate to vite 8 with tunnel plugins and build tooling overhaul
-- typo
-- domain typo
-- remove baseUrl from all tsconfigs

--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/docs.pinner.xyz",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/libs/analytics/package.json
+++ b/libs/analytics/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lumeweb/analytics",
   "version": "0.1.0",
+  "private": true,
   "description": "Analytics hooks for PostHog integration across portal apps",
   "type": "module",
   "main": "./dist/index.js",

--- a/libs/pinner/CHANGELOG.md
+++ b/libs/pinner/CHANGELOG.md
@@ -1,21 +1,3 @@
-## 0.1.2 (2026-05-21)
-
-### Features
-
-#### Features
-
-- add Websites and IPNS API support
-- add SSL status monitoring for websites with watch functionality
-- migrate to vite 8 with tunnel plugins and build tooling overhaul
-- sync IpnsClient and WebsitesClient with server swagger
-- update default endpoint and gateway URLs
-- remove baseUrl from all tsconfigs
-- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
-- implement core pinning and upload library
-- enhance SSRF protection with comprehensive IP validation
-- correct operation list response handling and csv formatter
-- make setDriverFactory actually work
-
 ## 0.1.1 (2026-01-17)
 
 ### Features

--- a/libs/pinner/package.json
+++ b/libs/pinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/pinner",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add changeset files for `@lumeweb/docs.pinner.xyz` and `@lumeweb/pinner` packages, and remove manually maintained changelog entries from their CHANGELOG.md files.

This migrates changelog tracking to the changeset workflow, replacing hand-written CHANGELOG entries with changeset files that will automatically generate changelogs upon release. The changesets document the following existing features:

- **@lumeweb/docs.pinner.xyz** (minor): Documentation site, Vite 8 migration, typo fixes, and tsconfig baseUrl removal
- **@lumeweb/pinner** (minor): Websites and IPNS API support, SSL monitoring, Vite 8 migration, client sync with server swagger, endpoint/gateway URL updates, import alias changes, core pinning/upload library, SSRF protection improvements, operation list response handling fixes, and setDriverFactory fix
<!-- kody-pr-summary:end -->