### PR TITLE
chore: changesets

### DIFF
--- a/.changeset/silver-shoes-fold.md
+++ b/.changeset/silver-shoes-fold.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/docs.pinner.xyz: minor
+---
+
+## Features
+
+- add docs.pinner.xyz documentation site
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- typo
+- domain typo
+- remove baseUrl from all tsconfigs

--- a/.changeset/tall-baths-clap.md
+++ b/.changeset/tall-baths-clap.md
@@ -1,0 +1,17 @@
+---
+@lumeweb/pinner: minor
+---
+
+## Features
+
+- add Websites and IPNS API support
+- add SSL status monitoring for websites with watch functionality
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- sync IpnsClient and WebsitesClient with server swagger
+- update default endpoint and gateway URLs
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- implement core pinning and upload library
+- enhance SSRF protection with comprehensive IP validation
+- correct operation list response handling and csv formatter
+- make setDriverFactory actually work


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add changesets for `@lumeweb/pinner` and `@lumeweb/docs.pinner.xyz` (minor)

This PR introduces two changeset files documenting minor version bumps for the pinner packages:

- **@lumeweb/docs.pinner.xyz**: Adds the documentation site, migrates to Vite 8 with tunnel plugins and build tooling overhaul, fixes typos (including a domain typo), and removes `baseUrl` from all tsconfigs.

- **@lumeweb/pinner**: Adds Websites and IPNS API support, SSL status monitoring for websites with watch functionality, migrates to Vite 8 with tunnel plugins and build tooling overhaul, syncs IpnsClient and WebsitesClient with server swagger, updates default endpoint and gateway URLs, removes `baseUrl` from all tsconfigs, replaces bare `src/` imports with `@/` alias and upgrades tsdown external to `deps.neverBundle`, implements core pinning and upload library, enhances SSRF protection with comprehensive IP validation, corrects operation list response handling and CSV formatter, and fixes `setDriverFactory` to actually work.
<!-- kody-pr-summary:end -->