### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/purple-doors-allow.md
+++ b/.changeset/purple-doors-allow.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- correct root CID for directory uploads with wrapWithDirectory


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds a changeset documenting a patch fix for the `@lumeweb/pinner` package. The fix corrects the root CID (Content Identifier) returned for directory uploads when the `wrapWithDirectory` option is used, ensuring the correct CID is reported for wrapped directory uploads.
<!-- kody-pr-summary:end -->