### PR TITLE
fix(pinner): update swagger spec and add WebsiteValidationReason enum

### DIFF
--- a/libs/pinner/src/__tests__/msw-websites-ipns-handlers.ts
+++ b/libs/pinner/src/__tests__/msw-websites-ipns-handlers.ts
@@ -498,6 +498,7 @@ export const validateWebsiteHandler = http.post(
       domain: website.domain,
       valid: true,
       message: "DNS validation successful",
+      reason: "validated",
     };
 
     return HttpResponse.json(validationResult, {

--- a/libs/pinner/src/api/__tests__/websites.spec.ts
+++ b/libs/pinner/src/api/__tests__/websites.spec.ts
@@ -1,7 +1,7 @@
 import { test as it } from "../../__tests__/int-test";
 import { describe, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { WebsitesClient } from "../websites";
+import { WebsitesClient, WebsiteValidationReason, getValidationReason, isValidationReason } from "../websites";
 import { SSLStatus } from "../websites";
 import type { PinnerConfig } from "@/config";
 import type {
@@ -289,8 +289,10 @@ describe("WebsitesClient", () => {
       expect(result).toHaveProperty("domain");
       expect(result).toHaveProperty("valid");
       expect(result).toHaveProperty("message");
+      expect(result).toHaveProperty("reason");
       expect(result.valid).toBe(true);
       expect(result.message).toBe("DNS validation successful");
+      expect(result.reason).toBe("validated");
     });
 
     it("should throw NotFoundError for non-existent website", async ({ worker }) => {
@@ -308,6 +310,44 @@ describe("WebsitesClient", () => {
       });
 
       await expect(client.validateWebsite(1)).rejects.toThrow(AuthenticationError);
+    });
+
+    it("should return reason field from validation response", async ({ worker }) => {
+      worker.use(...websitesHandlers);
+      const client = new WebsitesClient(mockConfig);
+
+      const result = await client.validateWebsite(1);
+
+      expect(result.reason).toBe(WebsiteValidationReason.VALIDATED);
+    });
+  });
+
+  describe("WebsiteValidationReason helpers", () => {
+    it("getValidationReason extracts reason from response", () => {
+      const response = { id: 1, domain: "example.com", valid: true, message: "ok", reason: "validated" } as WebsiteValidateResponse;
+      expect(getValidationReason(response)).toBe(WebsiteValidationReason.VALIDATED);
+    });
+
+    it("getValidationReason returns empty string for null", () => {
+      expect(getValidationReason(null)).toBe("");
+    });
+
+    it("getValidationReason returns empty string for undefined", () => {
+      expect(getValidationReason(undefined)).toBe("");
+    });
+
+    it("isValidationReason checks if response matches a reason", () => {
+      const response = { id: 1, domain: "example.com", valid: false, message: "missing", reason: "dns_missing" } as WebsiteValidateResponse;
+      expect(isValidationReason(response, WebsiteValidationReason.DNS_MISSING)).toBe(true);
+      expect(isValidationReason(response, WebsiteValidationReason.VALIDATED)).toBe(false);
+    });
+
+    it("isValidationReason returns false for null", () => {
+      expect(isValidationReason(null, WebsiteValidationReason.VALIDATED)).toBe(false);
+    });
+
+    it("isValidationReason returns false for undefined", () => {
+      expect(isValidationReason(undefined, WebsiteValidationReason.VALIDATED)).toBe(false);
     });
   });
 

--- a/libs/pinner/src/api/swagger.yaml
+++ b/libs/pinner/src/api/swagger.yaml
@@ -683,6 +683,8 @@ components:
           type: integer
         message:
           type: string
+        reason:
+          type: string
         valid:
           type: boolean
       required:
@@ -690,6 +692,7 @@ components:
       - domain
       - valid
       - message
+      - reason
       type: object
     ZoneListResponse:
       additionalProperties: false

--- a/libs/pinner/src/api/websites.ts
+++ b/libs/pinner/src/api/websites.ts
@@ -34,11 +34,17 @@ export const WebsiteValidationReason = {
 
 export type WebsiteValidationReasonValue = (typeof WebsiteValidationReason)[keyof typeof WebsiteValidationReason];
 
+const validationReasonValues = Object.values(WebsiteValidationReason) as readonly string[];
+
 export function getValidationReason(response: WebsiteValidateResponse | null | undefined): WebsiteValidationReasonValue | "" {
   if (!response) {
     return "";
   }
-  return (response.reason as WebsiteValidationReasonValue) ?? "";
+  const reason = response.reason;
+  if (typeof reason === "string" && validationReasonValues.includes(reason)) {
+    return reason as WebsiteValidationReasonValue;
+  }
+  return "";
 }
 
 export function isValidationReason(response: WebsiteValidateResponse | null | undefined, reason: WebsiteValidationReasonValue): boolean {

--- a/libs/pinner/src/api/websites.ts
+++ b/libs/pinner/src/api/websites.ts
@@ -22,6 +22,31 @@ export const SSLStatus = {
 } as const;
 
 export type SSLStatusValue = (typeof SSLStatus)[keyof typeof SSLStatus];
+
+// Website validation reason constants
+export const WebsiteValidationReason = {
+  VALIDATED: "validated",
+  TOKEN_EXPIRED: "token_expired",
+  DNS_MISSING: "dns_missing",
+  DNS_MISMATCH: "dns_mismatch",
+  TOKEN_MISSING: "token_missing",
+} as const;
+
+export type WebsiteValidationReasonValue = (typeof WebsiteValidationReason)[keyof typeof WebsiteValidationReason];
+
+export function getValidationReason(response: WebsiteValidateResponse | null | undefined): WebsiteValidationReasonValue | "" {
+  if (!response) {
+    return "";
+  }
+  return (response.reason as WebsiteValidationReasonValue) ?? "";
+}
+
+export function isValidationReason(response: WebsiteValidateResponse | null | undefined, reason: WebsiteValidationReasonValue): boolean {
+  if (!response) {
+    return false;
+  }
+  return response.reason === reason;
+}
 import {
   ConfigurationError,
   AuthenticationError,

--- a/libs/pinner/src/index.ts
+++ b/libs/pinner/src/index.ts
@@ -30,7 +30,8 @@ export type {
 
 // API exports
 export { IpnsClient } from "./api/ipns";
-export { WebsitesClient } from "./api/websites";
+export { WebsitesClient, WebsiteValidationReason, getValidationReason, isValidationReason } from "./api/websites";
+export type { WebsiteValidationReasonValue } from "./api/websites";
 
 // Error exports
 export {


### PR DESCRIPTION
- Update swagger.yaml with reason field on DNSVerification
- Add WebsiteValidationReason enum with 5 values (validated, token_expired,
  dns_missing, dns_mismatch, token_missing)
- Add getValidationReason() and isValidationReason() helpers
- Update MSW mock and tests for reason field

---

<!-- kody-pr-summary:start -->
Add `reason` field to website validation response with enum and helper functions

Updates the pinner SDK to align with the updated API by adding a required `reason` field to the `WebsiteValidateResponse`. This includes:

- **Swagger spec**: Added `reason` (string, required) to the `WebsiteValidateResponse` schema
- **`WebsiteValidationReason` enum**: Defines the possible validation reasons — `validated`, `token_expired`, `dns_missing`, `dns_mismatch`, `token_missing`
- **Helper functions**: `getValidationReason()` extracts the reason from a response (with null/undefined safety), and `isValidationReason()` checks if a response matches a specific reason
- **Exports**: All new types, enum, and helpers are exported from the package entry point
<!-- kody-pr-summary:end -->