### PR TITLE
fix(go): add missing go.mod and handler.go for portal-plugin-billing

### DIFF
--- a/.changeset/wild-rings-fly.md
+++ b/.changeset/wild-rings-fly.md
@@ -1,0 +1,5 @@
+---
+"@lumeweb/portal-plugin-billing": patch
+---
+
+Add missing Go module files (go.mod and handler.go) for portal-plugin-billing

--- a/go/portal-plugin-billing/go.mod
+++ b/go/portal-plugin-billing/go.mod
@@ -1,0 +1,3 @@
+module go.lumeweb.com/web/go/portal-plugin-billing
+
+go 1.23

--- a/go/portal-plugin-billing/handler.go
+++ b/go/portal-plugin-billing/handler.go
@@ -1,0 +1,15 @@
+package portal_plugin_billing
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:build/*
+var appFs embed.FS
+
+func GetFS() fs.FS {
+	appFiles, _ := fs.Sub(appFs, "build")
+
+	return appFiles
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add missing Go source file for the portal-plugin-billing module

This PR adds the missing `handler.go` file for the `portal-plugin-billing` Go package. The file provides an embedded filesystem accessor that embeds the `build` directory contents and exposes them via a `GetFS()` function, enabling the billing plugin to serve its frontend build artifacts.
<!-- kody-pr-summary:end -->