### PR TITLE
feat(ci): migrate lumeweb.com deployment from Cloudflare to Pinner

### DIFF
--- a/.github/workflows/deploy-lumeweb.com.yml
+++ b/.github/workflows/deploy-lumeweb.com.yml
@@ -3,25 +3,18 @@ name: Deploy lumeweb.com
 on:
   push:
     branches:
-      - '**'
+      - develop
     paths:
-      - 'apps/lumeweb.com/**'
-  pull_request:
-    branches:
-      - '**'
-    paths:
-      - 'apps/lumeweb.com/**'
+      - "apps/lumeweb.com/**"
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
-  pull-requests: write
   deployments: write
   contents: read
 
-
 jobs:
-  build:
+  deploy:
     name: Deploy lumeweb.com
     runs-on: ubuntu-latest
     steps:
@@ -31,16 +24,11 @@ jobs:
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
       - name: Build
         run: pnpm build:lumeweb.com
-      - name: Deploy to Cloudflare Pages
-        id: deploy_cf
-        uses: cloudflare/wrangler-action@v3
+      - name: Deploy to IPFS via Pinner
+        id: deploy_pinner
+        uses: lumeweb/pinner-deploy-action@v0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages deploy apps/lumeweb.com/dist --project-name=lumeweb-com
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-      - uses: mshick/add-pr-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          message: |
-            lumeweb.com has been deployed to [Staging](${{ steps.deploy_cf.outputs.deployment-url }}).
+          api-key: ${{ secrets.PINNER_API_KEY }}
+          path: apps/lumeweb.com/dist
+          domain: lumeweb.com
+          remove-previous: true


### PR DESCRIPTION
Switch deploy-lumeweb.com.yml from Cloudflare Pages to IPFS via lumeweb/pinner-deploy-action. Triggers on develop branch only (no PR previews — Pinner doesn't support them). Uses remove-previous to clean old pins on deploy.

---

<!-- kody-pr-summary:start -->
This pull request migrates the deployment process for `lumeweb.com` from Cloudflare Pages to IPFS using the Pinner service. 

Key changes include:
- Replacing the Cloudflare Wrangler deployment action with the `lumeweb/pinner-deploy-action`, configured to deploy the built assets, set the domain to `lumeweb.com`, and remove previous deployments.
- Updating the workflow triggers to only run on pushes to the `develop` branch, removing the previous trigger for all branches and pull requests.
- Removing the `pull-requests: write` permission and the step that commented the Cloudflare deployment URL on pull requests, as PR deployments are no longer triggered.
<!-- kody-pr-summary:end -->