### PR TITLE
chore: changesets

### DIFF
--- a/.changeset/brown-rockets-change.md
+++ b/.changeset/brown-rockets-change.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/portal-sdk: minor
+---
+
+## Features
+
+- add Websites and IPNS API support
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- add gateway-agnostic billing plugin
+- fix YAML syntax errors in account swagger.yaml
+- remove baseUrl from all tsconfigs

--- a/.changeset/rich-books-arrive.md
+++ b/.changeset/rich-books-arrive.md
@@ -1,0 +1,10 @@
+---
+@lumeweb/advanced-rest-provider: minor
+---
+
+## Features
+
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- migrate advanced-rest to ky v1 API (prefixUrl -> prefix)
+- remove CJS output and fix tsconfig paths
+- remove baseUrl from all tsconfigs

--- a/.changeset/thin-spiders-sink.md
+++ b/.changeset/thin-spiders-sink.md
@@ -1,0 +1,14 @@
+---
+@lumeweb/pinner: minor
+---
+
+## Features
+
+- add Websites and IPNS API support
+- add SSL status monitoring for websites with watch functionality
+- migrate to vite 8 with tunnel plugins and build tooling overhaul
+- sync IpnsClient and WebsitesClient with server swagger
+- update default endpoint and gateway URLs
+- remove baseUrl from all tsconfigs
+- replace bare src/ imports with @/ alias and upgrade tsdown external to deps.neverBundle
+- move blockstore-core and nanoevents to runtime dependencies


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add changesets for minor version bumps across three packages

This PR introduces three changeset files documenting minor version updates for the following packages:

- **@lumeweb/portal-sdk**: Adds Websites and IPNS API support, migrates to Vite 8 with tunnel plugins and build tooling overhaul, adds gateway-agnostic billing plugin, fixes YAML syntax errors in account swagger.yaml, and removes baseUrl from tsconfigs.

- **@lumeweb/advanced-rest-provider**: Migrates to Vite 8 with tunnel plugins and build tooling overhaul, migrates advanced-rest to ky v1 API (prefixUrl → prefix), removes CJS output and fixes tsconfig paths, and removes baseUrl from tsconfigs.

- **@lumeweb/pinner**: Adds Websites and IPNS API support, adds SSL status monitoring for websites with watch functionality, migrates to Vite 8 with tunnel plugins and build tooling overhaul, syncs IpnsClient and WebsitesClient with server swagger, updates default endpoint and gateway URLs, removes baseUrl from tsconfigs, replaces bare src/ imports with @/ alias and upgrades tsdown external to deps.neverBundle, and moves blockstore-core and nanoevents to runtime dependencies.
<!-- kody-pr-summary:end -->