### PR TITLE
feat(portal-plugin-quota): add dashboard widget, useQuota hook, and Refine capability

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -58,6 +58,10 @@ changelog = "libs/portal-plugin-core/CHANGELOG.md"
 versioned_files = ["libs/portal-plugin-dashboard/package.json"]
 changelog = "libs/portal-plugin-dashboard/CHANGELOG.md"
 
+[packages."@lumeweb/portal-plugin-quota"]
+versioned_files = ["libs/portal-plugin-quota/package.json"]
+changelog = "libs/portal-plugin-quota/CHANGELOG.md"
+
 [packages."@lumeweb/portal-plugin-ipfs"]
 versioned_files = ["libs/portal-plugin-ipfs/package.json"]
 changelog = "libs/portal-plugin-ipfs/CHANGELOG.md"

--- a/libs/portal-plugin-quota/README.md
+++ b/libs/portal-plugin-quota/README.md
@@ -1,0 +1,39 @@
+# `@lumeweb/portal-plugin-quota`
+
+Dashboard widget plugin that displays storage, upload, and download quota usage as Tailwind progress bars.
+
+## What It Does
+
+Registers a `QuotaWidget` in the `dashboard:header` area showing three usage bars:
+
+- **Storage** — bytes used vs limit
+- **Upload** — bytes used vs limit
+- **Download** — bytes used vs limit
+
+Each bar changes color based on utilization: default under 70%, warning (yellow) at 70–90%, destructive (red) above 90%. When a quota type has no limit, "Unlimited" is displayed instead of a bar.
+
+Data is fetched through Refine's `useCustom` hook hitting the `/account/quota` endpoint via the `account` data provider.
+
+## Dependencies
+
+- `core:dashboard` — provides the `dashboard:header` widget area and API URL
+
+## SDK
+
+Convenience wrappers are available in `@lumeweb/portal-sdk`:
+
+```ts
+import { AccountApi } from "@lumeweb/portal-sdk";
+
+const api = new AccountApi(baseUrl);
+const status = await api.quota();        // QuotaStatusResponse
+const history = await api.quotaHistory(); // QuotaHistoryResponse
+```
+
+### MSW Mocks
+
+Mock handlers for testing are exported from the dedicated subpath:
+
+```ts
+import { getGetApiAccountQuotaMockHandler } from "@lumeweb/portal-sdk/mocks";
+```

--- a/libs/portal-plugin-quota/package.json
+++ b/libs/portal-plugin-quota/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@lumeweb/portal-plugin-quota",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "lib-dist/index.js",
+  "types": "lib-dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib-dist/esm/index.d.ts",
+      "import": "./lib-dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "echo 'Build skipped' && exit 0",
+    "build:lib": "tsdown",
+    "e2e": "dotenv -- run-s build e2e:playwright",
+    "e2e:playwright": "playwright test",
+    "e2e:playwright:ui": "playwright test --ui",
+    "serve": "vite preview",
+    "lint": "oxlint ."
+  },
+  "dependencies": {
+    "@lumeweb/advanced-rest-provider": "workspace:*",
+    "@lumeweb/portal-framework-auth": "workspace:*",
+    "@lumeweb/portal-framework-core": "workspace:*",
+    "@lumeweb/portal-framework-ui": "workspace:*",
+    "@lumeweb/portal-framework-ui-core": "workspace:*",
+    "@lumeweb/portal-sdk": "workspace:*",
+    "@refinedev/core": "catalog:",
+    "lucide-react": "catalog:",
+    "nanoevents": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router": "catalog:"
+  },
+  "devDependencies": {
+    "@mswjs/interceptors": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "msw": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:framework",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LumeWeb/web"
+  }
+}

--- a/libs/portal-plugin-quota/plugin.config.ts
+++ b/libs/portal-plugin-quota/plugin.config.ts
@@ -1,0 +1,15 @@
+import type { PluginConfig } from "@lumeweb/portal-framework-core/vite";
+
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default {
+  name: "core:quota",
+  dir: __dirname,
+  exposes: {
+    ".": "./src/index",
+    "./widgets/quota": "./src/ui/widgets/quota",
+  },
+} satisfies PluginConfig;

--- a/libs/portal-plugin-quota/postcss.config.cjs
+++ b/libs/portal-plugin-quota/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/libs/portal-plugin-quota/src/__tests__/QuotaWidget.spec.tsx
+++ b/libs/portal-plugin-quota/src/__tests__/QuotaWidget.spec.tsx
@@ -1,0 +1,205 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @refinedev/core to avoid QueryClientProvider requirement
+const mockUseCustom = vi.fn();
+
+vi.mock("@refinedev/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@refinedev/core")>();
+  return {
+    ...actual,
+    useCustom: (...args: any[]) => mockUseCustom(...args),
+  };
+});
+
+// Mock portal-framework-auth to prevent loading portal-framework-ui -> indexedDB
+vi.mock("@lumeweb/portal-framework-auth", () => ({
+  DATA_PROVIDER_NAME: "account",
+}));
+
+// Mock portal-framework-ui to prevent indexedDB errors from saved-filters store
+vi.mock("@lumeweb/portal-framework-ui", () => ({
+  withTheme: (Component: any) => Component,
+}));
+
+import QuotaWidget from "../ui/widgets/quota";
+
+// Mock UI components from portal-framework-ui-core
+vi.mock("@lumeweb/portal-framework-ui-core", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card">{children}</div>
+  ),
+  CardContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-content">{children}</div>
+  ),
+  CardHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-header">{children}</div>
+  ),
+  CardTitle: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="card-title">{children}</div>
+  ),
+  Progress: (props: any) => (
+    <div
+      data-testid="progress"
+      data-max={props.max}
+      data-value={props.value}
+    />
+  ),
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+describe("QuotaWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCustom.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders 3 progress bars with data (Storage, Upload, Download labels visible)", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: {
+          download: {
+            limit: 10737418240,
+            percentage: 50,
+            used: 5368709120,
+          },
+          storage: {
+            limit: 107374182400,
+            percentage: 50,
+            used: 53687091200,
+          },
+          upload: {
+            limit: 1073741824,
+            percentage: 19.5,
+            used: 209715200,
+          },
+        },
+      },
+    });
+
+    render(<QuotaWidget />);
+
+    expect(screen.getByText("Quota Usage")).toBeInTheDocument();
+    expect(screen.getByText("Storage")).toBeInTheDocument();
+    expect(screen.getByText("Upload")).toBeInTheDocument();
+    expect(screen.getByText("Download")).toBeInTheDocument();
+
+    const progressBars = screen.getAllByTestId("progress");
+    expect(progressBars).toHaveLength(3);
+  });
+
+  it("shows loading skeleton while fetching", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    render(<QuotaWidget />);
+
+    expect(screen.getByText("Quota Usage")).toBeInTheDocument();
+    const skeletons = screen.getAllByTestId("skeleton");
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    // Progress bars should not be present during loading
+    expect(screen.queryAllByTestId("progress")).toHaveLength(0);
+  });
+
+  it("shows error message on API failure", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: true,
+        isLoading: false,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    render(<QuotaWidget />);
+
+    expect(screen.getByText("Quota Usage")).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to load quota data"),
+    ).toBeInTheDocument();
+
+    // Progress bars should not be present on error
+    expect(screen.queryAllByTestId("progress")).toHaveLength(0);
+  });
+
+  it("shows 'Unlimited' when limit is undefined", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: {
+          download: {
+            limit: undefined,
+            percentage: 0,
+            used: 5368709120,
+          },
+          storage: {
+            limit: 107374182400,
+            percentage: 50,
+            used: 53687091200,
+          },
+          upload: {
+            limit: 1073741824,
+            percentage: 19.5,
+            used: 209715200,
+          },
+        },
+      },
+    });
+
+    render(<QuotaWidget />);
+
+    expect(screen.getByText("Unlimited")).toBeInTheDocument();
+
+    // Only 2 progress bars should render (storage and upload; download is unlimited)
+    const progressBars = screen.getAllByTestId("progress");
+    expect(progressBars).toHaveLength(2);
+  });
+
+  it("renders null when not ready and not busy and no error", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: false,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    const { container } = render(<QuotaWidget />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/libs/portal-plugin-quota/src/__tests__/mocks/lodash-isEqual.ts
+++ b/libs/portal-plugin-quota/src/__tests__/mocks/lodash-isEqual.ts
@@ -1,0 +1,1 @@
+export { default } from "lodash/isEqual.js";

--- a/libs/portal-plugin-quota/src/__tests__/msw/index.ts
+++ b/libs/portal-plugin-quota/src/__tests__/msw/index.ts
@@ -1,0 +1,1 @@
+export { quotaHandlers } from "./quota-handlers";

--- a/libs/portal-plugin-quota/src/__tests__/msw/quota-handlers.ts
+++ b/libs/portal-plugin-quota/src/__tests__/msw/quota-handlers.ts
@@ -1,0 +1,9 @@
+import {
+  getGetApiAccountQuotaMockHandler,
+  getGetApiAccountQuotaHistoryMockHandler,
+} from "@lumeweb/portal-sdk/mocks";
+
+export const quotaHandlers = [
+  getGetApiAccountQuotaMockHandler(),
+  getGetApiAccountQuotaHistoryMockHandler(),
+];

--- a/libs/portal-plugin-quota/src/__tests__/setup.node.ts
+++ b/libs/portal-plugin-quota/src/__tests__/setup.node.ts
@@ -1,0 +1,18 @@
+import "@testing-library/jest-dom/vitest";
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { setupServer } from "msw/node";
+import { quotaHandlers } from "./msw";
+
+export const server = setupServer(...quotaHandlers);
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterAll(() => {
+  server.close();
+});
+
+afterEach(() => {
+  server.resetHandlers(...quotaHandlers);
+});

--- a/libs/portal-plugin-quota/src/__tests__/useQuota.spec.ts
+++ b/libs/portal-plugin-quota/src/__tests__/useQuota.spec.ts
@@ -1,0 +1,200 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useQuota, QUOTA_QUERY_KEY } from "../hooks/useQuota";
+
+// Mock useCustom from @refinedev/core
+const mockUseCustom = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useCustom: (...args: any[]) => mockUseCustom(...args),
+}));
+
+vi.mock("@lumeweb/portal-framework-auth", () => ({
+  DATA_PROVIDER_NAME: "account",
+}));
+
+describe("useQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCustom.mockReset();
+  });
+
+  it("returns loading state initially (isBusy = true)", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    const { result } = renderHook(() => useQuota());
+
+    expect(result.current.isBusy).toBe(true);
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.hasError).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns quota data after successful fetch (isReady = true, data has storage/upload/download)", () => {
+    const mockData = {
+      download: {
+        limit: 10737418240,
+        percentage: 50,
+        used: 5368709120,
+      },
+      storage: {
+        limit: 107374182400,
+        percentage: 50,
+        used: 53687091200,
+      },
+      upload: {
+        limit: 1073741824,
+        percentage: 19.5,
+        used: 209715200,
+      },
+    };
+
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: mockData,
+      },
+    });
+
+    const { result } = renderHook(() => useQuota());
+
+    expect(result.current.isBusy).toBe(false);
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.hasError).toBe(false);
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.data?.storage.used).toBe(53687091200);
+    expect(result.current.data?.upload.used).toBe(209715200);
+    expect(result.current.data?.download.used).toBe(5368709120);
+  });
+
+  it("returns error state on failed query (hasError = true)", () => {
+    const mockError = {
+      message: "Internal Server Error",
+      statusCode: 500,
+    };
+
+    mockUseCustom.mockReturnValue({
+      query: {
+        error: mockError,
+        isError: true,
+        isLoading: false,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    const { result } = renderHook(() => useQuota());
+
+    expect(result.current.isBusy).toBe(false);
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.error).toEqual(mockError);
+  });
+
+  it("calls useCustom with correct parameters", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    renderHook(() => useQuota());
+
+    expect(mockUseCustom).toHaveBeenCalledWith({
+      url: "/account/quota",
+      method: "get",
+      dataProviderName: "account",
+      queryOptions: undefined,
+    });
+  });
+
+  it("passes queryOptions to useCustom when provided", () => {
+    const queryOptions = { enabled: false };
+
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: true,
+        isSuccess: false,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: undefined,
+      },
+    });
+
+    renderHook(() => useQuota({ queryOptions }));
+
+    expect(mockUseCustom).toHaveBeenCalledWith({
+      url: "/account/quota",
+      method: "get",
+      dataProviderName: "account",
+      queryOptions,
+    });
+  });
+
+  it("exposes refetch function that calls query.refetch", () => {
+    const mockRefetch = vi.fn();
+
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        refetch: mockRefetch,
+      },
+      result: {
+        data: { storage: { used: 0, percentage: 0 }, upload: { used: 0, percentage: 0 }, download: { used: 0, percentage: 0 } },
+      },
+    });
+
+    const { result } = renderHook(() => useQuota());
+
+    result.current.refetch();
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns not-ready when query succeeds but data is falsy", () => {
+    mockUseCustom.mockReturnValue({
+      query: {
+        isError: false,
+        isLoading: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+      },
+      result: {
+        data: null,
+      },
+    });
+
+    const { result } = renderHook(() => useQuota());
+
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/libs/portal-plugin-quota/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-quota/src/capabilities/refineConfig.ts
@@ -1,0 +1,94 @@
+import type { RefineProps } from "@refinedev/core";
+import {
+  Framework,
+  RefineConfigCapability,
+  type CapabilityStatus,
+  mergeRefineConfig,
+  syncAuthProviderWithDataProvider,
+} from "@lumeweb/portal-framework-core";
+import dataProvider from "@lumeweb/advanced-rest-provider";
+import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
+import { createNanoEvents, Emitter } from "nanoevents";
+
+export class Capability implements RefineConfigCapability {
+  readonly id: string = "quota:refine-config";
+  status: CapabilityStatus = "active";
+  readonly type = "core:refine-config";
+  version!: string;
+  #apiUrl!: string;
+  #authToken: string | null = null;
+  #emitter!: Emitter;
+  #authUnbind: (() => void) | null = null;
+  dependencies = ["dashboard:refine-config"];
+
+  getApiUrl(): string {
+    return this.#apiUrl;
+  }
+
+  getAuthToken(): string | null {
+    return this.#authToken;
+  }
+
+  getEmitter(): Emitter {
+    return this.#emitter;
+  }
+
+  async destroy() {
+    if (this.#authUnbind) {
+      this.#authUnbind();
+      this.#authUnbind = null;
+    }
+  }
+
+  getConfig(existing?: Partial<RefineProps>) {
+    const quotaResources = [
+      {
+        meta: {
+          dataProviderName: DATA_PROVIDER_NAME,
+          template: "/account/quota",
+        },
+        name: "account-quota",
+      },
+      {
+        meta: {
+          dataProviderName: DATA_PROVIDER_NAME,
+          template: "/account/quota/history",
+        },
+        name: "account-quota-history",
+      },
+    ];
+
+    const acctProvider = dataProvider(this.#apiUrl, true);
+
+    this.#authUnbind = syncAuthProviderWithDataProvider(
+      acctProvider,
+      existing?.authProvider,
+      {
+        onTokenChange: (token) => {
+          this.#authToken = token;
+          this.#emitter.emit("authTokenChanged", token);
+        },
+      },
+    );
+
+    return mergeRefineConfig(existing, { [DATA_PROVIDER_NAME]: acctProvider }, quotaResources);
+  }
+
+  async initialize(framework: Framework) {
+    this.#emitter = createNanoEvents();
+
+    const dashboardCapability = await framework.getCapability<
+      RefineConfigCapability & { apiUrl: string }
+    >("dashboard:refine-config");
+
+    if (!dashboardCapability) {
+      throw new Error("Dashboard refine capability not found");
+    }
+
+    this.#apiUrl = dashboardCapability.apiUrl;
+
+    if (!this.#apiUrl) {
+      throw new Error("API URL not found in dashboard capability");
+    }
+  }
+}

--- a/libs/portal-plugin-quota/src/hooks/useQuota.ts
+++ b/libs/portal-plugin-quota/src/hooks/useQuota.ts
@@ -1,0 +1,50 @@
+import { useCustom } from "@refinedev/core";
+import type { HttpError, UseCustomProps } from "@refinedev/core";
+import type { QuotaStatusResponse } from "@lumeweb/portal-sdk";
+import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
+
+interface UseQuotaConfig {
+  queryOptions?: UseCustomProps<
+    QuotaStatusResponse,
+    HttpError,
+    unknown,
+    unknown,
+    QuotaStatusResponse
+  >["queryOptions"];
+}
+
+export const QUOTA_QUERY_KEY = [
+  ...(DATA_PROVIDER_NAME ? [DATA_PROVIDER_NAME] : []),
+  "/account/quota",
+];
+
+interface UseQuotaReturn {
+  data: QuotaStatusResponse | undefined;
+  isReady: boolean;
+  isBusy: boolean;
+  hasError: boolean;
+  error: HttpError | null;
+  refetch: () => void;
+  result: ReturnType<typeof useCustom<QuotaStatusResponse>>;
+}
+
+export function useQuota(config: UseQuotaConfig = {}): UseQuotaReturn {
+  const { queryOptions } = config;
+
+  const customResult = useCustom<QuotaStatusResponse>({
+    url: "/account/quota",
+    method: "get",
+    dataProviderName: DATA_PROVIDER_NAME,
+    queryOptions,
+  });
+
+  return {
+    data: customResult.result.data,
+    isReady: customResult.query.isSuccess && !!customResult.result.data,
+    isBusy: customResult.query.isLoading,
+    hasError: customResult.query.isError,
+    error: customResult.query.error ?? null,
+    refetch: () => { customResult.query.refetch(); },
+    result: customResult,
+  };
+}

--- a/libs/portal-plugin-quota/src/index.ts
+++ b/libs/portal-plugin-quota/src/index.ts
@@ -1,0 +1,23 @@
+import {
+  createNamespacedId,
+  Framework,
+  type Plugin,
+} from "@lumeweb/portal-framework-core";
+
+import { Capability as RefineConfigCapability } from "./capabilities/refineConfig";
+import routes from "./routes";
+import widgets from "./widgetRegistrations";
+
+export default function (): Plugin {
+  return {
+    capabilities: [new RefineConfigCapability()],
+    dependencies: [{ id: "core:dashboard" }],
+    async destroy(_framework: Framework) {
+    },
+    id: createNamespacedId("core", "quota"),
+    async initialize(_framework: Framework) {
+    },
+    routes,
+    widgets,
+  } satisfies Plugin;
+}

--- a/libs/portal-plugin-quota/src/routes.tsx
+++ b/libs/portal-plugin-quota/src/routes.tsx
@@ -1,0 +1,5 @@
+import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+
+const routes: RouteDefinition[] = [];
+
+export default routes;

--- a/libs/portal-plugin-quota/src/ui/widgets/quota.tsx
+++ b/libs/portal-plugin-quota/src/ui/widgets/quota.tsx
@@ -1,0 +1,117 @@
+import { useQuota } from "../../hooks/useQuota";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@lumeweb/portal-framework-ui-core";
+import { Progress } from "@lumeweb/portal-framework-ui-core";
+import { Skeleton } from "@lumeweb/portal-framework-ui-core";
+import type { QuotaTypeStatus } from "@lumeweb/portal-sdk";
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+function getBarColor(percentage: number): string {
+  if (percentage > 90) return "bg-destructive";
+  if (percentage >= 70) return "bg-yellow-500";
+  return "bg-foreground";
+}
+
+interface QuotaBarProps {
+  label: string;
+  quota: QuotaTypeStatus;
+}
+
+function QuotaBar({ label, quota }: QuotaBarProps) {
+  const isUnlimited = quota.limit === undefined;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">{label}</span>
+        {isUnlimited ? (
+          <span className="text-muted-foreground">Unlimited</span>
+        ) : (
+          <span className="text-muted-foreground">
+            {quota.percentage.toFixed(1)}%
+          </span>
+        )}
+      </div>
+      {isUnlimited ? (
+        <div className="text-xs text-muted-foreground">
+          {formatBytes(quota.used)} used
+        </div>
+      ) : (
+        <>
+          <Progress
+            className="h-2"
+            indicatorClassName={getBarColor(quota.percentage)}
+            max={quota.limit ?? 0}
+            value={quota.used}
+          />
+          <div className="text-xs text-muted-foreground">
+            {formatBytes(quota.used)} / {formatBytes(quota.limit ?? 0)}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function QuotaWidget() {
+  const { data, isReady, isBusy, hasError } = useQuota();
+
+  if (isBusy) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Quota Usage</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-2 w-full" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-2 w-full" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-2 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Quota Usage</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">Failed to load quota data</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!isReady || !data) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Quota Usage</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <QuotaBar label="Storage" quota={data.storage} />
+        <QuotaBar label="Upload" quota={data.upload} />
+        <QuotaBar label="Download" quota={data.download} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/libs/portal-plugin-quota/src/widgetRegistrations.ts
+++ b/libs/portal-plugin-quota/src/widgetRegistrations.ts
@@ -1,0 +1,22 @@
+import type {
+  WidgetRegistration,
+} from "@lumeweb/portal-framework-core";
+
+export const widgetRegistrations: WidgetRegistration[] = [
+  {
+    areaId: "dashboard:header",
+    componentName: "widgets/quota",
+    id: "quota:usage",
+    position: {
+      size: {
+        height: 1,
+        width: 12,
+      },
+    },
+  },
+];
+
+export default {
+  areas: [],
+  widgets: widgetRegistrations,
+};

--- a/libs/portal-plugin-quota/tailwind.config.ts
+++ b/libs/portal-plugin-quota/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/libs/portal-plugin-quota/tsconfig.json
+++ b/libs/portal-plugin-quota/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@e2e/*": ["./e2e/*"],
+      "@lib/*": ["./src-lib/*"]
+    }
+  }
+}

--- a/libs/portal-plugin-quota/tsdown.config.ts
+++ b/libs/portal-plugin-quota/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+import { createLibraryConfigWithDirs } from "@lumeweb/tsdown-config";
+
+export default defineConfig(
+  createLibraryConfigWithDirs("./src-lib/index.ts", "lib-dist/esm", {
+    target: "es2022",
+    platform: "node",
+  })
+);

--- a/libs/portal-plugin-quota/vite.config.ts
+++ b/libs/portal-plugin-quota/vite.config.ts
@@ -1,0 +1,13 @@
+import { Config, PLUGIN_TYPE } from "@lumeweb/portal-framework-core/vite";
+
+import * as sharedModules from "../../shared-modules";
+import config from "./plugin.config";
+
+export default Config({
+  dir: config.dir,
+  entryFile: "src/index.ts",
+  exposes: config.exposes,
+  name: config.name,
+  sharedModules: sharedModules.getSharedModules(),
+  type: PLUGIN_TYPE,
+});

--- a/libs/portal-plugin-quota/vitest.config.ts
+++ b/libs/portal-plugin-quota/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    name: "node",
+    include: ["src/**/*.spec.ts", "src/**/*.spec.tsx"],
+    setupFiles: ["./src/__tests__/setup.node.ts"],
+    environment: "happy-dom",
+    passWithNoTests: true,
+    deps: {
+      inline: [/@refinedev\/react-table/],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "lodash/isEqual": path.resolve(__dirname, "./src/__tests__/mocks/lodash-isEqual.ts"),
+      "@refinedev/react-table": path.resolve(
+        __dirname,
+        "../../node_modules/.pnpm/@refinedev+react-table@6.0.1_@refinedev+core@5.0.12_@tanstack+react-query@5.100.10_reac_6b2fa63708308f224bce6b91254105bc/node_modules/@refinedev/react-table/dist/index.cjs"
+      ),
+    },
+  },
+});

--- a/libs/portal-sdk/src/account/mocks.ts
+++ b/libs/portal-sdk/src/account/mocks.ts
@@ -1,2 +1,3 @@
 export * from './generated/quota';
 export * from './generated/default';
+export * from './generated/billing';


### PR DESCRIPTION
- Add QuotaWidget component with 3 Tailwind progress bars (storage, upload, download)
- Add useQuota hook using Refine useCustom with /account/quota endpoint
- Add RefineConfigCapability registering account-quota and account-quota-history resources
- Add widget registration in dashboard:header (width:12, height:1)
- Add MSW test infrastructure using @lumeweb/portal-sdk/mocks
- Add integration tests (12 tests: 7 hook + 5 widget)
- Color thresholds: <70% default, 70-90% warning, >90% destructive
- Handle loading, error, and unlimited (limit undefined) states

---

<!-- kody-pr-summary:start -->
This pull request adds the `portal-plugin-quota` plugin, which provides a dashboard widget displaying storage, upload, and download quota usage. The key additions include:

- **QuotaWidget**: A dashboard card widget registered in the `dashboard:header` area that renders three progress bars (Storage, Upload, Download) with color-coded thresholds — default under 70%, yellow warning at 70–90%, and red destructive above 90%. Displays "Unlimited" when a quota type has no limit, and shows loading skeletons or an error message as appropriate.

- **useQuota hook**: A convenience hook wrapping Refine's `useCustom` to fetch quota data from the `/account/quota` endpoint via the `account` data provider, exposing `data`, `isReady`, `isBusy`, `hasError`, `error`, and `refetch`.

- **Refine config capability**: Registers `account-quota` and `account-quota-history` resources with the account data provider, syncs authentication tokens, and resolves the API URL from the `dashboard:refine-config` capability.

- **Tests**: Unit tests for both `useQuota` and `QuotaWidget` covering loading, success, error, and unlimited-quota states, along with MSW mock handlers for the quota API endpoints.

- **SDK update**: Re-exports billing mocks from the portal SDK account module.
<!-- kody-pr-summary:end -->