### PR TITLE
fix/tsdown skip node modules bundle

### DIFF
--- a/libs/portal-framework-auth/tsdown.config.ts
+++ b/libs/portal-framework-auth/tsdown.config.ts
@@ -3,6 +3,6 @@ import { createLibraryConfig, entryPatterns } from "@lumeweb/tsdown-config";
 
 export default defineConfig(
   createLibraryConfig(entryPatterns.withoutTests, {
-    deps: { neverBundle: /node_modules/ },
+    deps: { skipNodeModulesBundle: true },
   })
 );

--- a/libs/portal-framework-ui-core/tsdown.config.ts
+++ b/libs/portal-framework-ui-core/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 
 const baseOptions: Partial<UserConfig> = {
   deps: {
-    neverBundle: [/node_modules/],
+    skipNodeModulesBundle: true,
   },
   minify: false,
   platform: "neutral",

--- a/libs/portal-framework-ui/tsdown.config.ts
+++ b/libs/portal-framework-ui/tsdown.config.ts
@@ -6,7 +6,7 @@ import image from "@rollup/plugin-image";
 export default defineConfig([
   {
     ...createLibraryConfigWithPlugins(entryPatterns.withoutTests, [image() as any], {
-      deps: { neverBundle: [/node_modules/, /@refinedev\/.*/] },
+      deps: { skipNodeModulesBundle: true, neverBundle: [/@refinedev\/.*/] },
       unbundle: true,
     }),
   },

--- a/libs/tsdown-config/index.ts
+++ b/libs/tsdown-config/index.ts
@@ -6,7 +6,7 @@ import type { UserConfig } from "tsdown";
 const baseOptions: Partial<UserConfig> = {
   clean: true,
   deps: {
-    neverBundle: [/node_modules/],
+    skipNodeModulesBundle: true,
   },
   dts: true,
   hash: false,
@@ -71,6 +71,10 @@ export function createLibraryConfigWithExternals(
   externals: (string | RegExp)[],
   options: Partial<UserConfig> = {}
 ): UserConfig {
+  const filteredExternals = externals.filter(
+    (e) => !(e instanceof RegExp && e.source === "node_modules")
+  );
+
   return {
     ...baseOptions,
     entry: Array.isArray(entry) ? entry : [entry],
@@ -83,7 +87,8 @@ export function createLibraryConfigWithExternals(
       },
     },
     deps: {
-      neverBundle: externals,
+      skipNodeModulesBundle: true,
+      ...(filteredExternals.length > 0 ? { neverBundle: filteredExternals } : {}),
     },
     ...options,
   };

--- a/libs/tsdown-config/tsdown.config.ts
+++ b/libs/tsdown-config/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   clean: true,
   deps: {
-    neverBundle: [/node_modules/],
+    skipNodeModulesBundle: true,
   },
   dts: true,
   entry: ["./index.ts"],


### PR DESCRIPTION
- **fix(tsdown-config): use skipNodeModulesBundle to prevent absolute paths in dist**
- **fix(portal-framework-auth): use skipNodeModulesBundle to prevent absolute paths in dist**
- **fix(portal-framework-ui-core): use skipNodeModulesBundle to prevent absolute paths in dist**
- **fix(portal-framework-ui): use skipNodeModulesBundle to prevent absolute paths in dist**

---

<!-- kody-pr-summary:start -->
Replace `neverBundle: [/node_modules/]` with the dedicated `skipNodeModulesBundle: true` option across all tsdown configurations

This PR migrates from using the regex pattern `/node_modules/` in the `neverBundle` option to the purpose-built `skipNodeModulesBundle: true` configuration option provided by tsdown. The changes include:

- **Shared tsdown-config library**: Updated base options to use `skipNodeModulesBundle: true`, and modified `createLibraryConfigWithExternals` to filter out any `/node_modules/` regex from externals before passing them to `neverBundle`, preventing redundancy with the new option.
- **Individual library configs**: Updated `portal-framework-auth`, `portal-framework-ui-core`, and `portal-framework-ui` to use the new option, while preserving other `neverBundle` entries (e.g., `/@refinedev\/.*/` in portal-framework-ui).
<!-- kody-pr-summary:end -->