### PR TITLE
fix(pinner): mark faker and msw as external in tsdown config

### DIFF
--- a/libs/pinner/tsdown.config.ts
+++ b/libs/pinner/tsdown.config.ts
@@ -4,6 +4,6 @@ import { createLibraryConfigWithExternals } from "@lumeweb/tsdown-config";
 export default defineConfig(
   createLibraryConfigWithExternals(
     ["./src/index.ts", "./src/api/generated/index.msw.ts", "!src/**/*.{spec,stories}.{ts,tsx}"],
-    [/node_modules/, "@uppy/core", "@uppy/tus", "stream"]
+    [/node_modules/, "@uppy/core", "@uppy/tus", "stream", "@faker-js/faker", "msw"]
   )
 );


### PR DESCRIPTION
MSW mock files (.msw.ts) import @faker-js/faker and msw as bare
specifiers, but tsdown was resolving them to absolute node_modules
paths in the build output. Adding them to deps.neverBundle keeps
the imports as bare specifiers so consumers can resolve their own
versions.

---

<!-- kody-pr-summary:start -->
This pull request updates the `tsdown` configuration for the `pinner` library to mark `@faker-js/faker` and `msw` as external dependencies. This prevents these packages from being bundled into the library's output, ensuring they are resolved at runtime from the consumer's environment.
<!-- kody-pr-summary:end -->