### PR TITLE
chore(ci): remove portal-frontend-template dispatch from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,28 +48,6 @@ jobs:
       - name: Publish to npm
         run: NODE_AUTH_TOKEN="" pnpm publish:npm
 
-      # Check for portal-frontend changes and notify template repo
-      - name: Check portal-frontend changes and notify
-        id: check-changes
-        run: |
-          CHANGES=$(git diff --name-only HEAD^ HEAD apps/portal-frontend)
-          if [ ! -z "$CHANGES" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
-
-      - if: steps.check-changes.outputs.has_changes == 'true'
-        name: Trigger portal-frontend template repo update
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.PAT }}
-          repository: lumeweb/portal-frontend-template
-          event-type: portal-frontend-update
-          client-payload: |
-            {
-              "source_sha": "${{ github.sha }}",
-              "source_ref": "${{ github.ref }}"
-            }
-
       # Release the Go modules
       - name: Trigger Go module release
         uses: peter-evans/repository-dispatch@v4


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removes the portal-frontend change detection and repository dispatch steps from the release workflow. This eliminates the logic that checked for changes in `apps/portal-frontend` and triggered a `portal-frontend-update` event to the `lumeweb/portal-frontend-template` repository upon release.
<!-- kody-pr-summary:end -->