### PR TITLE
chore: changesets

### DIFF
--- a/.changeset/breezy-singers-burn.md
+++ b/.changeset/breezy-singers-burn.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- mark faker and msw as external in tsdown config


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Mark `faker` and `msw` as external dependencies in the tsdown configuration for the `@lumeweb/pinner` package, preventing them from being bundled into the build output.
<!-- kody-pr-summary:end -->