### PR TITLE
fix(tunnel): split server_cmd into array before passing to tunnel_start_server

### DIFF
--- a/tunnel-lib.sh
+++ b/tunnel-lib.sh
@@ -407,6 +407,7 @@ tunnel_multi_app() {
     local main_host="$TUNNEL_MAIN_HOST"
     local main_port="${TUNNEL_MAIN_PORT:-4173}"
     local server_cmd="${TUNNEL_SERVER_CMD:-pnpm serve}"
+    read -ra server_cmd_parts <<< "$server_cmd"
     local plugin_config="${TUNNEL_PLUGIN_CONFIG:-}"
     local plugins_base_dir="${TUNNEL_PLUGINS_BASE_DIR:-$base_dir/libs}"
     local plugins_list="${TUNNEL_PLUGINS:-}"
@@ -442,7 +443,7 @@ tunnel_multi_app() {
     tunnel_start_server "$main_app_dir" "$main_port" "main app" \
         VITE_TUNNEL_HOST="$main_host.$(tunnel_get_domain)" \
         VITE_PORT="$main_port" \
-        "$server_cmd"
+        "${server_cmd_parts[@]}"
 
     # Start plugin apps if plugin config exists
     if [ -n "$plugin_config" ] && [ -f "$plugin_config" ]; then
@@ -465,7 +466,7 @@ tunnel_multi_app() {
             tunnel_start_server "$plugin_dir" "$forwarding_port" "'$name'" \
                 VITE_TUNNEL_HOST="$tunnelHost" \
                 VITE_PORT="$forwarding_port" \
-                "$server_cmd"
+                "${server_cmd_parts[@]}"
         done < <(jq -c '.[]' "$plugin_config")
     fi
 

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -233,6 +233,8 @@ else
     # Substitute {PORT} placeholder in server args if present
     server_cmd="${server_cmd//\{PORT\}/$local_port}"
 
+    read -ra server_cmd_parts <<< "$server_cmd"
+
     tunnel_single_app "$TUNNEL_APP_DIR" "$local_port" "$TUNNEL_HOST" \
-        "${TUNNEL_APP_NAME:-app}" "$server_cmd"
+        "${TUNNEL_APP_NAME:-app}" "${server_cmd_parts[@]}"
 fi


### PR DESCRIPTION
server_cmd was passed as a single quoted string, arriving as one argument to tunnel_start_server. That function iterates over $@ and classifies anything containing '=' as an env var. Commands like 'pnpm preview --port=4173' contain '=' and got misclassified, causing 'export: not a valid identifier'.

Use read -ra to split the string into an array first, then spread with ${server_cmd_parts[@]} so each word is a separate argument.

---

<!-- kody-pr-summary:start -->
Fix: Properly split `server_cmd` into an array before passing to tunnel server functions

Previously, `server_cmd` was passed as a single quoted string to `tunnel_start_server` and `tunnel_single_app`, which meant multi-word commands (e.g., `pnpm serve`) were treated as a single argument rather than separate command and arguments. This change splits `server_cmd` into an array using `read -ra` before passing it, ensuring the command and its arguments are correctly expanded as individual parameters.
<!-- kody-pr-summary:end -->