### PR TITLE
fix(pinner.xyz): use || instead of ?? for env var fallbacks to handle empty strings

### DIFF
--- a/apps/pinner.xyz/.env.example
+++ b/apps/pinner.xyz/.env.example
@@ -1,5 +1,5 @@
 # Portal API base URL (used by pricing plans, etc.)
-PUBLIC_PORTAL_API_URL=https://dev.pinner.xyz
+PUBLIC_PORTAL_API_URL=https://pinner.xyz
 
 # Listmonk newsletter (derived from portal domain as list.<domain> if unset)
 PUBLIC_LISTMONK_URL=

--- a/apps/pinner.xyz/src/lib/config.ts
+++ b/apps/pinner.xyz/src/lib/config.ts
@@ -4,17 +4,14 @@
  * to avoid hydration mismatches.
  */
 const portalApiUrl =
-  import.meta.env.PUBLIC_PORTAL_API_URL ?? "https://account.dev.pinner.xyz";
+  import.meta.env.PUBLIC_PORTAL_API_URL || "https://pinner.xyz";
 
-const portalDomain = new URL(portalApiUrl).hostname.replace(
-  /^[^.]+\./,
-  ""
-);
+const portalDomain = new URL(portalApiUrl).hostname;
 
 export const config = {
   portalApiUrl,
   listmonkUrl:
-    import.meta.env.PUBLIC_LISTMONK_URL ?? `https://list.${portalDomain}`,
+    import.meta.env.PUBLIC_LISTMONK_URL || `https://list.${portalDomain}`,
   listmonkListUuid:
     import.meta.env.PUBLIC_LISTMONK_LIST_UUID ?? "",
 } as const;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fix environment variable fallbacks in pinner.xyz config to handle empty strings

This PR changes the environment variable fallback logic in the pinner.xyz configuration from using the nullish coalescing operator (`??`) to the logical OR operator (`||`). This ensures that empty strings are treated as "not set" and properly fall back to their default values, since `??` only falls back for `null` or `undefined`, while `||` also handles empty strings and other falsy values.

Additionally, the default portal API URL was updated from the development URL (`https://account.dev.pinner.xyz`) to the production URL (`https://pinner.xyz`).
<!-- kody-pr-summary:end -->