### PR TITLE
fix(pinner): correct root CID for directory uploads with wrapWithDirectory

### DIFF
--- a/libs/pinner/src/upload/__tests__/car.spec.ts
+++ b/libs/pinner/src/upload/__tests__/car.spec.ts
@@ -253,6 +253,29 @@ describe("car.ts", () => {
       expect(roots[0].toString()).toBe(result.rootCid);
     });
 
+    it("should produce correct root CID for mixed root-level and nested files", async () => {
+      const rootFile = createRegularFile("root content", "index.html");
+      const nestedFile = createRegularFile("nested content", "about.html");
+      setWebkitRelativePath(nestedFile, "about/index.html");
+
+      const files = [rootFile, nestedFile];
+      const result = await preprocessToCar(files);
+
+      const carBytes = await collectAsyncIterable(
+        readableStreamToAsyncIterable(result.carStream),
+      );
+      const metadata = await extractCarMetadata(carBytes);
+
+      expect(metadata.rootCid).toBe(result.rootCid);
+
+      const reader = await CarReader.fromBytes(carBytes);
+      const roots = await reader.getRoots();
+      expect(roots.length).toBe(1);
+      expect(roots[0].toString()).toBe(result.rootCid);
+
+      expect(metadata.blockCount).toBeGreaterThan(1);
+    });
+
     it("should handle large CAR file that must be streamed", async () => {
       const chunkSize = 1024 * 1024; // 1MB chunks
       const numChunks = 200; // 100MB total

--- a/libs/pinner/src/upload/car.ts
+++ b/libs/pinner/src/upload/car.ts
@@ -171,6 +171,11 @@ export async function preprocessToCar(
     files = [input];
   }
 
+  // wrapWithDirectory must be true for directory uploads (File[] input) so the
+  // last addAll yield is the root directory CID, not a child file/subdirectory.
+  // Single files don't need wrapping. Matches Go SDK wrapInDir behavior.
+  const wrapWithDirectory = Array.isArray(input);
+
   const heliaInstance = await getHelia();
   const fs = unixfs(heliaInstance);
   const c = car(heliaInstance);
@@ -184,6 +189,7 @@ export async function preprocessToCar(
   for await (const result of fs.addAll(src, {
     cidVersion: 1,
     rawLeaves: false,
+    wrapWithDirectory,
     signal: options?.signal,
     onProgress(event) {
       if (event.type === "blocks:put:blockstore:put") {


### PR DESCRIPTION
preprocessToCar captured the last addAll() yield as rootCid, but helia's
importer yields files first and directories last via depth-first flush.
Without wrapWithDirectory, the last yield could be a subdirectory CID
instead of the root directory containing all files.

Set wrapWithDirectory=true for File[] (directory) inputs so the importer
guarantees the last yield is the wrapping root directory. Single files
and streams keep wrapWithDirectory=false. Matches Go SDK wrapInDir behavior.

Add regression test for mixed root-level + nested files.

---

<!-- kody-pr-summary:start -->
Fix directory upload root CID by enabling `wrapWithDirectory` for multi-file inputs

When uploading a directory (array of files), the `wrapWithDirectory` option was not set, causing the last yield from `addAll` to potentially be a child file or subdirectory CID instead of the root directory CID. This fix sets `wrapWithDirectory: true` for directory uploads (File[] input) and `false` for single file uploads, matching the Go SDK's `wrapInDir` behavior. A test case for mixed root-level and nested files is also added to verify the correct root CID is produced.
<!-- kody-pr-summary:end -->