### PR TITLE
Fix/queryclient context refactor

### DIFF
--- a/libs/portal-framework-ui/src/components/app/AppComponent.tsx
+++ b/libs/portal-framework-ui/src/components/app/AppComponent.tsx
@@ -73,7 +73,6 @@ function AppContent({
   loadNavigation = true,
   loadRoutes = true,
 }: AppContentProps) {
-  useIdentifyUser();
   const {
     error: frameworkError,
     framework,
@@ -178,6 +177,49 @@ function AppContent({
     addMenuItems,
   ]);
 
+  const options = {
+    ...pluginConfigs,
+    options: getDefaultRefineOptions(),
+    routerProvider,
+  } satisfies Partial<RefineProps>;
+
+  return (
+    <Refine {...options}>
+      <AppContentInner
+        error={error}
+        framework={framework}
+        frameworkError={frameworkError}
+        isFrameworkLoading={isFrameworkLoading}
+        isLoading={isLoading}
+        loadNavigation={loadNavigation}
+        loadRoutes={loadRoutes}
+        routes={routes}
+      />
+    </Refine>
+  );
+}
+
+function AppContentInner({
+  error,
+  framework,
+  frameworkError,
+  isFrameworkLoading,
+  isLoading,
+  loadNavigation,
+  loadRoutes,
+  routes,
+}: {
+  error: Error | null;
+  framework: Framework | null;
+  frameworkError: Error | null;
+  isFrameworkLoading: boolean;
+  isLoading: boolean;
+  loadNavigation: boolean;
+  loadRoutes: boolean;
+  routes: null | RouteDefinition[];
+}) {
+  useIdentifyUser();
+
   // Show loading state while framework is loading or we're loading navigation
   if (isFrameworkLoading || isLoading) {
     return <LoadingSpinner />;
@@ -204,9 +246,6 @@ function AppContent({
   if (!routes) {
     return null;
   }
-
-  // Spread plugin configs into a single object for Refine
-  const combinedPluginConfig = Object.assign({}, ...pluginConfigs);
 
   const routerRoutes = createRoutesFromElements(
     Array.isArray(routes)
@@ -243,12 +282,10 @@ function AppContent({
     );
 
     return (
-      // @ts-ignore
       <Route
         element={finalElement}
         errorElement={<RouteErrorBoundary />}
         index={route.index}
-        key={route.id}
         path={route.path}>
         {childRoutes}
       </Route>
@@ -261,20 +298,14 @@ function AppContent({
     router = createBrowserRouter(routerRoutes);
   }
 
-  const options = {
-    ...combinedPluginConfig,
-    options: getDefaultRefineOptions(),
-    routerProvider,
-  } satisfies Partial<RefineProps>;
-
   return (
-    <Refine {...options}>
+    <>
       <DialogProvider>
         {router && <RouterProvider router={router} />}
         {!router && <DialogRenderer />}
       </DialogProvider>
       <Toaster />
-    </Refine>
+    </>
   );
 }
 
@@ -283,7 +314,7 @@ function getLazyComponent(
   pluginId: NamespacedId | undefined,
   framework: Framework, // Pass framework instance
   routeId: NamespacedId | string, // For logging
-): ComponentType<any> | null {
+): ComponentType<unknown> | null {
   if (!componentString || !pluginId) {
     console.error(
       `Route Error: Missing component string or pluginId for route id ${routeId}`,
@@ -326,7 +357,7 @@ function getLazyComponent(
   }
 
   try {
-    //@ts-ignore
+    //@ts-expect-error -- createRemoteComponentLoader return type mismatch
     return createRemoteComponentLoader(
       { componentPath: componentName, pluginId: pluginId },
       framework,

--- a/libs/portal-plugin-quota/package.json
+++ b/libs/portal-plugin-quota/package.json
@@ -37,6 +37,7 @@
     "react-router": "catalog:"
   },
   "devDependencies": {
+    "@lumeweb/analytics": "workspace:*",
     "@mswjs/interceptors": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "npm-run-all": "catalog:",
     "orval": "catalog:",
     "oxlint": "^1.64.0",
+    "oxlint-tsgolint": "catalog:",
     "p-queue": "^9.2.0",
     "playwright": "catalog:",
     "prettier": "^3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ catalogs:
     otpauth:
       specifier: ^9.5.1
       version: 9.5.1
+    oxlint-tsgolint:
+      specifier: ^0.23.0
+      version: 0.23.0
     p-queue:
       specifier: ^9.2.0
       version: 9.2.0
@@ -383,7 +386,10 @@ importers:
         version: 8.10.0(@faker-js/faker@10.4.0)(prettier@3.8.3)(typescript@6.0.3)
       oxlint:
         specifier: ^1.64.0
-        version: 1.64.0
+        version: 1.64.0(oxlint-tsgolint@0.23.0)
+      oxlint-tsgolint:
+        specifier: 'catalog:'
+        version: 0.23.0
       p-queue:
         specifier: ^9.2.0
         version: 9.2.0
@@ -2042,6 +2048,9 @@ importers:
         specifier: 'catalog:'
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     devDependencies:
+      '@lumeweb/analytics':
+        specifier: workspace:*
+        version: link:../analytics
       '@mswjs/interceptors':
         specifier: 'catalog:'
         version: 0.41.9
@@ -4787,6 +4796,36 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.64.0':
     resolution: {integrity: sha512-2r6Nq3XXGLHEXKkSj8JtmJ6N4gDw431DPFOg0ZoJHlNjnG6HVMm/ksQ10m0HJ8WBvwgMe1L50UHPaYZutCRPCw==}
@@ -12242,6 +12281,10 @@ packages:
     resolution: {integrity: sha512-FktCvLby/mOHyuijZt22+nOt10dS24gGUZE3XwIbUg7Kf4+rer3/5T7RgwzazlNuVsCjPloZ3p8E+4ONT3A8Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxlint-tsgolint@0.23.0:
+    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+    hasBin: true
+
   oxlint@1.64.0:
     resolution: {integrity: sha512-Star3SNpWPeWFPw7kRXIhXUSn6fdiAl25q15CQzH/9WaOtG6e9CWTc25vNZOCr4PE1yEP1GtKJKIKglhj3OmEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -18856,6 +18899,24 @@ snapshots:
   '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.23.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.23.0':
+    optional: true
 
   '@oxlint/binding-android-arm-eabi@1.64.0':
     optional: true
@@ -27948,7 +28009,16 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.126.0
       '@oxc-parser/binding-win32-x64-msvc': 0.126.0
 
-  oxlint@1.64.0:
+  oxlint-tsgolint@0.23.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.23.0
+      '@oxlint-tsgolint/darwin-x64': 0.23.0
+      '@oxlint-tsgolint/linux-arm64': 0.23.0
+      '@oxlint-tsgolint/linux-x64': 0.23.0
+      '@oxlint-tsgolint/win32-arm64': 0.23.0
+      '@oxlint-tsgolint/win32-x64': 0.23.0
+
+  oxlint@1.64.0(oxlint-tsgolint@0.23.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.64.0
       '@oxlint/binding-android-arm64': 1.64.0
@@ -27969,6 +28039,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.64.0
       '@oxlint/binding-win32-ia32-msvc': 1.64.0
       '@oxlint/binding-win32-x64-msvc': 1.64.0
+      oxlint-tsgolint: 0.23.0
 
   p-defer@4.0.1: {}
 
@@ -31086,7 +31157,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.9.1)(@vitejs/devtools@0.1.22)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ catalog:
   '@module-federation/enhanced': ^0.24.1
   '@module-federation/vite': ^1.16.4
   '@mswjs/interceptors': ^0.41.9
+  oxlint-tsgolint: ^0.23.0
   '@radix-ui/react-dropdown-menu': ^2.1.16
   '@radix-ui/react-icons': ^1.3.2
   '@radix-ui/react-navigation-menu': ^1.2.14


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR fixes a QueryClient context issue by refactoring the `AppContent` component structure, and includes several code quality improvements and dependency updates.

### Key Changes

**Fix QueryClient context error**: The `Refine` provider (which provides React Query's QueryClient context) has been moved to wrap the component that calls `useIdentifyUser()`. Previously, `useIdentifyUser()` was called in `AppContent` *before* the `Refine` provider was rendered, causing a missing context error. The fix extracts a new `AppContentInner` component that is wrapped by `Refine`, ensuring the hook has access to the required context.

**Code quality improvements in `AppComponent.tsx`**:
- Replaced `@ts-ignore` with `@ts-expect-error` with descriptive comments for better type-safety documentation
- Changed `ComponentType<any>` to `ComponentType<unknown>` for stricter typing
- Removed unnecessary `key={route.id}` prop on `Route` component
- Simplified plugin config merging (spreads `pluginConfigs` directly instead of using `Object.assign`)

**Dependency updates**:
- Added `oxlint-tsgolint` (v0.23.0) to the workspace catalog
- Added `@lumeweb/analytics` as a dev dependency
- Minor bump for `tinyglobby` (0.2.16 → 0.2.17)
<!-- kody-pr-summary:end -->