### PR TITLE
fix(scripts): scope changeset generation to per-package changelog groups and validate against git history

### DIFF
--- a/.changeset/happy-cats-roll.md
+++ b/.changeset/happy-cats-roll.md
@@ -1,0 +1,14 @@
+---
+@lumeweb/pinner: minor
+---
+
+## Features
+
+- overhaul MSW test harness with stateful stores and orval mock generation
+
+## Fixes
+
+- update swagger spec and republish endpoint
+- update swagger spec and add WebsiteValidationReason enum
+- validate reason against known enum values in getValidationReason
+- use unique TUS upload IDs and relax test assertions

--- a/.changeset/jolly-dingos-sink.md
+++ b/.changeset/jolly-dingos-sink.md
@@ -1,10 +1,13 @@
 ---
-@lumeweb/advanced-rest-provider: minor
+@lumeweb/advanced-rest: minor
 ---
 
 ## Features
 
 - migrate to vite 8 with tunnel plugins and build tooling overhaul
 - migrate advanced-rest to ky v1 API (prefixUrl -> prefix)
+
+## Fixes
+
 - remove CJS output and fix tsconfig paths
 - remove baseUrl from all tsconfigs

--- a/scripts/generate-changesets-from-release.js
+++ b/scripts/generate-changesets-from-release.js
@@ -46,9 +46,7 @@ class ChangesetGenerator {
     this.dryRun = options.dryRun || false;
     this.git = simpleGit(this.packagesDir);
 
-    this.messageQueue = new PQueue({ concurrency: 10 });
-    this.fileQueue = new PQueue({ concurrency: 20 });
-    this.packageLookupQueue = new PQueue({ concurrency: 50 });
+    this.validationQueue = new PQueue({ concurrency: 10 });
     this.changesetQueue = new PQueue({ concurrency: 5 });
   }
 
@@ -116,149 +114,144 @@ class ChangesetGenerator {
     }
   }
 
-  extractUniqueChangelogMessages(content) {
-    const messages = new Set();
+  /**
+   * Parse knope dry-run output, extracting changelog messages grouped by
+   * the CHANGELOG.md path header knope emits. Returns a map of
+   * package path → [{message, type}] preserving knope's own per-package
+   * grouping instead of flattening into a global set.
+   */
+  extractPerPackageChangelogMessages(content) {
+    const result = {};
     const lines = content.split("\n");
-    let inChangelog = false;
+    let currentPkgPath = null;
+    let currentType = null;
 
     for (const line of lines) {
-      if (line.match(/CHANGELOG\.md:/)) {
-        inChangelog = true;
+      const changelogMatch = line.match(
+        /Would add the following to (.+)\/CHANGELOG\.md:/,
+      );
+      if (changelogMatch) {
+        currentPkgPath = changelogMatch[1];
+        currentType = null;
         continue;
       }
 
-      if ((line.startsWith("Would ") || line.startsWith("--")) && inChangelog) {
-        inChangelog = false;
+      // Terminus line ends the current changelog section
+      if (
+        currentPkgPath &&
+        (line.startsWith("Would ") || line.startsWith("--"))
+      ) {
+        currentPkgPath = null;
+        currentType = null;
         continue;
       }
 
-      if (inChangelog && line.startsWith("- ") && line.trim() !== "- ") {
+      if (!currentPkgPath) continue;
+
+      // Section headers like "### Features", "### Fixes", "### Breaking Changes"
+      const sectionMatch = line.match(/^###\s+(.+)$/);
+      if (sectionMatch) {
+        const section = sectionMatch[1].toLowerCase();
+        if (section.includes("breaking")) currentType = "breaking changes";
+        else if (section.includes("fix")) currentType = "fixes";
+        else if (section.includes("feature")) currentType = "features";
+        continue;
+      }
+
+      // Sub-headers like "#### Features" — skip but don't reset type
+      if (line.match(/^####\s+/)) continue;
+
+      // Changelog entry lines
+      if (line.startsWith("- ") && line.trim() !== "- ") {
         const message = line.substring(2).trim();
-        if (message) messages.add(message);
-      }
-    }
-    return Array.from(messages);
-  }
-
-  async findCommitsForMessage(message) {
-    const output = await this.git.raw([
-      "log",
-      "--all",
-      "--oneline",
-      `--grep=${message}`,
-    ]);
-    const lines = output.trim().split("\n");
-    const commits = [];
-    for (const line of lines) {
-      const match = line.match(/^([a-f0-9]+)\s+/);
-      if (match) commits.push(match[1]);
-    }
-    return commits;
-  }
-
-  async getChangedFilesForCommit(commit) {
-    try {
-      const output = await this.git.show([commit, "--name-only", "--pretty="]);
-      return output
-        .trim()
-        .split("\n")
-        .filter((f) => f.trim());
-    } catch (error) {
-      return [];
-    }
-  }
-
-  async findPackageForFileAtCommit(file, commit) {
-    try {
-      const parts = file.split(path.sep);
-      for (let i = parts.length - 1; i >= 0; i--) {
-        const possiblePath = parts.slice(0, i + 1).join(path.sep);
-        const pkgJsonPath = path.join(possiblePath, "package.json");
-
-        try {
-          const output = await this.git.show([`${commit}:${pkgJsonPath}`]);
-          const packageJson = JSON.parse(output);
-          if (packageJson.name) {
-            if (!this.packageNameToPath[packageJson.name]) {
-              this.packageNameToPath[packageJson.name] = possiblePath;
-              console.log(
-                `    Added package from git history: ${packageJson.name} -> ${possiblePath}`,
-              );
-            }
-            return packageJson.name;
-          }
-        } catch (e) {}
-      }
-      return null;
-    } catch (error) {
-      return null;
-    }
-  }
-
-  async findPackagesForFiles(fileData) {
-    const packages = new Set();
-    const tasks = fileData.map(({ file, commit }) =>
-      this.packageLookupQueue.add(async () => {
-        const packageName = await this.findPackageForFileAtCommit(file, commit);
-        if (packageName) {
-          packages.add(packageName);
+        if (message) {
+          if (!result[currentPkgPath]) result[currentPkgPath] = [];
+          result[currentPkgPath].push({
+            message,
+            type: currentType || "features",
+          });
         }
-      }),
-    );
-    await Promise.all(tasks);
-    return Array.from(packages);
-  }
-
-  async processSingleMessage(message) {
-    console.log(`  Finding packages for: "${message.substring(0, 60)}..."`);
-
-    const commits = await this.findCommitsForMessage(message);
-    if (commits.length === 0) {
-      console.log(`    No commits found for message`);
-      return { packages: [], type: "features" };
-    }
-
-    const allFiles = [];
-    const fileTasks = commits.map((commit) =>
-      this.fileQueue.add(async () => {
-        const files = await this.getChangedFilesForCommit(commit);
-        return files.map((file) => ({ file, commit }));
-      }),
-    );
-    const allFileResults = await Promise.all(fileTasks);
-    allFiles.push(...allFileResults.flat());
-
-    const packages = await this.findPackagesForFiles(allFiles);
-
-    if (packages.length === 0) {
-      console.log(`    No packages found for ${allFiles.length} changed files`);
-      return { packages: [], type: "features" };
-    }
-
-    console.log(
-      `    Found ${packages.length} package(s): ${packages.join(", ")}`,
-    );
-    return { packages, type: "features" };
-  }
-
-  async buildChangelogMessageMapping(messages) {
-    const mapping = {};
-    const seenMessages = new Set();
-
-    const filteredMessages = messages.filter((msg) => !seenMessages.has(msg));
-    const tasks = filteredMessages.map((message) =>
-      this.messageQueue.add(() => this.processSingleMessage(message)),
-    );
-    const results = await Promise.all(tasks);
-
-    filteredMessages.forEach((message, i) => {
-      const result = results[i];
-      if (result) {
-        mapping[message] = result;
-        seenMessages.add(message);
       }
-    });
-    return mapping;
+    }
+    return result;
+  }
+
+  /**
+   * Validate that a changelog message actually belongs to a package by
+   * checking if any commit matching the message touched files in the
+   * package's directory since its last release tag.
+   * This corrects for knope's over-broad changelog assignment (upstream bug
+   * where ALL conventional commits appear in EVERY package's changelog).
+   */
+  async validateMessageBelongsToPackage(message, pkgPath, tag) {
+    const args = ["log", "--oneline", `--grep=${message}`];
+    if (tag) {
+      args.push(`${tag}..HEAD`);
+    }
+    args.push("--", pkgPath);
+
+    try {
+      const output = await this.git.raw(args);
+      const commits = output.trim().split("\n").filter(Boolean);
+      return commits.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Build the final per-package changelog data by:
+   * 1. Using knope's per-package grouping from CHANGELOG.md headers
+   * 2. Validating each message actually belongs to the package
+   *    (scoped git grep since last tag, constrained to package dir)
+   * 3. Filtering to only packages in filteredVersions
+   */
+  async buildPackageChangelogs(perPackageMessages, filteredVersions, tagCache) {
+    const versionedPaths = new Set(Object.keys(filteredVersions));
+    const packageChangelogs = {};
+
+    const tasks = [];
+    for (const [pkgPath, entries] of Object.entries(perPackageMessages)) {
+      if (!versionedPaths.has(pkgPath)) continue;
+
+      const pkgName = this.pathToPackageName(pkgPath);
+      if (!pkgName) continue;
+
+      const tag = tagCache.get(pkgPath) || null;
+
+      const validationTasks = entries.map((entry) =>
+        this.validationQueue.add(async () => ({
+          ...entry,
+          valid: await this.validateMessageBelongsToPackage(
+            entry.message,
+            pkgPath,
+            tag,
+          ),
+        })),
+      );
+
+      tasks.push(
+        Promise.all(validationTasks).then((validated) => {
+          const validEntries = validated.filter((v) => v.valid);
+          if (validEntries.length > 0) {
+            packageChangelogs[pkgName] = {
+              version: filteredVersions[pkgPath]?.version || "0.0.0",
+              changelog: validEntries.map((v) => ({
+                type: v.type,
+                description: v.message,
+              })),
+            };
+          } else {
+            console.log(
+              `  No validated messages for ${pkgName}, skipping`,
+            );
+          }
+        }),
+      );
+    }
+
+    await Promise.all(tasks);
+    return packageChangelogs;
   }
 
   determineChangeType(version, changelog) {
@@ -352,40 +345,6 @@ class ChangesetGenerator {
     return null;
   }
 
-  groupChangelogsByPackages(changelogMapping, packageVersions) {
-    const versionedPaths = new Set(Object.keys(packageVersions));
-    const packageChangelogs = {};
-
-    for (const [message, data] of Object.entries(changelogMapping)) {
-      for (const packageName of data.packages) {
-        const pkgPath = this.packageNameToPath[packageName];
-        if (!pkgPath || !versionedPaths.has(pkgPath)) continue;
-
-        if (!packageChangelogs[packageName]) {
-          packageChangelogs[packageName] = [];
-        }
-        packageChangelogs[packageName].push({
-          type: data.type,
-          description: message,
-        });
-      }
-    }
-
-    const result = {};
-    for (const [pkgName, changelogs] of Object.entries(packageChangelogs)) {
-      const pkgPath = this.packageNameToPath[pkgName];
-      const versionInfo = pkgPath ? packageVersions[pkgPath] : null;
-
-      if (changelogs.length > 0) {
-        result[pkgName] = {
-          version: versionInfo?.version || "0.0.0",
-          changelog: changelogs,
-        };
-      }
-    }
-    return result;
-  }
-
   async createChangesetFile(packages, changelogItems) {
     const grouped = {};
     for (const item of changelogItems) {
@@ -477,19 +436,33 @@ class ChangesetGenerator {
       `Filtered to ${Object.keys(filteredVersions).length} packages with actual source changes`,
     );
 
-    const uniqueMessages = this.extractUniqueChangelogMessages(releaseOutput);
-    console.log(`Extracted ${uniqueMessages.length} unique changelog messages`);
-
-    console.log("\nBuilding changelog message to packages mapping...");
-    const changelogMapping =
-      await this.buildChangelogMessageMapping(uniqueMessages);
-
-    const packageChangelogs = this.groupChangelogsByPackages(
-      changelogMapping,
-      filteredVersions,
+    const perPackageMessages =
+      this.extractPerPackageChangelogMessages(releaseOutput);
+    const totalMessages = Object.values(perPackageMessages).reduce(
+      (sum, entries) => sum + entries.length,
+      0,
     );
     console.log(
-      "Packages with changelogs:",
+      `Extracted changelog messages for ${Object.keys(perPackageMessages).length} packages (${totalMessages} total entries)`,
+    );
+
+    const tagCache = new Map();
+    for (const pkgPath of Object.keys(filteredVersions)) {
+      const pkgName = this.pathToPackageName(pkgPath);
+      if (pkgName) {
+        const tag = await this.getLatestPackageTag(pkgName);
+        tagCache.set(pkgPath, tag);
+      }
+    }
+
+    console.log("\nValidating changelog messages against package scopes...");
+    const packageChangelogs = await this.buildPackageChangelogs(
+      perPackageMessages,
+      filteredVersions,
+      tagCache,
+    );
+    console.log(
+      "Packages with validated changelogs:",
       Object.keys(packageChangelogs).length,
     );
 


### PR DESCRIPTION
Replace flat message extraction + unscoped git grep reverse-mapping with
per-package changelog parsing and scoped validation. The old approach
extracted all changelog messages into a flat set, then used
git log --all --grep to find matching commits across the entire history,
which incorrectly assigned already-released changes to packages.

The new approach preserves knope's per-package CHANGELOG.md header grouping
and validates each message with git log scoped to the package's directory
since its last release tag.

---

<!-- kody-pr-summary:start -->
## Summary

This PR fixes the changeset generation script to correctly scope changelog entries to their respective packages and validate them against git history, addressing an upstream knope bug where all conventional commits were being incorrectly assigned to every package's changelog.

### Key Changes

**Script overhaul (`generate-changesets-from-release.js`):**

- **Replaced flat message extraction with per-package grouping**: The old approach extracted all changelog messages into a global set (losing package context), then tried to reverse-map messages to packages via commit history and file lookups. The new `extractPerPackageChangelogMessages` method parses knope's `CHANGELOG.md` path headers to preserve knope's own per-package grouping, and also captures section types (Features, Fixes, Breaking Changes) from `###` headers.

- **Added git-scoped validation**: New `validateMessageBelongsToPackage` method checks whether a changelog message actually belongs to a package by running a scoped `git log --grep` constrained to the package directory since its last release tag. This corrects for knope's over-broad changelog assignment where ALL conventional commits appear in EVERY package's changelog.

- **Simplified queue architecture**: Replaced three separate queues (`messageQueue`, `fileQueue`, `packageLookupQueue`) with a single `validationQueue`, reducing complexity.

- **Removed obsolete methods**: Deleted `findCommitsForMessage`, `getChangedFilesForCommit`, `findPackageForFileAtCommit`, `findPackagesForFiles`, `processSingleMessage`, `buildChangelogMessageMapping`, and `groupChangelogsByPackages` — all replaced by the new per-package extraction and validation flow.

**Changeset updates:**

- Added new changeset for `@lumeweb/pinner` (minor) with features and fixes
- Updated `@lumeweb/advanced-rest` changeset (renamed from `@lumeweb/advanced-rest-provider`) with additional fix entries
<!-- kody-pr-summary:end -->