### PR TITLE
chore: changesets

### DIFF
--- a/.changeset/silver-pears-train.md
+++ b/.changeset/silver-pears-train.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/pinner: minor
+---
+
+## Features
+
+- export per-endpoint mock handlers from ./mocks


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add changeset for `@lumeweb/pinner` minor version bump, documenting the new feature that exports per-endpoint mock handlers from the `./mocks` module.
<!-- kody-pr-summary:end -->