### PR TITLE
chore: add changeset, fix knope to add billing

### DIFF
--- a/.changeset/swift-bears-jump.md
+++ b/.changeset/swift-bears-jump.md
@@ -1,0 +1,5 @@
+---
+@lumeweb/portal-plugin-billing: major
+---
+
+Initial release of the billing plugin with subscription management and Stripe integration

--- a/.changeset/wild-rings-fly.md
+++ b/.changeset/wild-rings-fly.md
@@ -1,5 +1,5 @@
 ---
-"@lumeweb/portal-plugin-billing": patch
+@lumeweb/portal-plugin-billing: patch
 ---
 
 Add missing Go module files (go.mod and handler.go) for portal-plugin-billing

--- a/knope.toml
+++ b/knope.toml
@@ -65,6 +65,10 @@ changelog = "libs/portal-plugin-dashboard/CHANGELOG.md"
 versioned_files = ["libs/portal-plugin-quota/package.json"]
 changelog = "libs/portal-plugin-quota/CHANGELOG.md"
 
+[packages."@lumeweb/portal-plugin-billing"]
+versioned_files = ["libs/portal-plugin-billing/package.json"]
+changelog = "libs/portal-plugin-billing/CHANGELOG.md"
+
 [packages."@lumeweb/portal-plugin-ipfs"]
 versioned_files = ["libs/portal-plugin-ipfs/package.json"]
 changelog = "libs/portal-plugin-ipfs/CHANGELOG.md"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset configuration for the `@lumeweb/portal-plugin-billing` package and fixes a formatting issue in an existing changeset.

**Changes:**
- Added a new major changeset (`swift-bears-jump`) marking the initial release of the billing plugin with subscription management and Stripe integration
- Registered `@lumeweb/portal-plugin-billing` in `knope.toml` with its versioned files and changelog path, enabling proper versioning and changelog generation for the package
- Fixed a formatting issue in the existing `wild-rings-fly` changeset by removing unnecessary quotes around the package name to match the expected format
<!-- kody-pr-summary:end -->