### PR TITLE
fix/pinner upload response parsing

### DIFF
--- a/libs/pinner/src/__tests__/msw/upload-handlers.ts
+++ b/libs/pinner/src/__tests__/msw/upload-handlers.ts
@@ -6,30 +6,6 @@ import {
   testConfig,
 } from "../setup";
 import { TusStore, OperationStore } from "./upload-store";
-import type { UploadResult } from "@/types/upload";
-
-// Inlined from msw-helpers (deleted during harness migration)
-
-async function createMockUploadResult(
-  overrides: Partial<UploadResult> = {},
-): Promise<UploadResult> {
-  const { getNextRequestId } = await import("../setup");
-  const requestId = getNextRequestId();
-  const cid = overrides.cid || (await createMockCID(requestId));
-
-  return {
-    id: overrides.id || "test-upload-id",
-    cid,
-    name: overrides.name || "test.car",
-    size: overrides.size || 1024,
-    mimeType: overrides.mimeType || "application/vnd.ipld.car",
-    createdAt: overrides.createdAt || new Date(),
-    numberOfFiles: overrides.numberOfFiles || 1,
-    keyvalues: overrides.keyvalues,
-    isDirectory: overrides.isDirectory,
-    operationId: overrides.operationId,
-  };
-}
 
 async function applyMockDelay(
   delay: number = testConfig.mockDelay,
@@ -40,8 +16,6 @@ async function applyMockDelay(
 const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
 
 const XHR_FORM_FIELD = "file";
-const DEFAULT_FILENAME = "upload.car";
-const DEFAULT_FILE_SIZE = 1024;
 
 export function createUploadHandlers(tusStore: TusStore, operationStore: OperationStore) {
   const tusOptionsHandler = http.options(
@@ -290,31 +264,23 @@ export function createUploadHandlers(tusStore: TusStore, operationStore: Operati
     async ({ request }) => {
       await applyMockDelay(100);
 
-      let filename: string = DEFAULT_FILENAME;
-      let fileSize: number = DEFAULT_FILE_SIZE;
       try {
         const formData = await request.formData();
-        const file = formData.get(XHR_FORM_FIELD) as File;
-        if (file) {
-          filename = file.name;
-          fileSize = file.size;
-        }
+        formData.get(XHR_FORM_FIELD);
       } catch (error) {
         console.warn("[MSW] Could not extract file info from request:", error);
       }
 
       const operationId = operationStore.getNextOperationId();
-      const result = await createMockUploadResult({
-        name: filename,
-        cid: await createMockCID(operationId),
-        size: fileSize,
-        operationId,
-      });
+      const cid = await createMockCID(operationId);
 
-      return HttpResponse.json(result, {
-        status: 200,
-        headers: CORS_HEADERS,
-      });
+      return HttpResponse.json(
+        { CID: cid },
+        {
+          status: 200,
+          headers: CORS_HEADERS,
+        },
+      );
     },
   );
 
@@ -370,7 +336,7 @@ export function createUploadHandlers(tusStore: TusStore, operationStore: Operati
       });
 
       return HttpResponse.json(
-        { data: result, total: 1 },
+        { data: [result], total: 1 },
         {
           status: 200,
           headers: CORS_HEADERS,
@@ -407,6 +373,36 @@ export function createUploadHandlers(tusStore: TusStore, operationStore: Operati
     },
   );
 
+  const uploadResultHandler = http.get(
+    `${testConfig.apiUrl}/upload/result/:identifier`,
+    async ({ params }) => {
+      await applyMockDelay();
+      const identifier = params.identifier as string;
+
+      const operationId = parseInt(identifier, 10);
+      if (isNaN(operationId)) {
+        const resolvedCid = await createMockCID(parseInt(identifier.replace(/\D/g, "") || "1", 10));
+        return HttpResponse.json(
+          { status: "completed", cid: resolvedCid },
+          { status: 200, headers: CORS_HEADERS },
+        );
+      }
+
+      if (operationId === 99999) {
+        return HttpResponse.json(
+          { status: "failed", error: "Simulated upload failure" },
+          { status: 200, headers: CORS_HEADERS },
+        );
+      }
+
+      const resolvedCid = await createMockCID(operationId);
+      return HttpResponse.json(
+        { status: "completed", cid: resolvedCid },
+        { status: 200, headers: CORS_HEADERS },
+      );
+    },
+  );
+
   return [
     tusOptionsHandler,
     tusHeadHandler,
@@ -414,6 +410,7 @@ export function createUploadHandlers(tusStore: TusStore, operationStore: Operati
     tusPatchHandler,
     tusDeleteHandler,
     xhrUploadHandler,
+    uploadResultHandler,
     accountUploadLimitHandler,
     accountInfoHandler,
     listOperationsHandler,

--- a/libs/pinner/src/__tests__/pinner.integration.spec.ts
+++ b/libs/pinner/src/__tests__/pinner.integration.spec.ts
@@ -37,6 +37,7 @@ describe("Pinner Integration Tests", () => {
       expect(uploadResult.size).toBe(12);
 
       // Pin by the returned CID
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid);
       for await (const item of pinGenerator) {
@@ -63,6 +64,7 @@ describe("Pinner Integration Tests", () => {
       expect(uploadResult.name).toBe("test.txt");
 
       // Pin with metadata
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid, {
         name: "test-pin",
@@ -86,6 +88,7 @@ describe("Pinner Integration Tests", () => {
 
       expect(result1.cid).toBeDefined();
       expect(result2.cid).toBeDefined();
+      if (!result1.cid || !result2.cid) throw new Error("CID not yet available");
       expect(result1.cid).not.toBe(result2.cid);
     });
 
@@ -97,12 +100,14 @@ describe("Pinner Integration Tests", () => {
       const result2 = await pinner.uploadAndWait(mockFile2);
 
       // Pin both uploads
+      if (!result1.cid) throw new Error("CID not yet available");
       const pinResult1: CID[] = [];
       const pinGenerator1 = await pinner.pinByHash(result1.cid);
       for await (const item of pinGenerator1) {
         pinResult1.push(item);
       }
 
+      if (!result2.cid) throw new Error("CID not yet available");
       const pinResult2: CID[] = [];
       const pinGenerator2 = await pinner.pinByHash(result2.cid);
       for await (const item of pinGenerator2) {
@@ -124,6 +129,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid);
       for await (const item of pinGenerator) {
@@ -147,12 +153,14 @@ describe("Pinner Integration Tests", () => {
       const result2 = await pinner.uploadAndWait(mockFile2);
 
       // Pin both
+      if (!result1.cid) throw new Error("CID not yet available");
       const pinGenerator1 = await pinner.pinByHash(result1.cid, {
         name: "pin-1",
       });
       for await (const item of pinGenerator1) {
         item;
       }
+      if (!result2.cid) throw new Error("CID not yet available");
       const pinGenerator2 = await pinner.pinByHash(result2.cid, {
         name: "pin-2",
       });
@@ -176,6 +184,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid, {
         name: "test-pin",
@@ -203,6 +212,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid);
       for await (const item of pinGenerator) {
@@ -234,6 +244,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid, {
         name: "test-pin",
@@ -267,6 +278,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin with metadata
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid, {
         name: "test-pin",
@@ -294,6 +306,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid);
       for await (const item of pinGenerator) {
@@ -319,6 +332,7 @@ describe("Pinner Integration Tests", () => {
       const uploadResult = await pinner.uploadAndWait(mockFile);
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid);
       for await (const item of pinGenerator) {
@@ -350,6 +364,7 @@ describe("Pinner Integration Tests", () => {
       expect(uploadResult.cid).toBeDefined();
 
       // Pin
+      if (!uploadResult.cid) throw new Error("CID not yet available");
       const pinResult: CID[] = [];
       const pinGenerator = await pinner.pinByHash(uploadResult.cid, {
         name: "directory-pin",

--- a/libs/pinner/src/adapters/pinata/legacy/adapter.ts
+++ b/libs/pinner/src/adapters/pinata/legacy/adapter.ts
@@ -126,7 +126,11 @@ export function pinataLegacyAdapter(
 				keyvalues: options?.metadata?.keyvalues,
 			});
 
-			return createUploadResponse(result, file.name);
+			if (!result.cid) {
+				throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+			}
+
+			return createUploadResponse({ cid: result.cid, size: result.size, createdAt: result.createdAt }, file.name);
 		},
 
 		/**
@@ -149,7 +153,11 @@ export function pinataLegacyAdapter(
 				keyvalues: options?.metadata?.keyvalues,
 			});
 
-			return createUploadResponse(result, file.name);
+			if (!result.cid) {
+				throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+			}
+
+			return createUploadResponse({ cid: result.cid, size: result.size, createdAt: result.createdAt }, file.name);
 		},
 
 		/**

--- a/libs/pinner/src/adapters/pinata/v2/adapter.ts
+++ b/libs/pinner/src/adapters/pinata/v2/adapter.ts
@@ -377,6 +377,10 @@ class PublicUploadImpl implements PublicUpload {
 				keyvalues: keyvalues || options?.metadata?.keyvalues,
 			});
 
+			if (!result.cid) {
+				throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+			}
+
 			return {
 				id: result.cid,
 				name: file.name,
@@ -403,6 +407,10 @@ class PublicUploadImpl implements PublicUpload {
 				keyvalues: keyvalues || options?.metadata?.keyvalues,
 			});
 			const result = await operation.result;
+
+			if (!result.cid) {
+				throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+			}
 
 			return {
 				id: result.cid,
@@ -445,6 +453,10 @@ class PublicUploadImpl implements PublicUpload {
 				keyvalues: keyvalues || options?.metadata?.keyvalues,
 			});
 
+			if (!result.cid) {
+				throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+			}
+
 			return {
 				id: result.cid,
 				name: file.name,
@@ -480,6 +492,10 @@ class PublicUploadImpl implements PublicUpload {
 				name: name || options?.metadata?.name,
 				keyvalues: keyvalues || options?.metadata?.keyvalues,
 			});
+
+			if (!result.cid) {
+				throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+			}
 
 			return {
 				id: result.cid,

--- a/libs/pinner/src/adapters/pinata/v2/builder.ts
+++ b/libs/pinner/src/adapters/pinata/v2/builder.ts
@@ -52,10 +52,13 @@ abstract class BaseUploadBuilder<
   abstract execute(): Promise<TResult>;
 
   protected toUploadResult(result: {
-    cid: string;
+    cid?: string;
     size: number;
     createdAt: Date;
   }): PinataUploadResult {
+    if (!result.cid) {
+      throw new Error("Upload result has no CID yet — use waitForOperation() to poll for the CID");
+    }
     return {
       IpfsHash: result.cid,
       PinSize: result.size,

--- a/libs/pinner/src/api/swagger.yaml
+++ b/libs/pinner/src/api/swagger.yaml
@@ -178,9 +178,14 @@ components:
           type: integer
         ipns_name:
           type: string
+        last_published_at:
+          format: date-time
+          type: string
         name:
           type: string
         peer_id:
+          type: string
+        value:
           type: string
       required:
       - id
@@ -222,9 +227,14 @@ components:
           type: integer
         ipns_name:
           type: string
+        last_published_at:
+          format: date-time
+          type: string
         name:
           type: string
         peer_id:
+          type: string
+        value:
           type: string
       required:
       - id
@@ -383,6 +393,14 @@ components:
       - pin
       - delegates
       type: object
+    PostUploadResponse:
+      additionalProperties: false
+      properties:
+        CID:
+          type: string
+      required:
+      - CID
+      type: object
     RecordIdentifier:
       additionalProperties: false
       properties:
@@ -492,6 +510,18 @@ components:
       required:
       - status
       type: object
+    UploadResultResponse:
+      additionalProperties: false
+      properties:
+        cid:
+          type: string
+        error:
+          type: string
+        status:
+          type: string
+      required:
+      - status
+      type: object
     ValidationResponse:
       additionalProperties: false
       properties:
@@ -561,6 +591,8 @@ components:
           type: string
         validation_expires_at:
           format: date-time
+          type: string
+        validation_record_host:
           type: string
         validation_token:
           type: string
@@ -646,6 +678,8 @@ components:
           type: string
         validation_expires_at:
           format: date-time
+          type: string
+        validation_record_host:
           type: string
         validation_token:
           type: string
@@ -2384,6 +2418,10 @@ paths:
         required: true
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUploadResponse'
           description: File uploaded successfully
         "400":
           content:
@@ -2416,6 +2454,63 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Upload file to IPFS
+      tags:
+      - Content
+  /api/upload/result/{identifier}:
+    get:
+      description: |-
+        Retrieves the result of an upload operation by identifier.
+
+        Returns the root CID for completed uploads, or the current processing status for pending uploads.
+        Accepts either a TUS upload ID or a numeric request ID as the identifier.
+
+        See also: POST /upload (upload file), GET /pins/{id} (get pin details)
+      parameters:
+      - description: 'TUS upload ID or numeric request ID. Example: abc123-def456
+          or 42'
+        in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadResultResponse'
+          description: Upload result
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get upload result
       tags:
       - Content
   /api/upload/tus:
@@ -4172,5 +4267,115 @@ paths:
       summary: Replace pinned content
       tags:
       - Pinning
+  /routing/v1/ipns/{name}:
+    get:
+      description: |-
+        Returns the signed IPNS record for the given peer ID.
+
+        Implements the IPFS Delegated Routing V1 HTTP API (IPIP-337). The response is a raw IPNS record in binary format (application/vnd.ipfs.ipns-record). Accepts both CIDv1 (bafzaajaiaejc...) and raw peer ID (12D3KooW...) formats.
+
+        See also: https://specs.ipfs.tech/ipips/ipip-337/
+      parameters:
+      - description: Peer ID of the IPNS key (CIDv1 or raw peer ID format)
+        in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/vnd.ipfs.ipns-record:
+              schema:
+                type: string
+          description: IPNS record
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get IPNS record
+      tags:
+      - Routing
+  /routing/v1/providers/{cid}:
+    get:
+      description: |-
+        Returns provider records for the given CID.
+
+        Implements the IPFS Delegated Routing V1 HTTP API (IPIP-337). Supports both JSON and streaming NDJSON response formats via content negotiation (Accept header).
+
+        See also: https://specs.ipfs.tech/ipips/ipip-337/
+      parameters:
+      - description: Content identifier
+        in: path
+        name: cid
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/x-ndjson:
+              schema:
+                type: string
+          description: Provider records
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Find providers for a CID
+      tags:
+      - Routing
 servers:
 - url: /

--- a/libs/pinner/src/types/upload.ts
+++ b/libs/pinner/src/types/upload.ts
@@ -13,8 +13,10 @@ export interface UploadResult {
 
   /**
    * IPFS Content Identifier for the uploaded content.
+   * Undefined when the CID is not yet available (e.g. TUS uploads where
+   * the CID is assigned asynchronously — poll GET /api/upload/result/{id}).
    */
-  cid: string;
+  cid?: string;
 
   /**
    * User-provided or auto-generated name for the content.

--- a/libs/pinner/src/upload/__tests__/manager.integration.spec.ts
+++ b/libs/pinner/src/upload/__tests__/manager.integration.spec.ts
@@ -7,6 +7,7 @@ import {
   streamToFile,
 } from "./test-helpers";
 import { EmptyFileError } from "@/errors";
+import { UploadResultSymbol } from "@/types/upload";
 import { test as it } from "./int-test";
 import { DEFAULT_UPLOAD_LIMIT, MOCK_CONFIG } from "./test-constants";
 import { assertUploadOperationStructure } from "./test-assertions";
@@ -41,8 +42,7 @@ describe("UploadManager Integration Tests", () => {
         // Verify the operation completes successfully
         const result = await operation.result;
         expect(result).toBeDefined();
-        expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
-        expect(result.name).toBe("test.car");
+        expect(result.id).toBeDefined();
         expect(result.cid).toBeDefined();
       });
 
@@ -57,7 +57,8 @@ describe("UploadManager Integration Tests", () => {
 
         expect(operation).toBeDefined();
         const result = await operation.result;
-        expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
+        expect(result.id).toBeDefined();
+        expect(result.cid).toBeDefined();
       });
 
       it("should preserve file data integrity", async () => {
@@ -70,8 +71,8 @@ describe("UploadManager Integration Tests", () => {
 
         // Verify the upload completes successfully
         expect(result).toBeDefined();
-        expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
-        expect(result.name).toBe("integrity-test.car");
+        expect(result.id).toBeDefined();
+        expect(result.cid).toBeDefined();
       });
 
       it("should handle binary data files", async () => {
@@ -89,8 +90,8 @@ describe("UploadManager Integration Tests", () => {
 
         // Verify the upload completes successfully
         expect(result).toBeDefined();
-        expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
-        expect(result.name).toBe("binary.car");
+        expect(result.id).toBeDefined();
+        expect(result.cid).toBeDefined();
       });
 
       it("should handle files with multiple chunks", async () => {
@@ -110,8 +111,8 @@ describe("UploadManager Integration Tests", () => {
 
         // Verify the upload completes successfully
         expect(result).toBeDefined();
-        expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
-        expect(result.name).toBe("multi-chunk.car");
+        expect(result.id).toBeDefined();
+        expect(result.cid).toBeDefined();
       });
 
       it("should throw EmptyFileError for empty files", async () => {
@@ -164,7 +165,8 @@ describe("UploadManager Integration Tests", () => {
       // Verify the operation completes successfully
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should use XHR handler for small ReadableStream with size override", async () => {
@@ -177,7 +179,8 @@ describe("UploadManager Integration Tests", () => {
 
       expect(operation).toBeDefined();
       const result = await operation.result;
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should use TUS handler for large ReadableStream with size override", async () => {
@@ -190,7 +193,8 @@ describe("UploadManager Integration Tests", () => {
 
       expect(operation).toBeDefined();
       const result = await operation.result;
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result.id).toBeDefined();
+      // TUS uploads assign CID asynchronously — cid may be undefined
     }, 30000);
 
     it("should preserve stream data integrity with size override", async () => {
@@ -206,8 +210,8 @@ describe("UploadManager Integration Tests", () => {
 
       // Verify the upload completes successfully
       expect(result).toBeDefined();
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
-      expect(result.name).toBe("integrity-test.car");
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
   });
 
@@ -225,7 +229,8 @@ describe("UploadManager Integration Tests", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
   });
 
@@ -248,8 +253,8 @@ describe("UploadManager Integration Tests", () => {
 
       expect(result1).toBeDefined();
       expect(result2).toBeDefined();
-      expect(result1.id).toMatch(/^test-upload-id(-\d+)?$/);
-      expect(result2.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result1.id).toBeDefined();
+      expect(result2.id).toBeDefined();
     });
 
     it("should maintain handler selection consistency across uploads", async () => {
@@ -268,8 +273,8 @@ describe("UploadManager Integration Tests", () => {
 
       expect(result1).toBeDefined();
       expect(result2).toBeDefined();
-      expect(result1.id).toMatch(/^test-upload-id(-\d+)?$/);
-      expect(result2.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result1.id).toBeDefined();
+      expect(result2.id).toBeDefined();
     });
   });
 
@@ -284,9 +289,7 @@ describe("UploadManager Integration Tests", () => {
       // Verify the operation completes successfully
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
-      expect(result.name).toBe("valid.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.id).toBeDefined();
       expect(result.cid).toBeDefined();
     });
 
@@ -297,8 +300,8 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.name).toBe("explicit.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should upload CAR file via uploadCar method", async () => {
@@ -308,8 +311,8 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.name).toBe("uploadcar.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should upload CAR file as ReadableStream", async () => {
@@ -323,8 +326,8 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.name).toBe("stream.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should reject invalid CAR files (fake .car extension)", async () => {
@@ -336,8 +339,7 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      // The file will be preprocessed to CAR, so it will have .car extension
-      expect(result.name).toContain("fake");
+      expect(result.id).toBeDefined();
     });
 
     it.skip("should handle large CAR files via TUS", async () => {
@@ -348,8 +350,8 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.name).toBe("large.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.id).toBeDefined();
+      // TUS: cid assigned asynchronously, may be undefined
     });
 
     it("should preserve CAR MIME type even if original has different type", async () => {
@@ -363,7 +365,8 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should respect isCarFile: false option even for valid CAR files", async () => {
@@ -377,8 +380,7 @@ describe("UploadManager Integration Tests", () => {
 
       const result = await operation.result;
       expect(result).toBeDefined();
-      // File should still be processed (preprocessed to CAR)
-      expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
     });
   });
 
@@ -397,23 +399,18 @@ describe("UploadManager Integration Tests", () => {
       const stream = createReadableStream("test content");
       const file = await streamToFile(stream, "test.car");
 
-      // First upload to get a result with operationId
+      // First upload to get a result with cid
       const operation = await manager.upload(file);
       const uploadResult = await operation.result;
 
-      expect(uploadResult.operationId).toBeDefined();
-      expect(uploadResult.size).toBeGreaterThan(0);
-      expect(uploadResult.name).toBe("test.car");
+      expect(uploadResult.cid).toBeDefined();
 
-      // Wait for operation using the upload result
+      // Wait for operation using the upload result (has cid, no operationId)
       const finalResult = await manager.waitForOperation(uploadResult);
 
-      // Verify original metadata is preserved
-      expect(finalResult.size).toBe(uploadResult.size);
-      expect(finalResult.name).toBe(uploadResult.name);
-      expect(finalResult.mimeType).toBe(uploadResult.mimeType);
-      expect(finalResult.numberOfFiles).toBe(uploadResult.numberOfFiles);
-      expect(finalResult.operationId).toBe(uploadResult.operationId);
+      // Verify the operation result has cid from the polling
+      expect(finalResult.cid).toBeDefined();
+      expect(finalResult.id).toBeDefined();
     });
 
     it("should support custom polling options", async () => {
@@ -438,6 +435,55 @@ describe("UploadManager Integration Tests", () => {
 
       await expect(manager.waitForOperation(operationId)).rejects.toThrow();
     });
+
+    describe("TUS upload result polling", () => {
+      it("should resolve CID from upload result endpoint for TUS uploads without cid", async () => {
+        const tusResult = {
+          [UploadResultSymbol]: true,
+          id: "tus-upload-123",
+          name: "large-file.car",
+          size: 150000000,
+          mimeType: "application/vnd.ipld.car",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+        };
+
+        const result = await manager.waitForOperation(tusResult);
+
+        expect(result).toBeDefined();
+        expect(result.cid).toBeDefined();
+        expect(result.id).toBe("tus-upload-123");
+      });
+
+      it("should throw when upload result endpoint returns failed status", async () => {
+        const tusResult = {
+          [UploadResultSymbol]: true,
+          id: "99999",
+          name: "failing-upload.car",
+          size: 1000,
+          mimeType: "application/vnd.ipld.car",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+        };
+
+        await expect(manager.waitForOperation(tusResult)).rejects.toThrow();
+      });
+
+      it("should throw when upload result has no id", async () => {
+        const noIdResult = {
+          [UploadResultSymbol]: true,
+          name: "orphan.car",
+          size: 1000,
+          mimeType: "application/vnd.ipld.car",
+          createdAt: new Date(),
+          numberOfFiles: 1,
+        };
+
+        await expect(manager.waitForOperation(noIdResult)).rejects.toThrow(
+          "No operation ID or CID provided",
+        );
+      });
+    });
   });
 
   describe("upload with waitForOperation option", () => {
@@ -452,7 +498,6 @@ describe("UploadManager Integration Tests", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
-      expect(result.operationId).toBeDefined();
       expect(result.cid).toBeDefined();
     });
 
@@ -471,7 +516,7 @@ describe("UploadManager Integration Tests", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
-      expect(result.operationId).toBeDefined();
+      expect(result.cid).toBeDefined();
     });
 
     it("should preserve upload metadata after waiting for operation", async () => {
@@ -486,10 +531,8 @@ describe("UploadManager Integration Tests", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
-      expect(result.operationId).toBeDefined();
-      expect(result.size).toBeGreaterThan(0);
-      expect(result.name).toBe("metadata-test.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      expect(result.cid).toBeDefined();
+      expect(result.id).toBeDefined();
     });
 
     it("should work with directory upload", async () => {
@@ -504,7 +547,6 @@ describe("UploadManager Integration Tests", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
-      expect(result.operationId).toBeDefined();
       expect(result.cid).toBeDefined();
       expect(result.isDirectory).toBe(true);
       expect(result.numberOfFiles).toBe(2);

--- a/libs/pinner/src/upload/__tests__/test-assertions.ts
+++ b/libs/pinner/src/upload/__tests__/test-assertions.ts
@@ -19,10 +19,12 @@ export function assertMockUploadResult(result: UploadResult) {
   expect(result).toEqual(MOCK_UPLOAD_RESULT);
 }
 
-export function assertValidUploadResult(result: UploadResult) {
+export function assertValidUploadResult(result: UploadResult, expectCid: boolean = true) {
   expect(result).toBeDefined();
   expect(result.id).toBeDefined();
-  expect(result.cid).toBeDefined();
+  if (expectCid) {
+    expect(result.cid).toBeDefined();
+  }
   expect(result.name).toBeDefined();
   expect(result.size).toBeGreaterThanOrEqual(0);
   expect(result.mimeType).toBeDefined();

--- a/libs/pinner/src/upload/__tests__/tus-upload.integration.spec.ts
+++ b/libs/pinner/src/upload/__tests__/tus-upload.integration.spec.ts
@@ -14,7 +14,7 @@ import { testConfig } from "@/__tests__/setup";
 
 describe("TUSUploadHandler Integration", () => {
   describe("upload method integration", () => {
-    it("should successfully upload a file via TUS protocol", async ({
+    it("should successfully upload a file via TUS protocol and return uploadId", async ({
       worker,
     }) => {
       const mockConfig = createMockConfig();
@@ -26,7 +26,26 @@ describe("TUSUploadHandler Integration", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
+      expect(result.id).toBeDefined();
+      expect(result.id).not.toBe("");
       assertUploadOperationStructure(operation);
+
+      handler.destroy();
+    }, 30000);
+
+    it("should not fabricate cid when server has none yet", async ({
+      worker,
+    }) => {
+      const mockConfig = createMockConfig();
+      const TUSUploadHandler = await importTUSUploadHandler();
+      const handler = new TUSUploadHandler(mockConfig);
+      const mockFile = createTestUploadFile();
+
+      const operation = await handler.upload(mockFile);
+      const result = await operation.result;
+
+      expect(result.id).toBeDefined();
+      expect(result.cid).toBeUndefined();
 
       handler.destroy();
     }, 30000);
@@ -84,6 +103,11 @@ describe("TUSUploadHandler Integration", () => {
       await operation.result;
 
       assertCallbackCalled(onComplete);
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.any(String),
+        }),
+      );
 
       handler.destroy();
     });

--- a/libs/pinner/src/upload/__tests__/xhr-upload.integration.spec.ts
+++ b/libs/pinner/src/upload/__tests__/xhr-upload.integration.spec.ts
@@ -11,7 +11,7 @@ describe("XHRUploadHandler Integration", () => {
   });
 
   describe("upload method integration", () => {
-    it("should successfully upload a file and return a result", async ({
+    it("should successfully upload a file and return a result with CID from server", async ({
       worker,
     }) => {
       const mockConfig = createMockConfig();
@@ -22,13 +22,27 @@ describe("XHRUploadHandler Integration", () => {
       const result = await operation.result;
 
       expect(result).toBeDefined();
-      expect(result.id).toMatch(/^test-upload-id(-\d+)?$/);
+      expect(result.cid).toBeDefined();
+      expect(result.cid).not.toBe("");
 
       const { CID } = await import("multiformats/cid");
       expect(() => CID.parse(result.cid)).not.toThrow();
 
-      expect(result.name).toBe("test.car");
-      expect(result.mimeType).toBe("application/vnd.ipld.car");
+      handler.destroy();
+    });
+
+    it("should map server CID (uppercase) to cid (lowercase)", async ({
+      worker,
+    }) => {
+      const mockConfig = createMockConfig();
+      const handler = new XHRUploadHandler(mockConfig);
+      const mockFile = createTestUploadFile();
+
+      const operation = await handler.upload(mockFile);
+      const result = await operation.result;
+
+      expect(result.cid).toBeDefined();
+      expect(result.cid).not.toBe("");
 
       handler.destroy();
     });
@@ -71,7 +85,7 @@ describe("XHRUploadHandler Integration", () => {
       handler.destroy();
     });
 
-    it("should call onComplete callback on successful upload", async ({
+    it("should call onComplete callback with cid from server response", async ({
       worker,
     }) => {
       const mockConfig = createMockConfig();
@@ -86,11 +100,7 @@ describe("XHRUploadHandler Integration", () => {
       assertCallbackCalled(onComplete);
       expect(onComplete).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: "test-upload-id",
           cid: expect.any(String),
-          name: "test.car",
-          size: 12,
-          mimeType: "application/vnd.ipld.car",
         }),
       );
 

--- a/libs/pinner/src/upload/base-upload.ts
+++ b/libs/pinner/src/upload/base-upload.ts
@@ -10,6 +10,8 @@ import type {
   UploadProgress,
   UploadResult,
 } from "@/types/upload";
+import { UploadResultSymbol } from "@/types/upload";
+import type { PostUploadResponse } from "@/api/generated/schemas";
 import { normalizeUploadInput, type UploadInputObject } from "./normalize";
 import {
   fileToReadableStream,
@@ -267,4 +269,36 @@ export abstract class BaseUploadHandler {
   protected abstract configurePlugin(uppy: Uppy): void;
   protected abstract parseResult(result: unknown): UploadResult;
   protected abstract getUploadSource(): string;
+
+  protected mapUploadResponse(
+    body: unknown,
+    uploadId: string,
+    overrides?: Partial<UploadResult>,
+  ): UploadResult {
+    if (body && typeof body === "object" && "CID" in body) {
+      const { CID } = body as PostUploadResponse;
+      return {
+        id: uploadId,
+        cid: CID,
+        name: "",
+        size: 0,
+        mimeType: "",
+        createdAt: new Date(),
+        numberOfFiles: 1,
+        [UploadResultSymbol]: true,
+        ...overrides,
+      };
+    }
+
+    return {
+      id: uploadId,
+      name: "",
+      size: 0,
+      mimeType: "",
+      createdAt: new Date(),
+      numberOfFiles: 1,
+      [UploadResultSymbol]: true,
+      ...overrides,
+    };
+  }
 }

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -1,10 +1,13 @@
 import type { OperationPollingOptions } from "@lumeweb/portal-sdk";
 import {
+  AccountError,
   OPERATION_STATUS,
   type OperationsQueryParams,
   Sdk,
+  poll,
 } from "@lumeweb/portal-sdk";
 import { createEqFilter } from "@lumeweb/query-builder";
+import type { UploadResultResponse } from "@/api/generated/schemas";
 
 import type { PinnerConfig } from "../config";
 import type {
@@ -34,6 +37,7 @@ import { EmptyFileError } from "../errors";
 import { type UploadInputObject } from "./normalize";
 
 export class UploadManager {
+  private config: PinnerConfig;
   private xhrHandler: XHRUploadHandler;
   private tusHandler: TUSUploadHandler;
   private portalSdk: Sdk;
@@ -41,6 +45,7 @@ export class UploadManager {
   private limitFetched: boolean = false;
 
   constructor(config: PinnerConfig) {
+    this.config = config;
     this.xhrHandler = new XHRUploadHandler(config);
     this.tusHandler = new TUSUploadHandler(config);
     this.portalSdk = new Sdk(config.endpoint || DEFAULT_ENDPOINT);
@@ -106,41 +111,22 @@ export class UploadManager {
   ): Promise<UploadResult> {
     // Scenario 1: UploadResult with operationId - use it directly
     if (isUploadResult(input) && input.operationId) {
-      const result = await this.portalSdk
-        .account()
-        .waitForOperation(input.operationId, options);
-
-      if (!result.success) {
-        throw new Error(
-          result.error?.message || `Operation ${input.operationId} failed`,
-        );
-      }
-
-      const operation = result.data;
-      if (!operation.cid) {
-        throw new Error(`Operation ${input.operationId} completed without CID`);
-      }
-
-      if (
-        operation.status?.toLowerCase() === OPERATION_STATUS.FAILED ||
-        operation.status?.toLowerCase() === OPERATION_STATUS.ERROR
-      ) {
-        throw new Error(
-          `Operation ${input.operationId} failed: ${operation.error || operation.status_message || "Unknown error"}`,
-        );
-      }
-
-      // Merge operation data into the original upload result
-      return {
-        ...input,
-        cid: operation.cid,
-        operationId: operation.id,
-      };
+      return await this.#waitForOperationById(input, options);
     }
 
     // Scenario 2: UploadResult with CID but no operationId - find by CID
     if (isUploadResult(input) && input.cid) {
       return await this.#waitForOperationByCid(input, options);
+    }
+
+    // Scenario 3: UploadResult with no CID and no operationId — TUS upload.
+    // Poll GET /api/upload/result/{id} to resolve the CID, then proceed via CID.
+    if (isUploadResult(input) && input.id) {
+      const resolved = await this.#waitForUploadResult(input, options);
+      if (resolved.cid) {
+        return await this.#waitForOperationByCid(resolved, options);
+      }
+      return resolved;
     }
 
     // Scenario 3: Only operation ID provided
@@ -202,6 +188,10 @@ export class UploadManager {
     uploadResult: UploadResult,
     options?: OperationPollingOptions,
   ): Promise<UploadResult> {
+    if (!uploadResult.cid) {
+      throw new Error("Cannot wait for operation by CID — CID not available. Use upload result ID to poll GET /api/upload/result/{id} instead.");
+    }
+
     // List operations filtered by CID
     const params: OperationsQueryParams = {
       filters: [createEqFilter("cid", uploadResult.cid)],
@@ -251,6 +241,90 @@ export class UploadManager {
       ...uploadResult,
       cid: finalOperation.cid,
       operationId: finalOperation.id,
+    };
+  }
+
+  async #waitForOperationById(
+    input: UploadResult,
+    options?: OperationPollingOptions,
+  ): Promise<UploadResult> {
+    const result = await this.portalSdk
+      .account()
+      .waitForOperation(input.operationId!, options);
+
+    if (!result.success) {
+      throw new Error(
+        result.error?.message || `Operation ${input.operationId} failed`,
+      );
+    }
+
+    const operation = result.data;
+    if (!operation.cid) {
+      throw new Error(`Operation ${input.operationId} completed without CID`);
+    }
+
+    if (
+      operation.status?.toLowerCase() === OPERATION_STATUS.FAILED ||
+      operation.status?.toLowerCase() === OPERATION_STATUS.ERROR
+    ) {
+      throw new Error(
+        `Operation ${input.operationId} failed: ${operation.error || operation.status_message || "Unknown error"}`,
+      );
+    }
+
+    return {
+      ...input,
+      cid: operation.cid,
+      operationId: operation.id,
+    };
+  }
+
+  async #waitForUploadResult(
+    uploadResult: UploadResult,
+    options?: OperationPollingOptions,
+  ): Promise<UploadResult> {
+    const uploadId = uploadResult.id;
+    if (!uploadId) {
+      throw new Error("No upload ID available to poll for upload result");
+    }
+
+    const baseUrl = this.config.endpoint || DEFAULT_ENDPOINT;
+    const fetchUrl = `${baseUrl}/api/upload/result/${encodeURIComponent(uploadId)}`;
+    const headers = { Authorization: `Bearer ${this.config.jwt}` };
+
+    const result = await poll<UploadResultResponse>(
+      async () => {
+        const response = await fetch(fetchUrl, { headers });
+
+        if (response.status === 404) {
+          return {
+            success: false,
+            error: new AccountError(`Upload result not found for ID ${uploadId}`, 404),
+          };
+        }
+
+        const body: UploadResultResponse = await response.json();
+
+        if (body.status === "failed") {
+          return {
+            success: false,
+            error: new AccountError(body.error || `Upload failed for ID ${uploadId}`, 500),
+          };
+        }
+
+        return { success: true, data: body };
+      },
+      (data) => data.status === "completed" || data.status === "duplicate",
+      { interval: options?.interval, timeout: options?.timeout },
+    );
+
+    if (!result.success) {
+      throw result.error;
+    }
+
+    return {
+      ...uploadResult,
+      ...(result.data.cid ? { cid: result.data.cid } : {}),
     };
   }
 

--- a/libs/pinner/src/upload/tus-upload.ts
+++ b/libs/pinner/src/upload/tus-upload.ts
@@ -1,7 +1,6 @@
 import Uppy from "@uppy/core";
 import TusPlugin from "@uppy/tus";
 import type { UploadResult } from "@/types/upload";
-import { UploadResultSymbol } from "@/types/upload";
 import { BaseUploadHandler } from "./base-upload";
 import type { PinnerConfig } from "@/config";
 import { UPLOAD_SOURCE_TUS } from "./constants";
@@ -16,7 +15,7 @@ export class TUSUploadHandler extends BaseUploadHandler {
       headers: {
         Authorization: `Bearer ${this.config.jwt}`,
       },
-      chunkSize: 10 * 1024 * 1024, // 10MB chunks
+      chunkSize: 10 * 1024 * 1024,
       retryDelays: [0, 1000, 3000, 5000],
     });
   }
@@ -25,55 +24,20 @@ export class TUSUploadHandler extends BaseUploadHandler {
     const uppyResponse = result as
       | {
           uploadURL: string;
-          body?: UploadResult;
+          body?: unknown;
         }
       | undefined;
 
     if (!uppyResponse) {
-      return {
-        id: "",
-        cid: "",
-        name: "",
-        size: 0,
-        mimeType: "",
-        createdAt: new Date(),
-        numberOfFiles: 1,
-        isDirectory: false,
-        [UploadResultSymbol]: true,
-      };
-    }
-
-    const response = uppyResponse.body;
-
-    if (response && response.cid) {
-      return {
-        id: response.id,
-        cid: response.cid,
-        name: response.name,
-        size: response.size,
-        mimeType: response.mimeType,
-        createdAt: new Date(response.createdAt),
-        numberOfFiles: response.numberOfFiles,
-        isDirectory: response.isDirectory ?? false,
-        keyvalues: response.keyvalues,
-        operationId: response.operationId,
-        [UploadResultSymbol]: true,
-      };
+      return this.mapUploadResponse(undefined, "");
     }
 
     const uploadId = uppyResponse.uploadURL?.split("/").pop() || "";
+    const body = uppyResponse.body;
 
-    return {
-      id: uploadId,
-      cid: "",
-      name: "",
-      size: 0,
-      mimeType: "",
-      createdAt: new Date(),
-      numberOfFiles: 1,
+    return this.mapUploadResponse(body, uploadId, {
       isDirectory: false,
-      [UploadResultSymbol]: true,
-    };
+    });
   }
 
   protected getUploadSource(): string {

--- a/libs/pinner/src/upload/xhr-upload.ts
+++ b/libs/pinner/src/upload/xhr-upload.ts
@@ -1,7 +1,6 @@
 import Uppy from "@uppy/core";
 import XHRUpload from "@lumeweb/uppy-post-upload";
 import type { UploadResult } from "@/types/upload";
-import { UploadResultSymbol } from "@/types/upload";
 import { BaseUploadHandler } from "./base-upload";
 import { UPLOAD_SOURCE_XHR } from "./constants";
 
@@ -20,33 +19,13 @@ export class XHRUploadHandler extends BaseUploadHandler {
   protected parseResult(result: unknown): UploadResult {
     const uppyResponse = result as {
       uploadURL: string;
-      body?: {
-        id: string;
-        cid: string;
-        name: string;
-        size: number;
-        mimeType: string;
-        createdAt: string;
-        numberOfFiles: number;
-        keyvalues?: Record<string, string>;
-        operationId?: number;
-      };
+      body?: unknown;
     };
 
-    const response = uppyResponse.body || (uppyResponse as any);
+    const body = uppyResponse.body;
+    const uploadId = uppyResponse.uploadURL?.split("/").pop() || "";
 
-    return {
-      id: response.id,
-      cid: response.cid,
-      name: response.name,
-      size: response.size,
-      mimeType: response.mimeType,
-      createdAt: new Date(response.createdAt),
-      numberOfFiles: response.numberOfFiles,
-      keyvalues: response.keyvalues,
-      operationId: response.operationId,
-      [UploadResultSymbol]: true,
-    };
+    return this.mapUploadResponse(body, uploadId);
   }
 
   protected getUploadSource(): string {

--- a/libs/portal-sdk/src/index.ts
+++ b/libs/portal-sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from "@/sdk";
 export * from "@/types";
 export * from "@/openapi";
 export { DEFAULT_SETTLED_STATES, OPERATION_STATUS } from "@/account";
+export { delay, poll, type PollOptions } from "@/http-utils";
 export * from "@/account/generated/accountAPI.schemas";
 export * from '@/account/generated/default';
 export * from '@/query-utils';


### PR DESCRIPTION
- **feat(portal-sdk): export poll, delay and PollOptions from http-utils**
- **fix(pinner): fix XHR/TUS upload response parsing and add TUS async CID resolution**

---

<!-- kody-pr-summary:start -->
This PR fixes the pinner upload response parsing to correctly handle the actual server API response format and properly support asynchronous CID resolution for TUS uploads.

**Key changes:**

- **Fix XHR upload response parsing**: The server's POST `/upload` endpoint returns `{ CID: "..." }` (uppercase), not a full `UploadResult` object. The previous code incorrectly expected the response body to contain all `UploadResult` fields. A new `mapUploadResponse` method in `BaseUploadHandler` now correctly maps the server's `CID` field to the client's `cid` property.

- **Make `cid` optional in `UploadResult`**: For TUS uploads, the CID is assigned asynchronously and is not available in the initial response. The `cid` field is now `cid?: string` to reflect this reality.

- **Add upload result polling for TUS uploads**: A new `GET /api/upload/result/{identifier}` endpoint is used to poll for the CID when it's not immediately available. The `UploadManager.waitForOperation()` now handles three scenarios: results with `operationId`, results with `cid`, and results with only an `id` (TUS uploads that need polling).

- **Add CID availability guards**: Pinata adapter methods now throw a clear error if the upload result has no CID yet, directing users to use `waitForOperation()` to poll for it.

- **Fix mock server handlers**: The MSW test handlers now return the correct response format (`{ CID: cid }` for XHR uploads, `{ data: [result] }` for list operations), and a new `uploadResultHandler` mock is added for the result polling endpoint.
<!-- kody-pr-summary:end -->