### PR TITLE
feat(portal-sdk): add quota/quotaHistory wrappers, MSW mock generation, and dedicated mocks export

### DIFF
--- a/libs/portal-sdk/orval.config.ts
+++ b/libs/portal-sdk/orval.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       client: "fetch",
       target: "account/generated",
       workspace: "./src",
+      mock: {
+        type: "msw",
+        delay: 0,
+        indexMockFiles: true,
+      },
     },
   },
 });

--- a/libs/portal-sdk/package.json
+++ b/libs/portal-sdk/package.json
@@ -19,6 +19,11 @@
       "import": "./dist/esm/openapi.js",
       "require": "./dist/cjs/openapi.cjs"
     },
+    "./mocks": {
+      "types": "./dist/esm/account/mocks.d.ts",
+      "import": "./dist/esm/account/mocks.js",
+      "require": "./dist/cjs/account/mocks.cjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -37,8 +42,10 @@
     "@lumeweb/query-builder": "workspace:*"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.0.0",
     "@lumeweb/tsdown-config": "workspace:*",
     "@vitest/coverage-v8": "^4.1.6",
+    "msw": "catalog:",
     "orval": "catalog:",
     "tsdown": "catalog:"
   },

--- a/libs/portal-sdk/src/__tests__/account.quota.spec.ts
+++ b/libs/portal-sdk/src/__tests__/account.quota.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { AccountApi } from "@/account";
+import { expectSuccess, expectFailure } from "./test-helpers";
+
+function createMockFetchResponse(
+  body: any,
+  status: number,
+  headers: Record<string, string> = {}
+): Response {
+  const response = new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json", ...headers },
+  });
+  Object.defineProperty(response, "status", { value: status, writable: false });
+  Object.defineProperty(response, "ok", { value: status >= 200 && status < 300 });
+  return response;
+}
+
+describe("AccountApi - quota", () => {
+  let accountApi: AccountApi;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    accountApi = new AccountApi("https://test.com");
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("quota", () => {
+    it("should return QuotaStatusResponse on success", async () => {
+      const mockData = {
+        download: { used: 1073741824, limit: 10737418240, remaining: 9663676416, percentage: 10 },
+        storage: { used: 2147483648, limit: 10737418240, remaining: 8589934592, percentage: 20 },
+        upload: { used: 536870912, limit: 5368709120, remaining: 4831838208, percentage: 10 },
+      };
+      mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
+
+      const result = await accountApi.quota();
+
+      expectSuccess(result);
+      expect(result.data.storage.used).toBe(2147483648);
+      expect(result.data.storage.limit).toBe(10737418240);
+      expect(result.data.storage.remaining).toBe(8589934592);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("https://account.test.com/api/account/quota"),
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+
+    it("should return error on failure", async () => {
+      mockFetch.mockResolvedValue(
+        createMockFetchResponse({ error: "Unauthorized" }, 401)
+      );
+
+      const result = await accountApi.quota();
+
+      expectFailure(result);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("quotaHistory", () => {
+    it("should return QuotaHistoryResponse on success without params", async () => {
+      const mockData = {
+        points: [
+          { bytes: 1073741824, date: "2024-01-01" },
+          { bytes: 2147483648, date: "2024-01-02" },
+        ],
+        user_id: 1,
+      };
+      mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
+
+      const result = await accountApi.quotaHistory();
+
+      expectSuccess(result);
+      expect(result.data.points).toHaveLength(2);
+      expect(result.data.user_id).toBe(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("https://account.test.com/api/account/quota/history"),
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+    });
+
+    it("should return QuotaHistoryResponse with query params", async () => {
+      const mockData = {
+        points: [
+          { bytes: 1073741824, date: "2024-06-01" },
+        ],
+        user_id: 1,
+      };
+      mockFetch.mockResolvedValue(createMockFetchResponse(mockData, 200));
+
+      const result = await accountApi.quotaHistory({
+        start_date: "2024-01-01",
+        end_date: "2024-12-31",
+        type: "storage",
+      });
+
+      expectSuccess(result);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/account/quota/history"),
+        expect.objectContaining({
+          method: "GET",
+        })
+      );
+
+      const callArgs = mockFetch.mock.calls[0];
+      const url = callArgs[0] as string;
+      const urlObj = new URL(url);
+
+      expect(urlObj.searchParams.get("start_date")).toBe("2024-01-01");
+      expect(urlObj.searchParams.get("end_date")).toBe("2024-12-31");
+      expect(urlObj.searchParams.get("type")).toBe("storage");
+    });
+
+    it("should return error on failure", async () => {
+      mockFetch.mockResolvedValue(
+        createMockFetchResponse({ error: "Bad Request" }, 400)
+      );
+
+      const result = await accountApi.quotaHistory();
+
+      expectFailure(result);
+      expect(result.error).toBeDefined();
+    });
+  });
+});

--- a/libs/portal-sdk/src/account.ts
+++ b/libs/portal-sdk/src/account.ts
@@ -9,7 +9,7 @@ import {
 
 import {
   AccountInfoResponse,
-  GetApiOperationsParams,
+  GetApiAccountQuotaHistoryParams,
   LoginRequest,
   LoginResponse,
   OperationDetailResponse,
@@ -22,6 +22,8 @@ import {
   PasswordResetRequest,
   PasswordResetVerifyRequest,
   PongResponse,
+  QuotaHistoryResponse,
+  QuotaStatusResponse,
   RegisterRequest,
   ResendVerifyEmailRequest,
   UploadLimitResponse,
@@ -130,6 +132,34 @@ export class AccountApi {
    */
   public async info(): Promise<Result<AccountInfoResponse>> {
     return this.fetchJson<AccountInfoResponse>("/api/account", {
+      method: "GET",
+    });
+  }
+
+  public async quota(): Promise<Result<QuotaStatusResponse>> {
+    return this.fetchJson<QuotaStatusResponse>("/api/account/quota", {
+      method: "GET",
+    });
+  }
+
+  public async quotaHistory(
+    params?: GetApiAccountQuotaHistoryParams,
+  ): Promise<Result<QuotaHistoryResponse>> {
+    const url = new URL("/api/account/quota/history", this.apiUrl);
+
+    if (params) {
+      if (params.start_date) {
+        url.searchParams.set("start_date", params.start_date);
+      }
+      if (params.end_date) {
+        url.searchParams.set("end_date", params.end_date);
+      }
+      if (params.type) {
+        url.searchParams.set("type", params.type);
+      }
+    }
+
+    return this.fetchJson<QuotaHistoryResponse>(url.toString(), {
       method: "GET",
     });
   }

--- a/libs/portal-sdk/src/account/generated/billing.ts
+++ b/libs/portal-sdk/src/account/generated/billing.ts
@@ -23,6 +23,19 @@ import type {
   UserCreditsListResponse
 } from './accountAPI.schemas';
 
+import {
+  faker
+} from '@faker-js/faker';
+
+import {
+  HttpResponse,
+  delay,
+  http
+} from 'msw';
+import type {
+  RequestHandlerOptions
+} from 'msw';
+
 
 
 export type getApiAccountBillingBalanceResponse200 = {
@@ -1324,3 +1337,273 @@ export const getApiBillingPlans = async ( options?: RequestInit): Promise<getApi
 }
 
 
+
+
+export const getGetApiAccountBillingBalanceResponseMock = (overrideResponse: Partial<Extract<BalanceResponse, object>> = {}): BalanceResponse => ({balance: {}, user_id: faker.number.int(), ...overrideResponse})
+
+export const getPostApiAccountBillingCancelResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getPostApiAccountBillingCancelAbortResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getPostApiAccountBillingChangePlanResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getGetApiAccountBillingCheckoutSessionSessionIdStatusResponseMock = (overrideResponse: Partial<Extract<CheckoutSessionStatusResponse, object>> = {}): CheckoutSessionStatusResponse => ({customer_email: faker.string.alpha({length: {min: 10, max: 20}}), session_id: faker.string.alpha({length: {min: 10, max: 20}}), status: faker.string.alpha({length: {min: 10, max: 20}}), user_id: faker.number.int(), ...overrideResponse})
+
+export const getGetApiAccountBillingCheckoutUiPlanIdResponseMock = (overrideResponse: Partial<Extract<CheckoutUIResponse, object>> = {}): CheckoutUIResponse => ({expires_at: faker.date.past().toISOString().slice(0, 19) + 'Z', fragments: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({css: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), html: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), link: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), metadata: faker.helpers.arrayElement([{}, undefined]), script: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), type: faker.string.alpha({length: {min: 10, max: 20}})})), metadata: faker.helpers.arrayElement([{}, undefined]), session_id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getGetApiAccountBillingCreditsResponseMock = (overrideResponse: Partial<Extract<UserCreditsListResponse, object>> = {}): UserCreditsListResponse => ({data: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({amount: {}, created_at: faker.date.past().toISOString().slice(0, 19) + 'Z', description: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), direction: faker.string.alpha({length: {min: 10, max: 20}}), id: Array.from({ length: faker.number.int({min: 16, max: 16}) }, (_, i) => i + 1).map(() => (faker.number.int())), type: faker.string.alpha({length: {min: 10, max: 20}})})), total: faker.number.int(), ...overrideResponse})
+
+export const getPostApiAccountBillingCustomerPortalResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getPostApiAccountBillingManagementResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getGetApiAccountBillingManagementCapabilitiesResponseMock = (overrideResponse: Partial<Extract<ManagementCapabilitiesResponse, object>> = {}): ManagementCapabilitiesResponse => ({admin_operations: {
+        [faker.string.alphanumeric(5)]: faker.datatype.boolean()
+      }, management_mode: faker.string.alpha({length: {min: 10, max: 20}}), operations: {
+        [faker.string.alphanumeric(5)]: faker.datatype.boolean()
+      }, ...overrideResponse})
+
+export const getPostApiAccountBillingPauseResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getPostApiAccountBillingResumeResponseMock = (overrideResponse: Partial<Extract<ManagementResultResponse, object>> = {}): ManagementResultResponse => ({action: faker.string.alpha({length: {min: 10, max: 20}}), api_endpoint: faker.helpers.arrayElement([{method: faker.string.alpha({length: {min: 10, max: 20}}), path: faker.string.alpha({length: {min: 10, max: 20}})}, undefined]), can_abort: faker.datatype.boolean(), confirmation_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), effective_time: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), error_message: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), requires_confirmation: faker.datatype.boolean(), status: faker.string.alpha({length: {min: 10, max: 20}}), url: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), ...overrideResponse})
+
+export const getGetApiAccountBillingSubscriptionResponseMock = (overrideResponse: Partial<Extract<SubscriptionStatusResponse, object>> = {}): SubscriptionStatusResponse => ({created_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), gateway_type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), is_subscribed: faker.datatype.boolean(), paused_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), pricing_plan_period_id: faker.helpers.arrayElement([faker.number.int(), undefined]), updated_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), will_cancel_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), ...overrideResponse})
+
+export const getPostApiAccountBillingWebhooksGatewayTypeResponseMock = (overrideResponse: Partial<Extract<ErrorResponse, object>> = {}): ErrorResponse => ({error: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getGetApiBillingGatewaysResponseMock = (): GatewayListResponse => (Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({abilities: {checkout: faker.datatype.boolean(), customer_portal: faker.datatype.boolean(), session_status: faker.datatype.boolean()}, description: faker.string.alpha({length: {min: 10, max: 20}}), id: faker.string.alpha({length: {min: 10, max: 20}}), is_active: faker.datatype.boolean(), logo_url: faker.string.alpha({length: {min: 10, max: 20}}), name: faker.string.alpha({length: {min: 10, max: 20}})})))
+
+export const getGetApiBillingPlansResponseMock = (overrideResponse: Partial<Extract<PublicPricingPlansListResponse, object>> = {}): PublicPricingPlansListResponse => ({data: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({currency: faker.string.alpha({length: {min: 10, max: 20}}), description: faker.string.alpha({length: {min: 10, max: 20}}), features: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => (faker.string.alpha({length: {min: 10, max: 20}}))), id: faker.number.int(), name: faker.string.alpha({length: {min: 10, max: 20}}), pricing_periods: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({cadence: faker.string.alpha({length: {min: 10, max: 20}}), id: faker.number.int(), price_usd: faker.number.float({fractionDigits: 2}), quota_plan_id: faker.number.int(), rolling_days: faker.helpers.arrayElement([faker.number.int(), undefined])}))})), total: faker.number.int(), ...overrideResponse})
+
+
+export const getGetApiAccountBillingBalanceMockHandler = (overrideResponse?: BalanceResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<BalanceResponse> | BalanceResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/balance', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountBillingBalanceResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingCancelMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/cancel', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingCancelResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingCancelAbortMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/cancel/abort', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingCancelAbortResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingChangePlanMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/change-plan', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingChangePlanResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountBillingCheckoutSessionSessionIdStatusMockHandler = (overrideResponse?: CheckoutSessionStatusResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<CheckoutSessionStatusResponse> | CheckoutSessionStatusResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/checkout/session/:sessionId/status', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountBillingCheckoutSessionSessionIdStatusResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountBillingCheckoutUiPlanIdMockHandler = (overrideResponse?: CheckoutUIResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<CheckoutUIResponse> | CheckoutUIResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/checkout/ui/:planId', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountBillingCheckoutUiPlanIdResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountBillingCreditsMockHandler = (overrideResponse?: UserCreditsListResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserCreditsListResponse> | UserCreditsListResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/credits', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountBillingCreditsResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingCustomerPortalMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/customer-portal', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingCustomerPortalResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingManagementMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/management', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingManagementResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountBillingManagementCapabilitiesMockHandler = (overrideResponse?: ManagementCapabilitiesResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<ManagementCapabilitiesResponse> | ManagementCapabilitiesResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/management/capabilities', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountBillingManagementCapabilitiesResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingPauseMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/pause', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingPauseResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingResumeMockHandler = (overrideResponse?: ManagementResultResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ManagementResultResponse> | ManagementResultResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/resume', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingResumeResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountBillingSubscriptionMockHandler = (overrideResponse?: SubscriptionStatusResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<SubscriptionStatusResponse> | SubscriptionStatusResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/subscription', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountBillingSubscriptionResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountBillingSubscriptionEventsMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/billing/subscription/events', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountBillingWebhooksGatewayTypeMockHandler = (overrideResponse?: ErrorResponse | void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ErrorResponse | void> | ErrorResponse | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/billing/webhooks/:gatewayType', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+  const resolvedBody = overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountBillingWebhooksGatewayTypeResponseMock();
+    return resolvedBody === undefined
+      ? new HttpResponse(null, { status: 204 })
+      : HttpResponse.json(resolvedBody, { status: 200 })
+  }, options)
+}
+
+export const getGetApiBillingGatewaysMockHandler = (overrideResponse?: GatewayListResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<GatewayListResponse> | GatewayListResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/billing/gateways', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiBillingGatewaysResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiBillingGatewaysIdLogoMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.get('*/api/billing/gateways/:id/logo', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiBillingPlansMockHandler = (overrideResponse?: PublicPricingPlansListResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<PublicPricingPlansListResponse> | PublicPricingPlansListResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/billing/plans', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiBillingPlansResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+export const getBillingMock = () => [
+  getGetApiAccountBillingBalanceMockHandler(),
+  getPostApiAccountBillingCancelMockHandler(),
+  getPostApiAccountBillingCancelAbortMockHandler(),
+  getPostApiAccountBillingChangePlanMockHandler(),
+  getGetApiAccountBillingCheckoutSessionSessionIdStatusMockHandler(),
+  getGetApiAccountBillingCheckoutUiPlanIdMockHandler(),
+  getGetApiAccountBillingCreditsMockHandler(),
+  getPostApiAccountBillingCustomerPortalMockHandler(),
+  getPostApiAccountBillingManagementMockHandler(),
+  getGetApiAccountBillingManagementCapabilitiesMockHandler(),
+  getPostApiAccountBillingPauseMockHandler(),
+  getPostApiAccountBillingResumeMockHandler(),
+  getGetApiAccountBillingSubscriptionMockHandler(),
+  getGetApiAccountBillingSubscriptionEventsMockHandler(),
+  getPostApiAccountBillingWebhooksGatewayTypeMockHandler(),
+  getGetApiBillingGatewaysMockHandler(),
+  getGetApiBillingGatewaysIdLogoMockHandler(),
+  getGetApiBillingPlansMockHandler()
+]

--- a/libs/portal-sdk/src/account/generated/default.ts
+++ b/libs/portal-sdk/src/account/generated/default.ts
@@ -41,6 +41,19 @@ import type {
   VerifyEmailRequest
 } from './accountAPI.schemas';
 
+import {
+  faker
+} from '@faker-js/faker';
+
+import {
+  HttpResponse,
+  delay,
+  http
+} from 'msw';
+import type {
+  RequestHandlerOptions
+} from 'msw';
+
 
 
 export type deleteApiAccountResponse200 = {
@@ -1937,3 +1950,390 @@ export const getApiUploadLimit = async ( options?: RequestInit): Promise<getApiU
 }
 
 
+
+
+export const getGetApiAccountResponseMock = (overrideResponse: Partial<Extract<AccountInfoResponse, object>> = {}): AccountInfoResponse => ({avatar: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), created_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), email: faker.string.alpha({length: {min: 10, max: 20}}), first_name: faker.string.alpha({length: {min: 10, max: 20}}), id: faker.number.int(), last_name: faker.string.alpha({length: {min: 10, max: 20}}), otp: faker.datatype.boolean(), verified: faker.datatype.boolean(), ...overrideResponse})
+
+export const getPostApiAccountAvatarResponseMock = (overrideResponse: Partial<Extract<ErrorResponse, object>> = {}): ErrorResponse => ({error: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getGetApiAccountKeysResponseMock = (overrideResponse: Partial<Extract<APIKeyListResponse, object>> = {}): APIKeyListResponse => ({data: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({created_at: faker.date.past().toISOString().slice(0, 19) + 'Z', name: faker.string.alpha({length: {min: 10, max: 20}}), uuid: faker.string.uuid()})), total: faker.number.int(), ...overrideResponse})
+
+export const getPostApiAccountKeysResponseMock = (overrideResponse: Partial<Extract<CreateAPIKeyResponse, object>> = {}): CreateAPIKeyResponse => ({name: faker.string.alpha({length: {min: 10, max: 20}}), token: faker.string.alpha({length: {min: 10, max: 20}}), uuid: faker.string.uuid(), ...overrideResponse})
+
+export const getGetApiAccountPermissionsResponseMock = (overrideResponse: Partial<Extract<AccountPermissionsResponse, object>> = {}): AccountPermissionsResponse => ({model: {matchers: {key: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})}, policy_definition: {key: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})}, policy_effect: {key: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})}, request_definition: {key: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})}, role_definition: {key: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})}}, permissions: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({act: faker.string.alpha({length: {min: 10, max: 20}}), dom: faker.string.alpha({length: {min: 10, max: 20}}), obj: faker.string.alpha({length: {min: 10, max: 20}}), sub: faker.string.alpha({length: {min: 10, max: 20}})})), ...overrideResponse})
+
+export const getGetApiAccountQuotaHistoryResponseMock = (overrideResponse: Partial<Extract<QuotaHistoryResponse, object>> = {}): QuotaHistoryResponse => ({points: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({bytes: faker.number.int(), date: faker.string.alpha({length: {min: 10, max: 20}})})), user_id: faker.number.int(), ...overrideResponse})
+
+export const getPostApiAuthKeyResponseMock = (overrideResponse: Partial<Extract<LoginResponse, object>> = {}): LoginResponse => ({otp: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]), token: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getPostApiAuthLoginResponseMock = (overrideResponse: Partial<Extract<LoginResponse, object>> = {}): LoginResponse => ({otp: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]), token: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getPostApiAuthOtpDisableResponseMock = (overrideResponse: Partial<Extract<ErrorResponse, object>> = {}): ErrorResponse => ({error: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getPostApiAuthOtpGenerateResponseMock = (overrideResponse: Partial<Extract<OTPGenerateResponse, object>> = {}): OTPGenerateResponse => ({otp: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getPostApiAuthOtpVerifyResponseMock = (overrideResponse: Partial<Extract<ErrorResponse, object>> = {}): ErrorResponse => ({error: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getPostApiAuthPingResponseMock = (overrideResponse: Partial<Extract<PongResponse, object>> = {}): PongResponse => ({ping: faker.string.alpha({length: {min: 10, max: 20}}), token: faker.string.alpha({length: {min: 10, max: 20}}), ...overrideResponse})
+
+export const getGetApiOperationsResponseMock = (overrideResponse: Partial<Extract<OperationListItemResponse, object>> = {}): OperationListItemResponse => ({data: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({cid: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), current_step: faker.helpers.arrayElement([faker.number.int(), undefined]), error: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), estimated_completion_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), id: faker.number.int(), operation: faker.string.alpha({length: {min: 10, max: 20}}), operation_display_name: faker.string.alpha({length: {min: 10, max: 20}}), progress_percent: faker.number.float({fractionDigits: 2}), protocol: faker.string.alpha({length: {min: 10, max: 20}}), protocol_display_name: faker.string.alpha({length: {min: 10, max: 20}}), started_at: faker.date.past().toISOString().slice(0, 19) + 'Z', status: faker.string.alpha({length: {min: 10, max: 20}}), status_display_name: faker.string.alpha({length: {min: 10, max: 20}}), status_message: faker.string.alpha({length: {min: 10, max: 20}}), total_steps: faker.helpers.arrayElement([faker.number.int(), undefined]), updated_at: faker.date.past().toISOString().slice(0, 19) + 'Z'})), total: faker.number.int(), ...overrideResponse})
+
+export const getGetApiOperationsIdResponseMock = (overrideResponse: Partial<Extract<OperationDetailResponse, object>> = {}): OperationDetailResponse => ({cid: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), current_step: faker.helpers.arrayElement([faker.number.int(), undefined]), error: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), estimated_completion_at: faker.helpers.arrayElement([faker.date.past().toISOString().slice(0, 19) + 'Z', undefined]), id: faker.number.int(), operation: faker.string.alpha({length: {min: 10, max: 20}}), operation_display_name: faker.string.alpha({length: {min: 10, max: 20}}), progress_percent: faker.number.float({fractionDigits: 2}), protocol: faker.string.alpha({length: {min: 10, max: 20}}), protocol_display_name: faker.string.alpha({length: {min: 10, max: 20}}), started_at: faker.date.past().toISOString().slice(0, 19) + 'Z', status: faker.string.alpha({length: {min: 10, max: 20}}), status_display_name: faker.string.alpha({length: {min: 10, max: 20}}), status_message: faker.string.alpha({length: {min: 10, max: 20}}), total_steps: faker.helpers.arrayElement([faker.number.int(), undefined]), updated_at: faker.date.past().toISOString().slice(0, 19) + 'Z', ...overrideResponse})
+
+export const getGetApiOperationsFiltersResponseMock = (overrideResponse: Partial<Extract<OperationFiltersResponseResponse, object>> = {}): OperationFiltersResponseResponse => ({data: {data: {operations: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({description: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), name: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})})), protocols: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({description: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), name: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})})), statuses: Array.from({ length: faker.number.int({min: 1, max: 10}) }, (_, i) => i + 1).map(() => ({description: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), name: faker.string.alpha({length: {min: 10, max: 20}}), value: faker.string.alpha({length: {min: 10, max: 20}})}))}}, total: faker.number.int(), ...overrideResponse})
+
+export const getGetApiUploadLimitResponseMock = (overrideResponse: Partial<Extract<UploadLimitResponse, object>> = {}): UploadLimitResponse => ({limit: faker.number.int(), ...overrideResponse})
+
+
+export const getDeleteApiAccountMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.delete>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.delete('*/api/account', async (info: Parameters<Parameters<typeof http.delete>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountMockHandler = (overrideResponse?: AccountInfoResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<AccountInfoResponse> | AccountInfoResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPatchApiAccountMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.patch>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.patch('*/api/account', async (info: Parameters<Parameters<typeof http.patch>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountAvatarMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/avatar', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountAvatarMockHandler = (overrideResponse?: ErrorResponse | void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ErrorResponse | void> | ErrorResponse | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/avatar', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+  const resolvedBody = overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountAvatarResponseMock();
+    return resolvedBody === undefined
+      ? new HttpResponse(null, { status: 204 })
+      : HttpResponse.json(resolvedBody, { status: 200 })
+  }, options)
+}
+
+export const getGetApiAccountKeysMockHandler = (overrideResponse?: APIKeyListResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<APIKeyListResponse> | APIKeyListResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/keys', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountKeysResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountKeysMockHandler = (overrideResponse?: CreateAPIKeyResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<CreateAPIKeyResponse> | CreateAPIKeyResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/keys', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAccountKeysResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getDeleteApiAccountKeysKeyIDMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.delete>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.delete('*/api/account/keys/:keyID', async (info: Parameters<Parameters<typeof http.delete>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountPasswordResetConfirmMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/password-reset/confirm', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountPasswordResetRequestMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/password-reset/request', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountPermissionsMockHandler = (overrideResponse?: AccountPermissionsResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<AccountPermissionsResponse> | AccountPermissionsResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/permissions', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountPermissionsResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiAccountQuotaHistoryMockHandler = (overrideResponse?: QuotaHistoryResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<QuotaHistoryResponse> | QuotaHistoryResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/quota/history', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountQuotaHistoryResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountUpdateEmailMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/update-email', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountUpdatePasswordMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/update-password', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountVerifyEmailMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/verify-email', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAccountVerifyEmailResendMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/account/verify-email/resend', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthKeyMockHandler = (overrideResponse?: LoginResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<LoginResponse> | LoginResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/key', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAuthKeyResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthLoginMockHandler = (overrideResponse?: LoginResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<LoginResponse> | LoginResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/login', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAuthLoginResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthLogoutMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/logout', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthOtpDisableMockHandler = (overrideResponse?: ErrorResponse | void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ErrorResponse | void> | ErrorResponse | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/otp/disable', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+  const resolvedBody = overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAuthOtpDisableResponseMock();
+    return resolvedBody === undefined
+      ? new HttpResponse(null, { status: 204 })
+      : HttpResponse.json(resolvedBody, { status: 200 })
+  }, options)
+}
+
+export const getPostApiAuthOtpGenerateMockHandler = (overrideResponse?: OTPGenerateResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<OTPGenerateResponse> | OTPGenerateResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/otp/generate', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAuthOtpGenerateResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthOtpValidateMockHandler = (overrideResponse?: unknown | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<unknown> | unknown), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/otp/validate', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthOtpVerifyMockHandler = (overrideResponse?: ErrorResponse | void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<ErrorResponse | void> | ErrorResponse | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/otp/verify', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+  const resolvedBody = overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAuthOtpVerifyResponseMock();
+    return resolvedBody === undefined
+      ? new HttpResponse(null, { status: 204 })
+      : HttpResponse.json(resolvedBody, { status: 200 })
+  }, options)
+}
+
+export const getPostApiAuthPingMockHandler = (overrideResponse?: PongResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<PongResponse> | PongResponse), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/ping', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getPostApiAuthPingResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostApiAuthRegisterMockHandler = (overrideResponse?: void | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<void> | void), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/register', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiOperationsMockHandler = (overrideResponse?: OperationListItemResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<OperationListItemResponse> | OperationListItemResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/operations', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiOperationsResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiOperationsIdMockHandler = (overrideResponse?: OperationDetailResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<OperationDetailResponse> | OperationDetailResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/operations/:id', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiOperationsIdResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiOperationsFiltersMockHandler = (overrideResponse?: OperationFiltersResponseResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<OperationFiltersResponseResponse> | OperationFiltersResponseResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/operations/filters', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiOperationsFiltersResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+
+export const getGetApiUploadLimitMockHandler = (overrideResponse?: UploadLimitResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UploadLimitResponse> | UploadLimitResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/upload-limit', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiUploadLimitResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+export const getDefaultMock = () => [
+  getDeleteApiAccountMockHandler(),
+  getGetApiAccountMockHandler(),
+  getPatchApiAccountMockHandler(),
+  getGetApiAccountAvatarMockHandler(),
+  getPostApiAccountAvatarMockHandler(),
+  getGetApiAccountKeysMockHandler(),
+  getPostApiAccountKeysMockHandler(),
+  getDeleteApiAccountKeysKeyIDMockHandler(),
+  getPostApiAccountPasswordResetConfirmMockHandler(),
+  getPostApiAccountPasswordResetRequestMockHandler(),
+  getGetApiAccountPermissionsMockHandler(),
+  getGetApiAccountQuotaHistoryMockHandler(),
+  getPostApiAccountUpdateEmailMockHandler(),
+  getPostApiAccountUpdatePasswordMockHandler(),
+  getPostApiAccountVerifyEmailMockHandler(),
+  getPostApiAccountVerifyEmailResendMockHandler(),
+  getPostApiAuthKeyMockHandler(),
+  getPostApiAuthLoginMockHandler(),
+  getPostApiAuthLogoutMockHandler(),
+  getPostApiAuthOtpDisableMockHandler(),
+  getPostApiAuthOtpGenerateMockHandler(),
+  getPostApiAuthOtpValidateMockHandler(),
+  getPostApiAuthOtpVerifyMockHandler(),
+  getPostApiAuthPingMockHandler(),
+  getPostApiAuthRegisterMockHandler(),
+  getGetApiOperationsMockHandler(),
+  getGetApiOperationsIdMockHandler(),
+  getGetApiOperationsFiltersMockHandler(),
+  getGetApiUploadLimitMockHandler()
+]

--- a/libs/portal-sdk/src/account/generated/quota.ts
+++ b/libs/portal-sdk/src/account/generated/quota.ts
@@ -10,6 +10,19 @@ import type {
   QuotaStatusResponse
 } from './accountAPI.schemas';
 
+import {
+  faker
+} from '@faker-js/faker';
+
+import {
+  HttpResponse,
+  delay,
+  http
+} from 'msw';
+import type {
+  RequestHandlerOptions
+} from 'msw';
+
 
 
 export type getApiAccountQuotaResponse200 = {
@@ -72,3 +85,22 @@ export const getApiAccountQuota = async ( options?: RequestInit): Promise<getApi
 }
 
 
+
+
+export const getGetApiAccountQuotaResponseMock = (overrideResponse: Partial<Extract<QuotaStatusResponse, object>> = {}): QuotaStatusResponse => ({download: {limit: faker.helpers.arrayElement([faker.number.int(), undefined]), percentage: faker.number.int(), remaining: faker.helpers.arrayElement([faker.number.int(), undefined]), reserved: faker.helpers.arrayElement([faker.number.int(), undefined]), threshold: faker.helpers.arrayElement([faker.number.int(), undefined]), used: faker.number.int(), window: faker.helpers.arrayElement([{duration: faker.helpers.arrayElement([faker.number.int(), undefined]), end_date: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), start_date: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), timezone: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), type: faker.string.alpha({length: {min: 10, max: 20}})}, undefined])}, storage: {limit: faker.helpers.arrayElement([faker.number.int(), undefined]), percentage: faker.number.int(), remaining: faker.helpers.arrayElement([faker.number.int(), undefined]), reserved: faker.helpers.arrayElement([faker.number.int(), undefined]), threshold: faker.helpers.arrayElement([faker.number.int(), undefined]), used: faker.number.int(), window: faker.helpers.arrayElement([{duration: faker.helpers.arrayElement([faker.number.int(), undefined]), end_date: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), start_date: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), timezone: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), type: faker.string.alpha({length: {min: 10, max: 20}})}, undefined])}, upload: {limit: faker.helpers.arrayElement([faker.number.int(), undefined]), percentage: faker.number.int(), remaining: faker.helpers.arrayElement([faker.number.int(), undefined]), reserved: faker.helpers.arrayElement([faker.number.int(), undefined]), threshold: faker.helpers.arrayElement([faker.number.int(), undefined]), used: faker.number.int(), window: faker.helpers.arrayElement([{duration: faker.helpers.arrayElement([faker.number.int(), undefined]), end_date: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), start_date: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), timezone: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), undefined]), type: faker.string.alpha({length: {min: 10, max: 20}})}, undefined])}, ...overrideResponse})
+
+
+export const getGetApiAccountQuotaMockHandler = (overrideResponse?: QuotaStatusResponse | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<QuotaStatusResponse> | QuotaStatusResponse), options?: RequestHandlerOptions) => {
+  return http.get('*/api/account/quota', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+
+
+    return HttpResponse.json(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getGetApiAccountQuotaResponseMock(),
+      { status: 200
+      })
+  }, options)
+}
+export const getQuotaMock = () => [
+  getGetApiAccountQuotaMockHandler()
+]

--- a/libs/portal-sdk/src/account/mocks.ts
+++ b/libs/portal-sdk/src/account/mocks.ts
@@ -1,0 +1,2 @@
+export * from './generated/quota';
+export * from './generated/default';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build:portal-plugin-billing": "turbo build --filter=@lumeweb/portal-plugin-billing",
     "e2e:portal-plugin-dashboard": "turbo run e2e --filter=@lumeweb/portal-plugin-dashboard",
     "build:portal-plugin-core": "turbo build --filter=@lumeweb/portal-plugin-core",
-    "build:portal-plugin-ipfs": "turbo build --filter=@lumeweb/portal-plugin-ipfs"
+    "build:portal-plugin-ipfs": "turbo build --filter=@lumeweb/portal-plugin-ipfs",
+    "build:portal-plugin-quota": "turbo build --filter=@lumeweb/portal-plugin-quota"
   },
   "private": true,
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1927,6 +1927,67 @@ importers:
         specifier: workspace:*
         version: link:../tsdown-config
 
+  libs/portal-plugin-quota:
+    dependencies:
+      '@lumeweb/advanced-rest-provider':
+        specifier: workspace:*
+        version: link:../advanced-rest
+      '@lumeweb/portal-framework-auth':
+        specifier: workspace:*
+        version: link:../portal-framework-auth
+      '@lumeweb/portal-framework-core':
+        specifier: workspace:*
+        version: link:../portal-framework-core
+      '@lumeweb/portal-framework-ui':
+        specifier: workspace:*
+        version: link:../portal-framework-ui
+      '@lumeweb/portal-framework-ui-core':
+        specifier: workspace:*
+        version: link:../portal-framework-ui-core
+      '@lumeweb/portal-sdk':
+        specifier: workspace:*
+        version: link:../portal-sdk
+      '@refinedev/core':
+        specifier: 'catalog:'
+        version: 5.0.12(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.577.0(react@19.2.6)
+      nanoevents:
+        specifier: 'catalog:'
+        version: 9.1.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      react-router:
+        specifier: 'catalog:'
+        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    devDependencies:
+      '@mswjs/interceptors':
+        specifier: 'catalog:'
+        version: 0.41.9
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      msw:
+        specifier: 'catalog:'
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: catalog:framework
+        version: 8.0.8(@types/node@25.9.1)(@vitejs/devtools@0.1.22)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.48.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@types/node@25.9.1)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.8)
+
   libs/portal-plugin-template:
     dependencies:
       '@lumeweb/portal-framework-core':
@@ -1967,15 +2028,21 @@ importers:
         specifier: workspace:*
         version: link:../query-builder
     devDependencies:
+      '@faker-js/faker':
+        specifier: ^9.0.0
+        version: 9.9.0
       '@lumeweb/tsdown-config':
         specifier: workspace:*
         version: link:../tsdown-config
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
+      msw:
+        specifier: 'catalog:'
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       orval:
         specifier: 'catalog:'
-        version: 8.10.0(@faker-js/faker@10.4.0)(prettier@3.8.3)(typescript@6.0.3)
+        version: 8.10.0(@faker-js/faker@9.9.0)(prettier@3.8.3)(typescript@6.0.3)
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
@@ -3361,6 +3428,10 @@ packages:
   '@faker-js/faker@10.4.0':
     resolution: {integrity: sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
+
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -7079,16 +7150,8 @@ packages:
   '@tanstack/query-core@5.100.10':
     resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
 
-  '@tanstack/query-core@5.100.5':
-    resolution: {integrity: sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==}
-
   '@tanstack/react-query@5.100.10':
     resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
-    peerDependencies:
-      react: ^18 || ^19
-
-  '@tanstack/react-query@5.100.5':
-    resolution: {integrity: sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -12597,11 +12660,6 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
-    peerDependencies:
-      react: ^19.2.5
-
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -12760,10 +12818,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -16262,6 +16316,8 @@ snapshots:
 
   '@faker-js/faker@10.4.0': {}
 
+  '@faker-js/faker@9.9.0': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -17787,12 +17843,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
-    dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.2.14
-      react: 19.2.5
-
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -18199,9 +18249,25 @@ snapshots:
       - supports-color
       - typescript
 
+  '@orval/angular@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
   '@orval/axios@8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@orval/core': 8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
+  '@orval/axios@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@faker-js/faker'
       - supports-color
@@ -18226,9 +18292,37 @@ snapshots:
       - supports-color
       - typescript
 
+  '@orval/core@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@scalar/openapi-types': 0.8.0
+      acorn: 8.16.0
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      esbuild: 0.27.7
+      esutils: 2.0.3
+      fs-extra: 11.3.4
+      globby: 16.1.0
+      jiti: 2.6.1
+      remeda: 2.33.7
+      typedoc: 0.28.19(typescript@6.0.3)
+    optionalDependencies:
+      '@faker-js/faker': 9.9.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@orval/fetch@8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@orval/core': 8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)
+      '@scalar/openapi-types': 0.8.0
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
+  '@orval/fetch@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
       '@scalar/openapi-types': 0.8.0
     transitivePeerDependencies:
       - '@faker-js/faker'
@@ -18246,6 +18340,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@orval/hono@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/zod': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      fs-extra: 11.3.4
+      remeda: 2.33.7
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
   '@orval/mcp@8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@orval/core': 8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)
@@ -18256,9 +18361,28 @@ snapshots:
       - supports-color
       - typescript
 
+  '@orval/mcp@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/fetch': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/zod': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
   '@orval/mock@8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@orval/core': 8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)
+      remeda: 2.33.7
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
+  '@orval/mock@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
       remeda: 2.33.7
     transitivePeerDependencies:
       - '@faker-js/faker'
@@ -18275,9 +18399,28 @@ snapshots:
       - supports-color
       - typescript
 
+  '@orval/query@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/fetch': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      remeda: 2.33.7
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
   '@orval/solid-start@8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@orval/core': 8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)
+      '@scalar/openapi-types': 0.8.0
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
+  '@orval/solid-start@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
       '@scalar/openapi-types': 0.8.0
     transitivePeerDependencies:
       - '@faker-js/faker'
@@ -18293,9 +18436,27 @@ snapshots:
       - supports-color
       - typescript
 
+  '@orval/swr@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/fetch': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
   '@orval/zod@8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@orval/core': 8.10.0(@faker-js/faker@10.4.0)(typescript@6.0.3)
+      remeda: 2.33.7
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
+  '@orval/zod@8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)':
+    dependencies:
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
       remeda: 2.33.7
     transitivePeerDependencies:
       - '@faker-js/faker'
@@ -19826,7 +19987,7 @@ snapshots:
       lodash-es: 4.18.1
       papaparse: 5.5.3(patch_hash=8db42de1f1871890a205b993db193bd7914e8201801637ba4b6247c7604f7c56)
       pluralize: 8.0.0(patch_hash=88650615c62a180c406201cd54b23afb592a6a678db498f8b1a730f85ca868d2)
-      qs: 6.14.0
+      qs: 6.15.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       tslib: 2.8.1
@@ -19835,7 +19996,7 @@ snapshots:
   '@refinedev/devtools-internal@2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@refinedev/devtools-shared': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-query': 5.100.5(react@19.2.6)
+      '@tanstack/react-query': 5.100.10(react@19.2.6)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       error-stack-parser: 2.1.4
@@ -19844,7 +20005,7 @@ snapshots:
 
   '@refinedev/devtools-shared@2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/react-query': 5.100.5(react@19.2.6)
+      '@tanstack/react-query': 5.100.10(react@19.2.6)
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       error-stack-parser: 2.1.4
@@ -20366,12 +20527,12 @@ snapshots:
 
   '@storybook/addon-docs@8.6.14(@types/react@19.2.14)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/blocks': 8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@storybook/blocks': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/csf-plugin': 8.6.14(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       storybook: 10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -20440,15 +20601,6 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/blocks@8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
-    dependencies:
-      '@storybook/icons': 1.4.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      storybook: 10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   '@storybook/blocks@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@storybook/icons': 1.4.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -20485,11 +20637,6 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.4.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   '@storybook/icons@1.4.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -20518,10 +20665,10 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       storybook: 10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@storybook/react-dom-shim@8.6.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
       storybook: 10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   '@storybook/react-vite@10.3.6(esbuild@0.27.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.2)(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.8)':
@@ -20742,16 +20889,9 @@ snapshots:
 
   '@tanstack/query-core@5.100.10': {}
 
-  '@tanstack/query-core@5.100.5': {}
-
   '@tanstack/react-query@5.100.10(react@19.2.6)':
     dependencies:
       '@tanstack/query-core': 5.100.10
-      react: 19.2.6
-
-  '@tanstack/react-query@5.100.5(react@19.2.6)':
-    dependencies:
-      '@tanstack/query-core': 5.100.5
       react: 19.2.6
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -21109,7 +21249,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
 
   '@types/stack-utils@2.0.3': {}
 
@@ -27347,6 +27487,44 @@ snapshots:
       - supports-color
       - typescript
 
+  orval@8.10.0(@faker-js/faker@9.9.0)(prettier@3.8.3)(typescript@6.0.3):
+    dependencies:
+      '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
+      '@orval/angular': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/axios': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/core': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/fetch': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/hono': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/mcp': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/mock': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/query': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/solid-start': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/swr': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@orval/zod': 8.10.0(@faker-js/faker@9.9.0)(typescript@6.0.3)
+      '@scalar/json-magic': 0.12.12
+      '@scalar/openapi-parser': 0.25.12
+      '@scalar/openapi-types': 0.8.0
+      chokidar: 5.0.0
+      commander: 14.0.3
+      enquirer: 2.4.1
+      execa: 9.6.1
+      find-up: 8.0.0
+      fs-extra: 11.3.4
+      get-tsconfig: 4.14.0
+      jiti: 2.6.1
+      js-yaml: 4.1.1
+      remeda: 2.33.7
+      string-argv: 0.3.2
+      typedoc: 0.28.19(typescript@6.0.3)
+      typedoc-plugin-coverage: 4.0.3(typedoc@0.28.19(typescript@6.0.3))
+      typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@faker-js/faker'
+      - supports-color
+      - typescript
+
   otpauth@9.5.1:
     dependencies:
       '@noble/hashes': 2.2.0
@@ -28007,11 +28185,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@19.2.5(react@19.2.5):
-    dependencies:
-      react: 19.2.5
-      scheduler: 0.27.0
-
   react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -28216,8 +28389,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
-
-  react@19.2.5: {}
 
   react@19.2.6: {}
 


### PR DESCRIPTION
- Add AccountApi.quota() and quotaHistory() convenience wrappers
- Enable Orval MSW mock generation (mock.type: msw) for account endpoints
- Add account/mocks.ts barrel for Orval-generated mock handlers
- Add ./mocks package export for dedicated @lumeweb/portal-sdk/mocks import
- Add unit tests for quota() and quotaHistory() SDK methods
- Regenerate account API (billing, default, quota) with MSW support

---

<!-- kody-pr-summary:start -->
This PR adds quota-related API methods to the portal SDK, enables MSW mock generation, and creates a centralized mocks export.

**Key changes:**

- **AccountApi quota methods**: Added `quota()` method to fetch current quota status (download, storage, upload usage/limits) and `quotaHistory()` method to retrieve historical quota data with optional filtering by date range and type (`start_date`, `end_date`, `type` query parameters).

- **MSW mock generation**: Enabled Orval's MSW mock generation in the configuration, which auto-generates mock response factories and HTTP request handlers for all account API endpoints (billing, default, and quota). Each endpoint gets a response mock function (e.g., `getGetApiAccountQuotaResponseMock`) and a mock handler (e.g., `getGetApiAccountQuotaMockHandler`), along with aggregate mock arrays (`getQuotaMock`, `getDefaultMock`, `getBillingMock`).

- **Centralized mocks export**: Added `account/mocks.ts` that re-exports all generated mocks from the quota and default modules for convenient consumption.

- **Tests**: Added comprehensive test coverage for both `quota()` and `quotaHistory()` methods, including success responses, error handling, and query parameter construction.
<!-- kody-pr-summary:end -->