### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/breezy-years-film.md
+++ b/.changeset/breezy-years-film.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-auth: patch
+---
+
+## Fixes
+
+- use skipNodeModulesBundle to prevent absolute paths in dist

--- a/.changeset/public-glasses-marry.md
+++ b/.changeset/public-glasses-marry.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-ui-core: patch
+---
+
+## Fixes
+
+- use skipNodeModulesBundle to prevent absolute paths in dist

--- a/.changeset/thin-pumas-juggle.md
+++ b/.changeset/thin-pumas-juggle.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-sdk: patch
+---
+
+## Fixes
+
+- use skipNodeModulesBundle to prevent absolute paths in dist

--- a/.changeset/wide-turkeys-wonder.md
+++ b/.changeset/wide-turkeys-wonder.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-ui: patch
+---
+
+## Fixes
+
+- use skipNodeModulesBundle to prevent absolute paths in dist

--- a/knope.toml
+++ b/knope.toml
@@ -103,3 +103,9 @@ command = "git push"
 
 [[workflows.steps]]
 type = "Release"
+
+[[workflows]]
+name = "document-change"
+
+[[workflows.steps]]
+type = "CreateChangeFile"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset documentation for a build fix across four packages and introduces a new Knope workflow for creating change files.

**Changes:**

- **Changeset files added** for the following packages (all patch version bumps), documenting the same fix — using `skipNodeModulesBundle` to prevent absolute paths from appearing in the dist output:
  - `@lumeweb/portal-framework-auth`
  - `@lumeweb/portal-framework-ui-core`
  - `@lumeweb/portal-sdk`
  - `@lumeweb/portal-framework-ui`

- **Knope configuration** (`knope.toml`) updated to add a new `document-change` workflow with a `CreateChangeFile` step, streamlining the process of generating changeset files for future changes.
<!-- kody-pr-summary:end -->