### PR TITLE
chore: changesets

### DIFF
--- a/apps/docs.pinner.xyz/CHANGELOG.md
+++ b/apps/docs.pinner.xyz/CHANGELOG.md
@@ -1,1 +1,12 @@
 
+## 0.6.1 (2026-05-21)
+
+### Features
+
+#### Features
+
+- add docs.pinner.xyz documentation site
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- domain typo
+- remove baseUrl from all tsconfigs

--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/docs.pinner.xyz",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/libs/pinner/CHANGELOG.md
+++ b/libs/pinner/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.1.2 (2026-05-21)
+
+### Features
+
+#### Features
+
+- add Websites and IPNS API support
+- add SSL status monitoring for websites with watch functionality
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- sync IpnsClient and WebsitesClient with server swagger
+- update default endpoint and gateway URLs
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- implement core pinning and upload library
+- enhance SSRF protection with comprehensive IP validation
+- correct operation list response handling and csv formatter
+- make setDriverFactory actually work
+
 ## 0.1.1 (2026-01-17)
 
 ### Features

--- a/libs/pinner/package.json
+++ b/libs/pinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/pinner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add changeset-generated changelogs for `docs.pinner.xyz` (v0.6.1) and `pinner` (v0.1.2)

This PR introduces version-bumped changelog entries for two packages:

- **docs.pinner.xyz v0.6.1**: Documents the addition of the documentation site, migration to Vite 8 with tunnel plugins and build tooling overhaul, typo/domain typo fixes, and removal of `baseUrl` from tsconfigs.

- **pinner v0.1.2**: Documents new Websites and IPNS API support, SSL status monitoring for websites, Vite 8 migration, sync of IpnsClient/WebsitesClient with server swagger, updated default endpoint and gateway URLs, `baseUrl` removal from tsconfigs, `@/` alias imports replacing bare `src/` imports, core pinning/upload library implementation, enhanced SSRF protection with IP validation, operation list response handling and CSV formatter fixes, and a fix for `setDriverFactory`.
<!-- kody-pr-summary:end -->