### PR TITLE
fix(pinner): update swagger spec and republish endpoint

### DIFF
--- a/libs/pinner/src/__tests__/msw-websites-ipns-handlers.ts
+++ b/libs/pinner/src/__tests__/msw-websites-ipns-handlers.ts
@@ -275,14 +275,17 @@ export const publishIPNSHandler = http.post(
 );
 
 export const republishIPNSHandler = http.post(
-  `${testConfig.apiUrl}/ipns/republish`,
+  `${testConfig.apiUrl}/ipns/keys/:id/republish`,
   async () => {
-    return new HttpResponse(null, {
-      status: 202,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
+    return HttpResponse.json(
+      { count: 1, message: "Republish triggered" },
+      {
+        status: 200,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+        },
       },
-    });
+    );
   },
 );
 
@@ -637,7 +640,7 @@ export const ipnsUnauthorizedPublishHandler = http.post(
 
 // Add POST handler for unauthorized republish
 export const ipnsUnauthorizedRepublishHandler = http.post(
-  `${testConfig.apiUrl}/ipns/republish`,
+  `${testConfig.apiUrl}/ipns/keys/:id/republish`,
   async () => {
     return HttpResponse.json(
       { error: "Unauthorized" },

--- a/libs/pinner/src/api/__tests__/ipns.spec.ts
+++ b/libs/pinner/src/api/__tests__/ipns.spec.ts
@@ -246,11 +246,13 @@ describe("IpnsClient", () => {
   });
 
   describe("republish", () => {
-    it("should trigger IPNS republishing", async ({ worker }) => {
+    it("should republish an IPNS key by ID", async ({ worker }) => {
       worker.use(...ipnsHandlers);
       const client = new IpnsClient(mockConfig);
 
-      await expect(client.republish("k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e")).resolves.not.toThrow();
+      const result = await client.republish(1);
+      expect(result).toHaveProperty("count");
+      expect(result).toHaveProperty("message");
     });
 
     it("should handle authentication errors", async ({ worker }) => {
@@ -260,7 +262,7 @@ describe("IpnsClient", () => {
         endpoint: "https://test.pinner.xyz",
       });
 
-      await expect(client.republish("k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e")).rejects.toThrow(AuthenticationError);
+      await expect(client.republish(1)).rejects.toThrow(AuthenticationError);
     });
   });
 

--- a/libs/pinner/src/api/ipns.ts
+++ b/libs/pinner/src/api/ipns.ts
@@ -6,6 +6,7 @@ import type {
   IPNSKeyResponse,
   IPNSPublishRequest,
   IPNSPublishResponse,
+  IPNSRepublishResponse,
   IPNSResolveResponse,
 } from "./generated/schemas/index";
 import {
@@ -140,12 +141,11 @@ export class IpnsClient {
   }
 
   async republish(
-    name: string,
+    id: number,
     options?: IpnsClientOptions,
-  ): Promise<void> {
-    await this.request<void>("api/ipns/republish", {
+  ): Promise<IPNSRepublishResponse> {
+    return this.request<IPNSRepublishResponse>(`api/ipns/keys/${id}/republish`, {
       method: "POST",
-      body: JSON.stringify({ name }),
       signal: options?.signal,
     });
   }

--- a/libs/pinner/src/api/swagger.yaml
+++ b/libs/pinner/src/api/swagger.yaml
@@ -268,6 +268,17 @@ components:
       - validity
       - published
       type: object
+    IPNSRepublishResponse:
+      additionalProperties: false
+      properties:
+        count:
+          type: integer
+        message:
+          type: string
+      required:
+      - count
+      - message
+      type: object
     IPNSResolveResponse:
       additionalProperties: false
       properties:
@@ -513,6 +524,8 @@ components:
     WebsiteItem:
       additionalProperties: false
       properties:
+        active_cid:
+          type: string
         created:
           format: date-time
           type: string
@@ -528,6 +541,10 @@ components:
           type: string
         id:
           type: integer
+        ipns_key_id:
+          type: integer
+        is_subdomain:
+          type: boolean
         last_checked_at:
           format: date-time
           type: string
@@ -555,6 +572,7 @@ components:
       - status
       - validation_token
       - dns_hosting_enabled
+      - is_subdomain
       - created
       - updated
       - expired
@@ -591,6 +609,8 @@ components:
     WebsiteResponse:
       additionalProperties: false
       properties:
+        active_cid:
+          type: string
         created:
           format: date-time
           type: string
@@ -606,6 +626,10 @@ components:
           type: string
         id:
           type: integer
+        ipns_key_id:
+          type: integer
+        is_subdomain:
+          type: boolean
         last_checked_at:
           format: date-time
           type: string
@@ -633,6 +657,7 @@ components:
       - status
       - validation_token
       - dns_hosting_enabled
+      - is_subdomain
       - created
       - updated
       - expired
@@ -2161,6 +2186,61 @@ paths:
       summary: Get IPNS key
       tags:
       - IPNS
+  /api/ipns/keys/{id}/republish:
+    post:
+      description: |-
+        Republishes an IPNS record for a specific key owned by the authenticated user.
+
+        Re-broadcasts the current IPNS record to the network. Useful for refreshing records that may have fallen out of the DHT.
+
+        Prerequisites: User must own the specified IPNS key.
+      parameters:
+      - description: IPNS key ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IPNSRepublishResponse'
+          description: Republish result
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Republish IPNS record
+      tags:
+      - IPNS
   /api/ipns/publish:
     post:
       description: |-
@@ -2214,56 +2294,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Publish to IPNS
-      tags:
-      - IPNS
-  /api/ipns/republish:
-    post:
-      description: |-
-        Triggers IPNS record republishing for all keys.
-
-        Forces all IPNS records to be republished to the network. Useful for ensuring content remains available and records are refreshed.
-
-        See also:.*
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Success
-        "202":
-          description: Republish triggered
-        "400":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
-        "401":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Unauthorized
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
-      summary: Trigger IPNS republish
       tags:
       - IPNS
   /api/ipns/resolve/{name}:


### PR DESCRIPTION
- Update swagger.yaml to latest API spec
- Add active_cid, ipns_key_id, is_subdomain to WebsiteItem/WebsiteResponse
- Add IPNSRepublishResponse schema (count + message)
- Restructure IPNS republish: /api/ipns/republish -> /api/ipns/keys/{id}/republish
- Update IpnsClient.republish() to take key ID, return IPNSRepublishResponse
- Update test mocks and handlers for new republish endpoint

---

<!-- kody-pr-summary:start -->
Update the IPNS republish endpoint to use key ID in the path and return a structured response, and add new fields to the Website schema in the Swagger spec.

Key changes:
- **Republish endpoint restructured**: Changed from `POST /api/ipns/republish` (accepting a `name` string in the body) to `POST /api/ipns/keys/{id}/republish` (accepting a numeric key ID in the path), aligning with the RESTful pattern used by other key-specific endpoints.
- **Republish response**: The endpoint now returns an `IPNSRepublishResponse` with `count` (integer) and `message` (string) fields instead of a void 202 response.
- **Website schema updates**: Added `active_cid` (string), `ipns_key_id` (integer), and `is_subdomain` (boolean) properties to both `WebsiteItem` and `WebsiteResponse` schemas, with `is_subdomain` added as a required field.
- Updated the SDK client, mock handlers, and tests to reflect the new endpoint signature and response shape.
<!-- kody-pr-summary:end -->