### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/modern-planes-happen.md
+++ b/.changeset/modern-planes-happen.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- remove obsolete tus-js-client NodeHttpStack monkey-patch


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds a changeset documenting a patch-level fix for the `@lumeweb/pinner` package. The change removes an obsolete monkey-patch applied to `tus-js-client`'s `NodeHttpStack`, which is no longer needed.
<!-- kody-pr-summary:end -->