### PR TITLE
fix(scripts): update changeset generator to target [changes] config after knope migration

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -1,3 +1,6 @@
+[changes]
+ignore_conventional_commits = true
+
 [packages."@lumeweb/advanced-rest"]
 versioned_files = ["libs/advanced-rest/package.json"]
 changelog = "libs/advanced-rest/CHANGELOG.md"
@@ -82,20 +85,15 @@ changelog = "libs/rego/CHANGELOG.md"
 versioned_files = ["libs/uppy-post-upload/package.json"]
 changelog = "libs/uppy-post-upload/CHANGELOG.md"
 
-[github]
-owner = "LumeWeb"
-repo = "web"
-
 [[workflows]]
 name = "release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
-ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "Command"
-command = "git commit -m \"chore: prepare releases\""
+command = 'git commit -m "chore: prepare releases"'
 
 [[workflows.steps]]
 type = "Command"
@@ -109,3 +107,7 @@ name = "document-change"
 
 [[workflows.steps]]
 type = "CreateChangeFile"
+
+[github]
+owner = "LumeWeb"
+repo = "web"

--- a/scripts/generate-changesets-from-release.js
+++ b/scripts/generate-changesets-from-release.js
@@ -401,12 +401,8 @@ class ChangesetGenerator {
     try {
       console.log("Temporarily modifying knope.toml...");
       await this.modifyKnopeConfig((config) => {
-        for (const workflow of config.workflows || []) {
-          for (const step of workflow.steps || []) {
-            if (step.type === "PrepareRelease") {
-              step.ignore_conventional_commits = false;
-            }
-          }
+        if (config.changes) {
+          config.changes.ignore_conventional_commits = false;
         }
       });
 

--- a/scripts/generate-changesets-from-release.js
+++ b/scripts/generate-changesets-from-release.js
@@ -401,9 +401,8 @@ class ChangesetGenerator {
     try {
       console.log("Temporarily modifying knope.toml...");
       await this.modifyKnopeConfig((config) => {
-        if (config.changes) {
-          config.changes.ignore_conventional_commits = false;
-        }
+        config.changes = config.changes || {};
+        config.changes.ignore_conventional_commits = false;
       });
 
       releaseOutput = await this.runKnopeDryRun();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Update changeset generator script to target the new `[changes]` config in knope.toml

The script was previously iterating through `workflows` and their `steps` to find `PrepareRelease` steps and set `ignore_conventional_commits = false`. After the knope migration, this configuration has moved to a top-level `changes` section, so the script now directly sets `config.changes.ignore_conventional_commits = false` instead.
<!-- kody-pr-summary:end -->