### PR TITLE
chore: changesets

### DIFF
--- a/apps/docs.pinner.xyz/CHANGELOG.md
+++ b/apps/docs.pinner.xyz/CHANGELOG.md
@@ -1,12 +1,1 @@
 
-## 0.6.1 (2026-05-21)
-
-### Features
-
-#### Features
-
-- add docs.pinner.xyz documentation site
-- migrate to vite 8 with tunnel plugins and build tooling overhaul
-- typo
-- domain typo
-- remove baseUrl from all tsconfigs

--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/docs.pinner.xyz",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/libs/pinner/CHANGELOG.md
+++ b/libs/pinner/CHANGELOG.md
@@ -1,21 +1,3 @@
-## 0.1.2 (2026-05-21)
-
-### Features
-
-#### Features
-
-- add Websites and IPNS API support
-- add SSL status monitoring for websites with watch functionality
-- migrate to vite 8 with tunnel plugins and build tooling overhaul
-- sync IpnsClient and WebsitesClient with server swagger
-- update default endpoint and gateway URLs
-- remove baseUrl from all tsconfigs
-- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
-- implement core pinning and upload library
-- enhance SSRF protection with comprehensive IP validation
-- correct operation list response handling and csv formatter
-- make setDriverFactory actually work
-
 ## 0.1.1 (2026-01-17)
 
 ### Features

--- a/libs/pinner/package.json
+++ b/libs/pinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/pinner",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "type": "module",
   "files": [
     "dist",

--- a/libs/portal-analytics/package.json
+++ b/libs/portal-analytics/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lumeweb/portal-analytics",
   "version": "0.1.0",
+  "private": true,
   "description": "Analytics integration hooks for Lumeweb portal — bridges @lumeweb/analytics with @refinedev/core",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request removes prematurely committed changelog entries from two packages (`docs.pinner.xyz` and `pinner`). The version `0.6.1` section was removed from the docs app's changelog, and the version `0.1.2` section was removed from the pinner library's changelog. This aligns with a changeset-based workflow where changelogs should be generated automatically during releases rather than manually maintained.
<!-- kody-pr-summary:end -->