### PR TITLE
fix: MF bootstrap respects entryFileNames dir and rebases imports

### DIFF
--- a/.changeset/mf-bootstrap-entryFileNames-patch.md
+++ b/.changeset/mf-bootstrap-entryFileNames-patch.md
@@ -1,0 +1,14 @@
+---
+"@lumeweb/portal-app-shell": patch
+"@lumeweb/portal-plugin-abuse": patch
+"@lumeweb/portal-plugin-abuse-report": patch
+"@lumeweb/portal-plugin-admin": patch
+"@lumeweb/portal-plugin-billing": patch
+"@lumeweb/portal-plugin-core": patch
+"@lumeweb/portal-plugin-dashboard": patch
+"@lumeweb/portal-plugin-ipfs": patch
+"@lumeweb/portal-plugin-lbry": patch
+"@lumeweb/portal-plugin-quota": patch
+---
+
+Patch @module-federation/vite to respect entryFileNames directory for bootstrap file output. Fixes doubled path bug (static/js/static/js/) when bootstrap is emitted to a subdirectory.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
       "pluralize": "patches/pluralize.patch",
       "papaparse": "patches/papaparse.patch",
       "@uppy/core": "patches/@uppy__core.patch",
-      "better-sse@0.16.1": "patches/better-sse@0.16.1.patch"
+      "better-sse@0.16.1": "patches/better-sse@0.16.1.patch",
+      "@module-federation/vite": "patches/@module-federation__vite.patch"
     },
     "onlyBuiltDependencies": [
       "@ipshipyard/node-datachannel",

--- a/patches/@module-federation__vite.patch
+++ b/patches/@module-federation__vite.patch
@@ -1,0 +1,13573 @@
+diff --git a/lib/index.cjs b/lib/index.cjs
+index f4c8617a0f355d29ee97f45473c38cfe2d32f4c4..46076094646737c9898ef07d08fa3e716a307bad 100644
+--- a/lib/index.cjs
++++ b/lib/index.cjs
+@@ -1,148 +1,68 @@
+ Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+-const require_packageUtils = require("./packageUtils-se-UDhCa.cjs");
++//#region \0rolldown/runtime.js
++var __create = Object.create;
++var __defProp = Object.defineProperty;
++var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
++var __getOwnPropNames = Object.getOwnPropertyNames;
++var __getProtoOf = Object.getPrototypeOf;
++var __hasOwnProp = Object.prototype.hasOwnProperty;
++var __copyProps = (to, from, except, desc) => {
++	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
++		key = keys[i];
++		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
++			get: ((k) => from[k]).bind(null, key),
++			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
++		});
++	}
++	return to;
++};
++var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
++	value: mod,
++	enumerable: true
++}) : target, mod));
++//#endregion
++let defu = require("defu");
++defu = __toESM(defu);
+ let fs = require("fs");
+-fs = require_packageUtils.__toESM(fs);
++fs = __toESM(fs);
+ let module$1 = require("module");
+ let pathe = require("pathe");
+-pathe = require_packageUtils.__toESM(pathe);
+-let vite = require("vite");
+-let node_crypto = require("node:crypto");
++pathe = __toESM(pathe);
++let magic_string = require("magic-string");
++magic_string = __toESM(magic_string);
++let _module_federation_sdk = require("@module-federation/sdk");
++let _module_federation_dts_plugin = require("@module-federation/dts-plugin");
++let _module_federation_dts_plugin_core = require("@module-federation/dts-plugin/core");
++let _rollup_pluginutils = require("@rollup/pluginutils");
+ let url = require("url");
+ let es_module_lexer = require("es-module-lexer");
+-//#region src/utils/codeRewriter.ts
+-const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+-var CodeRewriter = class {
+-	replacements = [];
+-	constructor(original) {
+-		this.original = original;
+-	}
+-	overwrite(start, end, content) {
+-		if (start < 0 || end < start || end > this.original.length) throw new Error(`Invalid overwrite range: ${start}-${end}`);
+-		this.replacements.push({
+-			start,
+-			end,
+-			content
+-		});
+-	}
+-	toString() {
+-		return applyReplacements(this.original, this.getSortedReplacements()).code;
+-	}
+-	generateMap(source = "") {
+-		const { code, replacements } = applyReplacements(this.original, this.getSortedReplacements());
+-		return {
+-			version: 3,
+-			sources: [source],
+-			sourcesContent: [this.original],
+-			names: [],
+-			mappings: generateLineMappings(code, this.original, replacements)
+-		};
+-	}
+-	getSortedReplacements() {
+-		return [...this.replacements].sort((a, b) => a.start - b.start || a.end - b.end);
+-	}
+-};
+-function createSourceMap(code, source = "") {
+-	return {
+-		version: 3,
+-		sources: [source],
+-		sourcesContent: [code],
+-		names: [],
+-		mappings: generateLineMappings(code, code, [])
+-	};
+-}
+-function applyReplacements(original, replacements) {
+-	let code = "";
+-	let cursor = 0;
+-	let delta = 0;
+-	const applied = [];
+-	for (const replacement of replacements) {
+-		if (replacement.start < cursor) throw new Error("Overlapping overwrite ranges are not supported");
+-		code += original.slice(cursor, replacement.start);
+-		const generatedStart = replacement.start + delta;
+-		code += replacement.content;
+-		const generatedEnd = generatedStart + replacement.content.length;
+-		applied.push({
+-			...replacement,
+-			generatedStart,
+-			generatedEnd
+-		});
+-		cursor = replacement.end;
+-		delta += replacement.content.length - (replacement.end - replacement.start);
+-	}
+-	code += original.slice(cursor);
+-	return {
+-		code,
+-		replacements: applied
+-	};
+-}
+-function generateLineMappings(generated, original, replacements) {
+-	const generatedLineStarts = getLineStarts(generated);
+-	const originalLineStarts = getLineStarts(original);
+-	let previousOriginalLine = 0;
+-	let previousOriginalColumn = 0;
+-	let mappings = "";
+-	generatedLineStarts.forEach((generatedOffset, lineIndex) => {
+-		if (lineIndex > 0) mappings += ";";
+-		const originalOffset = generatedOffsetToOriginalOffset(generatedOffset, replacements);
+-		const originalLine = findLine(originalLineStarts, originalOffset);
+-		const originalColumn = originalOffset - originalLineStarts[originalLine];
+-		mappings += encodeSegment([
+-			0,
+-			0,
+-			originalLine - previousOriginalLine,
+-			originalColumn - previousOriginalColumn
+-		]);
+-		previousOriginalLine = originalLine;
+-		previousOriginalColumn = originalColumn;
+-	});
+-	return mappings;
+-}
+-function generatedOffsetToOriginalOffset(offset, replacements) {
+-	let delta = 0;
+-	for (const replacement of replacements) {
+-		if (offset < replacement.generatedStart) break;
+-		if (offset < replacement.generatedEnd) return replacement.start;
+-		delta += replacement.content.length - (replacement.end - replacement.start);
+-	}
+-	return offset - delta;
+-}
+-function getLineStarts(code) {
+-	const starts = [0];
+-	for (let i = 0; i < code.length; i++) if (code.charCodeAt(i) === 10) starts.push(i + 1);
+-	return starts;
+-}
+-function findLine(lineStarts, offset) {
+-	let low = 0;
+-	let high = lineStarts.length - 1;
+-	while (low <= high) {
+-		const mid = low + high >> 1;
+-		if (lineStarts[mid] <= offset) low = mid + 1;
+-		else high = mid - 1;
+-	}
+-	return Math.max(0, high);
+-}
+-function encodeSegment(values) {
+-	return values.map(encodeVlq).join("");
+-}
+-function encodeVlq(value) {
+-	let vlq = value < 0 ? (-value << 1) + 1 : value << 1;
+-	let encoded = "";
+-	do {
+-		let digit = vlq & 31;
+-		vlq >>>= 5;
+-		if (vlq > 0) digit |= 32;
+-		encoded += BASE64_CHARS[digit];
+-	} while (vlq > 0);
+-	return encoded;
++//#region src/utils/buildPaths.ts
++function getEntryFileNamesDir(rollupOutput) {
++	const outOpts = Array.isArray(rollupOutput) ? rollupOutput[0] : rollupOutput;
++	const entryPattern = typeof outOpts?.entryFileNames === "string" ? outOpts.entryFileNames : void 0;
++	if (!entryPattern) return "";
++	const nameIdx = entryPattern.indexOf("[name]");
++	if (nameIdx === -1) return "";
++	return entryPattern.slice(0, nameIdx);
++}
++function rebaseImport(importSrc, dir) {
++	if (!dir) return importSrc;
++	const prefix = "./" + dir;
++	if (importSrc.startsWith(prefix)) return "./" + importSrc.slice(prefix.length);
++	const absPrefix = "/" + dir;
++	if (importSrc.startsWith(absPrefix)) return "/" + importSrc.slice(absPrefix.length);
++	if (importSrc.startsWith(dir)) return "./" + importSrc.slice(dir.length);
++	return importSrc;
+ }
+ //#endregion
+ //#region src/utils/mapCodeToCodeWithSourcemap.ts
+ async function mapCodeToCodeWithSourcemap(code) {
+ 	const resolvedCode = await code;
+ 	if (resolvedCode === void 0) return;
++	const s = new magic_string.default(resolvedCode);
+ 	return {
+-		code: resolvedCode,
+-		map: createSourceMap(resolvedCode)
++		code: s.toString(),
++		map: s.generateMap({ hires: true })
+ 	};
+ }
+ //#endregion
+@@ -170,6 +90,228 @@ function injectEntryScript(html, initSrc) {
+ 	return html.replace("<head>", `<head><script type="module" src=${JSON.stringify(src)}><\/script>`);
+ }
+ //#endregion
++//#region src/utils/logger.ts
++const MODULE_FEDERATION_LOG_PREFIX = "[Module Federation]";
++function formatModuleFederationMessage(message) {
++	return `${MODULE_FEDERATION_LOG_PREFIX} ${message}`;
++}
++function createModuleFederationError(message) {
++	return new Error(formatModuleFederationMessage(message));
++}
++function toConsoleArgs(message, rest = []) {
++	if (typeof message === "string") return [formatModuleFederationMessage(message), ...rest];
++	if (message === void 0) return [MODULE_FEDERATION_LOG_PREFIX, ...rest];
++	return [
++		MODULE_FEDERATION_LOG_PREFIX,
++		message,
++		...rest
++	];
++}
++const moduleFederationConsole = {
++	log(message, ...rest) {
++		console.log(...toConsoleArgs(message, rest));
++	},
++	warn(message, ...rest) {
++		console.warn(...toConsoleArgs(message, rest));
++	},
++	error(message, ...rest) {
++		console.error(...toConsoleArgs(message, rest));
++	}
++};
++moduleFederationConsole.log;
++const mfWarn = moduleFederationConsole.warn;
++const mfError = moduleFederationConsole.error;
++//#endregion
++//#region src/utils/packageUtils.ts
++const dependencyPresenceCache = /* @__PURE__ */ new Map();
++let packageDetectionCwd;
++function getDependencyCacheKey(cwd, dependencyName) {
++	return `${cwd}:${dependencyName}`;
++}
++function setPackageDetectionCwd(cwd) {
++	packageDetectionCwd = cwd;
++}
++function getPackageDetectionCwd() {
++	return packageDetectionCwd || process.cwd();
++}
++const DEFAULT_EXPORT_CONDITIONS = [
++	"browser",
++	"import",
++	"module",
++	"default",
++	"require"
++];
++function resolveExportsEntry(exportsField, conditions = DEFAULT_EXPORT_CONDITIONS) {
++	if (typeof exportsField === "string") return exportsField;
++	if (!exportsField || typeof exportsField !== "object") return void 0;
++	const record = exportsField;
++	const rootExport = record["."];
++	if (rootExport) return resolveExportsEntry(rootExport);
++	for (const condition of conditions) {
++		const target = resolveExportsEntry(record[condition], conditions);
++		if (target) return target;
++	}
++	for (const target of Object.values(record)) {
++		const resolved = resolveExportsEntry(target, conditions);
++		if (resolved) return resolved;
++	}
++}
++function getPackageExportsTarget(pkg, packageName, exportsField) {
++	if (typeof exportsField === "string") return pkg === packageName ? exportsField : void 0;
++	if (!exportsField || typeof exportsField !== "object") return void 0;
++	const record = exportsField;
++	const subpath = pkg === packageName ? "." : `.${pkg.slice(packageName.length)}`;
++	if (subpath !== ".") return record[subpath];
++	return record["."] ?? (!Object.keys(record).some((key) => key.startsWith(".")) ? record : void 0);
++}
++/**
++* Escaping rules:
++* Convert using the format __${mapping}__, where _ and $ are not allowed in npm package names but can be used in variable names.
++*  @ => 1
++*  / => 2
++*  - => 3
++*  . => 4
++*/
++/**
++* Encodes a package name into a valid file name.
++* @param {string} name - The package name, e.g., "@scope/xx-xx.xx".
++* @returns {string} - The encoded file name.
++*/
++function packageNameEncode(name) {
++	if (typeof name !== "string") throw createModuleFederationError("A string package name is required");
++	return name.replace(/@/g, "_mf_0_").replace(/\//g, "_mf_1_").replace(/-/g, "_mf_2_").replace(/\./g, "_mf_3_");
++}
++/**
++* Decodes an encoded file name back to the original package name.
++* @param {string} encoded - The encoded file name, e.g., "_mf_0_scope_mf_1_xx_mf_2_xx_mf_3_xx".
++* @returns {string} - The decoded package name.
++*/
++function packageNameDecode(encoded) {
++	if (typeof encoded !== "string") throw createModuleFederationError("A string encoded file name is required");
++	return encoded.replace(/_mf_0_/g, "@").replace(/_mf_1_/g, "/").replace(/_mf_2_/g, "-").replace(/_mf_3_/g, ".");
++}
++/**
++* Removes any subpath from an npm package specifier and returns the package name only.
++* @param {string} packageString - The package specifier, e.g., "@scope/pkg/runtime" or "react/jsx-runtime".
++* @returns {string} - The base npm package name.
++*/
++function getPackageName(packageString) {
++	const match = packageString.match(/^(?:@[^/]+\/)?[^/]+/);
++	return match ? match[0] : packageString;
++}
++function getInstalledPackageJson(pkg, opts) {
++	const cwd = opts?.cwd || getPackageDetectionCwd();
++	const packageName = opts?.packageName || getPackageName(pkg);
++	const tryReadPackageJson = (packageJsonPath) => {
++		if (!(0, fs.existsSync)(packageJsonPath)) return void 0;
++		try {
++			return {
++				path: packageJsonPath,
++				dir: pathe.default.dirname(packageJsonPath),
++				packageJson: JSON.parse((0, fs.readFileSync)(packageJsonPath, "utf-8"))
++			};
++		} catch {
++			return;
++		}
++	};
++	const findPackageInPnpmStore = (startDir) => {
++		let currentDir = startDir;
++		const rootDir = pathe.default.parse(currentDir).root;
++		while (true) {
++			const pnpmStoreDir = pathe.default.join(currentDir, "node_modules", ".pnpm");
++			if ((0, fs.existsSync)(pnpmStoreDir)) try {
++				for (const entry of (0, fs.readdirSync)(pnpmStoreDir, { withFileTypes: true })) {
++					if (!entry.isDirectory()) continue;
++					const candidate = tryReadPackageJson(pathe.default.join(pnpmStoreDir, entry.name, "node_modules", packageName, "package.json"));
++					if (candidate?.packageJson.name === packageName) return candidate;
++				}
++			} catch {}
++			if (currentDir === rootDir) break;
++			currentDir = pathe.default.dirname(currentDir);
++		}
++	};
++	try {
++		const projectRequire = (0, module$1.createRequire)(new URL(`file://${pathe.default.join(cwd, "package.json")}`));
++		let resolvedPath;
++		if (opts?.fromResolvedEntry) resolvedPath = opts.fromResolvedEntry;
++		else try {
++			resolvedPath = projectRequire.resolve(pkg);
++		} catch {
++			resolvedPath = projectRequire.resolve(packageName);
++		}
++		let currentDir = pathe.default.dirname(resolvedPath);
++		const rootDir = pathe.default.parse(currentDir).root;
++		while (true) {
++			const packageJsonPath = pathe.default.join(currentDir, "package.json");
++			if ((0, fs.existsSync)(packageJsonPath)) {
++				const packageJsonContent = (0, fs.readFileSync)(packageJsonPath, "utf-8");
++				try {
++					const packageJson = JSON.parse(packageJsonContent);
++					if (packageJson.name === packageName) return {
++						path: packageJsonPath,
++						dir: currentDir,
++						packageJson
++					};
++				} catch (error) {
++					if (!(error instanceof SyntaxError)) throw error;
++				}
++			}
++			if (currentDir === rootDir) break;
++			currentDir = pathe.default.dirname(currentDir);
++		}
++	} catch {
++		let currentDir = cwd;
++		const rootDir = pathe.default.parse(currentDir).root;
++		while (true) {
++			const directCandidate = tryReadPackageJson(pathe.default.join(currentDir, "node_modules", packageName, "package.json"));
++			if (directCandidate?.packageJson.name === packageName) return directCandidate;
++			if (currentDir === rootDir) break;
++			currentDir = pathe.default.dirname(currentDir);
++		}
++		return findPackageInPnpmStore(cwd);
++	}
++}
++function getInstalledPackageEntry(pkg, opts) {
++	const installed = getInstalledPackageJson(pkg, opts);
++	if (!installed) return void 0;
++	const cwd = opts?.cwd || getPackageDetectionCwd();
++	const packageName = opts?.packageName || getPackageName(pkg);
++	if (pkg !== packageName && opts?.resolveSubpathWithRequire !== false) try {
++		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(cwd, "package.json")}`)).resolve(pkg);
++	} catch {}
++	const packageJson = installed.packageJson;
++	const explicitEntry = resolveExportsEntry(getPackageExportsTarget(pkg, packageName, packageJson.exports), opts?.conditions) || (typeof packageJson.module === "string" ? packageJson.module : void 0) || (typeof packageJson.main === "string" ? packageJson.main : void 0) || "index.js";
++	return pathe.default.join(installed.dir, explicitEntry);
++}
++/**
++* Detect whether the current runtime is Vite 8+ by checking for a Vite version flag
++* on the plugin hook context, with Rolldown metadata kept as a compatibility fallback.
++*/
++function getIsRolldown(ctx) {
++	const viteVersion = ctx?.meta?.viteVersion;
++	const viteMajor = Number(String(viteVersion ?? "").split(".")[0]);
++	return Number.isFinite(viteMajor) && viteMajor >= 8 || !!ctx?.meta?.rolldownVersion;
++}
++function hasPackageDependency(dependencyName, cwd = packageDetectionCwd || process.cwd()) {
++	const cacheKey = getDependencyCacheKey(cwd, dependencyName);
++	const cached = dependencyPresenceCache.get(cacheKey);
++	if (cached !== void 0) return cached;
++	try {
++		const packageJson = JSON.parse((0, fs.readFileSync)(pathe.default.join(cwd, "package.json"), "utf8"));
++		const hasDependency = [
++			packageJson.dependencies,
++			packageJson.devDependencies,
++			packageJson.peerDependencies,
++			packageJson.optionalDependencies
++		].some((deps) => !!deps?.[dependencyName]);
++		dependencyPresenceCache.set(cacheKey, hasDependency);
++		return hasDependency;
++	} catch {
++		dependencyPresenceCache.set(cacheKey, false);
++		return false;
++	}
++}
++//#endregion
+ //#region src/utils/normalizeModuleFederationOptions.ts
+ const INTERNAL_NAME_PREFIX = "__mfe_internal__";
+ function toInternalModuleFederationName(name) {
+@@ -177,7 +319,7 @@ function toInternalModuleFederationName(name) {
+ }
+ function warnOnReservedInternalNamePrefix(name, kind) {
+ 	if (!name.startsWith(INTERNAL_NAME_PREFIX)) return;
+-	require_packageUtils.mfWarn(`Reserved internal ${kind} prefix "${INTERNAL_NAME_PREFIX}" detected in public ${kind} "${name}". This prefix is reserved for internal module federation names and may cause conflicts.`);
++	mfWarn(`Reserved internal ${kind} prefix "${INTERNAL_NAME_PREFIX}" detected in public ${kind} "${name}". This prefix is reserved for internal module federation names and may cause conflicts.`);
+ }
+ function normalizeExposesItem(item) {
+ 	let importPath = "";
+@@ -241,7 +383,7 @@ function normalizeRemoteItem(key, remote) {
+ * @returns {string | undefined}
+ */
+ function searchPackageVersion(sharedName) {
+-	const version = require_packageUtils.getInstalledPackageJson(sharedName)?.packageJson.version;
++	const version = getInstalledPackageJson(sharedName, { packageName: sharedName })?.packageJson.version;
+ 	return typeof version === "string" ? version : void 0;
+ }
+ function inferVersionFromRequiredVersion(requiredVersion) {
+@@ -250,13 +392,27 @@ function inferVersionFromRequiredVersion(requiredVersion) {
+ }
+ function getLitExportSubpathShares(sharedName) {
+ 	if (sharedName !== "lit") return [];
+-	const exportsField = require_packageUtils.getInstalledPackageJson(sharedName, { packageName: sharedName })?.packageJson.exports;
++	const exportsField = getInstalledPackageJson(sharedName, { packageName: sharedName })?.packageJson.exports;
+ 	if (!exportsField || typeof exportsField === "string") return [];
+ 	return Object.keys(exportsField).filter((key) => key.startsWith("./") && key !== "." && !key.includes("*")).map((key) => `${sharedName}/${key.slice(2)}`);
+ }
+ function normalizeShareItem(key, shareItem) {
+-	const isImportFalse = typeof shareItem === "object" && shareItem.import === false;
+-	const version = (typeof shareItem === "object" ? shareItem.version || inferVersionFromRequiredVersion(shareItem.requiredVersion) : void 0) || searchPackageVersion(key);
++	let version;
++	if (!(typeof shareItem === "object" && shareItem.import === false)) try {
++		try {
++			version = require(pathe.join(getPackageName(key), "package.json")).version;
++		} catch (e1) {
++			try {
++				const localPath = pathe.join(process.cwd(), "node_modules", getPackageName(key), "package.json");
++				version = require(localPath).version;
++			} catch (e2) {
++				version = searchPackageVersion(key);
++				if (!version) mfError(e1);
++			}
++		}
++	} catch (e) {
++		mfError(`Unexpected error resolving version for ${key}:`, e);
++	}
+ 	if (typeof shareItem === "string") return {
+ 		name: shareItem,
+ 		version,
+@@ -271,21 +427,20 @@ function normalizeShareItem(key, shareItem) {
+ 	return {
+ 		name: key,
+ 		from: "",
+-		version,
++		version: shareItem.version || inferVersionFromRequiredVersion(shareItem.requiredVersion) || version,
+ 		scope: shareItem.shareScope || "default",
+ 		shareConfig: {
+ 			import: shareItem.import,
+ 			singleton: shareItem.singleton || false,
+-			requiredVersion: shareItem.requiredVersion || (isImportFalse || shareItem.version ? "*" : version ? `^${version}` : "*"),
++			requiredVersion: shareItem.requiredVersion || (version ? `^${version}` : "*"),
+ 			strictVersion: !!shareItem.strictVersion
+ 		}
+ 	};
+ }
+ function normalizeShared(shared) {
+-	explicitSharedKeys = /* @__PURE__ */ new Set();
+ 	if (!shared) {
+ 		const result = {};
+-		const packageJsonPath = pathe.join(require_packageUtils.getPackageDetectionCwd(), "package.json");
++		const packageJsonPath = pathe.join(getPackageDetectionCwd(), "package.json");
+ 		try {
+ 			const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+ 			if (packageJson.name === "@module-federation/vite") return result;
+@@ -304,16 +459,12 @@ function normalizeShared(shared) {
+ 	const result = {};
+ 	const sourceEntries = [];
+ 	if (Array.isArray(shared)) shared.forEach((key) => {
+-		if (isModuleFederationRuntimePackage(key)) return;
+ 		result[key] = normalizeShareItem(key, key);
+-		explicitSharedKeys.add(key);
+ 		sourceEntries.push([key, key]);
+ 	});
+ 	else if (typeof shared === "object") Object.keys(shared).forEach((key) => {
+-		if (isModuleFederationRuntimePackage(key)) return;
+ 		const value = shared[key];
+ 		result[key] = normalizeShareItem(key, value);
+-		explicitSharedKeys.add(key);
+ 		sourceEntries.push([key, value]);
+ 	});
+ 	sourceEntries.forEach(([key, value]) => {
+@@ -324,14 +475,11 @@ function normalizeShared(shared) {
+ 	});
+ 	return result;
+ }
+-function isModuleFederationRuntimePackage(key) {
+-	return key === "@module-federation/runtime" || key === "@module-federation/runtime-core";
+-}
+ function shouldAutoShareDependency(key) {
+-	const pkg = require_packageUtils.getInstalledPackageJson(key)?.packageJson;
++	const pkg = getInstalledPackageJson(key)?.packageJson;
+ 	if (!pkg) return false;
+ 	if (!pkg.browser && !pkg.exports && typeof pkg.module !== "string") return false;
+-	if (key === "@module-federation/vite" || isModuleFederationRuntimePackage(key)) return false;
++	if (key === "@module-federation/vite") return false;
+ 	const entry = [
+ 		pkg.module,
+ 		pkg.main,
+@@ -354,32 +502,16 @@ function normalizeManifest(manifest) {
+ 	};
+ }
+ let config;
+-let explicitSharedKeys = /* @__PURE__ */ new Set();
+-function resolveRuntimeImplementation() {
+-	const fallback = require.resolve("@module-federation/runtime");
+-	try {
+-		const packageJsonPath = require.resolve("@module-federation/runtime/package.json");
+-		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+-		const importExport = packageJson.exports?.["."];
+-		const exportImport = typeof importExport === "object" ? typeof importExport.import === "string" ? importExport.import : importExport.import?.default : void 0;
+-		const esmEntry = packageJson.module || exportImport;
+-		if (esmEntry) return pathe.join(pathe.dirname(packageJsonPath), esmEntry);
+-	} catch {}
+-	return fallback;
+-}
+ function getNormalizeModuleFederationOptions() {
+ 	return config;
+ }
+-function isExplicitSharedKey(key) {
+-	return explicitSharedKeys.has(key);
+-}
+ function getNormalizeShareItem(key) {
+ 	const options = getNormalizeModuleFederationOptions();
+-	return options.shared[key] || options.shared[require_packageUtils.getPackageName(key)] || options.shared[require_packageUtils.getPackageName(key) + "/"];
++	return options.shared[key] || options.shared[getPackageName(key)] || options.shared[getPackageName(key) + "/"];
+ }
+ function normalizeModuleFederationOptions(options) {
+ 	warnOnReservedInternalNamePrefix(options.name, "containerName");
+-	if (options.virtualModuleDir && options.virtualModuleDir.includes("/")) throw require_packageUtils.createModuleFederationError(`Invalid virtualModuleDir: "${options.virtualModuleDir}". The virtualModuleDir option cannot contain slashes (/). Please use a single directory name like '__mf__virtual__your_app_name'.`);
++	if (options.virtualModuleDir && options.virtualModuleDir.includes("/")) throw createModuleFederationError(`Invalid virtualModuleDir: "${options.virtualModuleDir}". The virtualModuleDir option cannot contain slashes (/). Please use a single directory name like '__mf__virtual__your_app_name'.`);
+ 	return config = {
+ 		exposes: normalizeExposes(options.exposes),
+ 		filename: options.filename || "remoteEntry-[hash]",
+@@ -391,7 +523,7 @@ function normalizeModuleFederationOptions(options) {
+ 		shareScope: options.shareScope || "default",
+ 		shared: normalizeShared(options.shared),
+ 		runtimePlugins: options.runtimePlugins || [],
+-		implementation: options.implementation || resolveRuntimeImplementation(),
++		implementation: options.implementation || require.resolve("@module-federation/runtime"),
+ 		manifest: normalizeManifest(options.manifest),
+ 		dev: options.dev,
+ 		dts: options.dts,
+@@ -410,6 +542,35 @@ function normalizeModuleFederationOptions(options) {
+ }
+ //#endregion
+ //#region src/utils/VirtualModule.ts
++/**
++* Initialize virtual module infrastructure BEFORE VirtualModule class is used.
++* This must be called in the config hook to ensure the directory exists
++* before Vite's optimization phase.
++*/
++function initVirtualModuleInfrastructure(root, virtualModuleDir = "__mf__virtual") {
++	const virtualPackagePath = (0, pathe.join)((0, pathe.join)(root, "node_modules"), virtualModuleDir);
++	(0, fs.mkdirSync)(virtualPackagePath, { recursive: true });
++	(0, fs.writeFileSync)((0, pathe.join)(virtualPackagePath, "empty.js"), "");
++	(0, fs.writeFileSync)((0, pathe.join)(virtualPackagePath, "package.json"), JSON.stringify({
++		name: virtualModuleDir,
++		main: "empty.js"
++	}));
++}
++let rootDir;
++function findNodeModulesDir(root = process.cwd()) {
++	let currentDir = root;
++	while (currentDir !== (0, pathe.parse)(currentDir).root) {
++		const nodeModulesPath = (0, pathe.join)(currentDir, "node_modules");
++		if ((0, fs.existsSync)(nodeModulesPath)) return nodeModulesPath;
++		currentDir = (0, pathe.dirname)(currentDir);
++	}
++	return "";
++}
++let cachedNodeModulesDir;
++function getNodeModulesDir() {
++	if (!cachedNodeModulesDir) cachedNodeModulesDir = findNodeModulesDir(rootDir);
++	return cachedNodeModulesDir;
++}
+ function getSuffix(name) {
+ 	const base = (0, pathe.basename)(name);
+ 	const dotIndex = base.lastIndexOf(".");
+@@ -418,52 +579,45 @@ function getSuffix(name) {
+ }
+ const patternMap = {};
+ const cacheMap = {};
+-const VITE_ID_PREFIX = "/@id/";
+-const VITE_ENCODED_NULL_BYTE_PREFIX = `${VITE_ID_PREFIX}__x00__`;
+-function escapeRegExp$1(value) {
+-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+-}
+-function createViteEncodedIdPrefixRegExp(sourcePrefix = "") {
+-	return new RegExp(`^(?:${escapeRegExp$1(VITE_ENCODED_NULL_BYTE_PREFIX)})?${sourcePrefix}`);
+-}
+-function toViteEncodedId(id) {
+-	return `${VITE_ENCODED_NULL_BYTE_PREFIX}${id}`;
+-}
+-function decodeViteId(id) {
+-	if (!id.startsWith("/@id/")) return id;
+-	const viteId = id.slice(5);
+-	return viteId.startsWith("__x00__") ? `\0${viteId.slice(7)}` : viteId;
+-}
++/**
++* Physically generate files as virtual modules under node_modules/__mf__virtual/*
++*/
+ function assertModuleFound(tag, str = "") {
+ 	const module = VirtualModule.findModule(tag, str);
+-	if (!module) throw require_packageUtils.createModuleFederationError(`Module Federation shared module '${str}' not found. Please ensure it's installed as a dependency in your package.json.`);
++	if (!module) throw createModuleFederationError(`Module Federation shared module '${str}' not found. Please ensure it's installed as a dependency in your package.json.`);
+ 	return module;
+ }
+-function normalizeVirtualModuleId(id) {
+-	const decoded = decodeViteId(id).replace(/^\0+/, "");
+-	const queryIndex = decoded.indexOf("?");
+-	const hashIndex = decoded.indexOf("#");
+-	const endIndex = queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
+-	return endIndex === -1 ? decoded : decoded.slice(0, endIndex);
+-}
+-var VirtualModule = class VirtualModule {
++var VirtualModule = class {
+ 	name;
+ 	tag;
+ 	suffix;
+ 	inited = false;
+-	code;
+-	static findName(tag, str = "") {
+-		if (!patternMap[tag]) patternMap[tag] = new RegExp(`(.*${require_packageUtils.packageNameEncode(tag)}(.+?)${require_packageUtils.packageNameEncode(tag)}.*)`);
+-		const moduleName = (normalizeVirtualModuleId(str).match(patternMap[tag]) || [])[2];
+-		return moduleName ? require_packageUtils.packageNameDecode(moduleName) : void 0;
++	/**
++	* Set the root path for finding node_modules
++	* @param root - Root path
++	*/
++	static setRoot(root) {
++		rootDir = root;
++		cachedNodeModulesDir = void 0;
+ 	}
+-	static findModule(tag, str = "") {
+-		const moduleName = VirtualModule.findName(tag, str);
+-		return moduleName ? cacheMap[tag][moduleName] : void 0;
++	/**
++	* Ensure virtual package directory exists
++	*/
++	static ensureVirtualPackageExists() {
++		const nodeModulesDir = getNodeModulesDir();
++		const { virtualModuleDir } = getNormalizeModuleFederationOptions();
++		const virtualPackagePath = (0, pathe.resolve)(nodeModulesDir, virtualModuleDir);
++		(0, fs.mkdirSync)(virtualPackagePath, { recursive: true });
++		(0, fs.writeFileSync)((0, pathe.resolve)(virtualPackagePath, "empty.js"), "");
++		(0, fs.writeFileSync)((0, pathe.resolve)(virtualPackagePath, "package.json"), JSON.stringify({
++			name: virtualModuleDir,
++			main: "empty.js"
++		}));
+ 	}
+-	static findById(id) {
+-		const normalized = normalizeVirtualModuleId(id);
+-		for (const modules of Object.values(cacheMap)) for (const module of Object.values(modules)) if (module.getImportId() === normalized) return module;
++	static findModule(tag, str = "") {
++		if (!patternMap[tag]) patternMap[tag] = new RegExp(`(.*${packageNameEncode(tag)}(.+?)${packageNameEncode(tag)}.*)`);
++		const moduleName = (str.match(patternMap[tag]) || [])[2];
++		if (moduleName) return cacheMap[tag][packageNameDecode(moduleName)];
+ 	}
+ 	constructor(name, tag = "__mf_v__", suffix = "") {
+ 		this.name = name;
+@@ -472,23 +626,128 @@ var VirtualModule = class VirtualModule {
+ 		if (!cacheMap[this.tag]) cacheMap[this.tag] = {};
+ 		cacheMap[this.tag][this.name] = this;
+ 	}
+-	getImportId() {
+-		const { internalName: mfName } = getNormalizeModuleFederationOptions();
+-		return `virtual:mf:${require_packageUtils.packageNameEncode(`${mfName}${this.tag}${this.name}${this.tag}`)}${this.suffix}`;
++	getPath() {
++		return (0, pathe.resolve)(getNodeModulesDir(), this.getImportId());
+ 	}
+-	getResolvedId() {
+-		return `\0${this.getImportId()}`;
++	getImportId() {
++		const { internalName: mfName, virtualModuleDir } = getNormalizeModuleFederationOptions();
++		return `${virtualModuleDir}/${packageNameEncode(`${mfName}${this.tag}${this.name}${this.tag}`)}${this.suffix}`;
+ 	}
+ 	writeSync(code, force) {
+ 		if (!force && this.inited) return;
+ 		if (!this.inited) this.inited = true;
+-		this.code = code;
++		const path = this.getPath();
++		(0, fs.mkdirSync)((0, pathe.dirname)(path), { recursive: true });
++		(0, fs.writeFileSync)(path, code);
+ 	}
+ 	write(code) {
+-		this.writeSync(code, true);
++		const path = this.getPath();
++		(0, fs.mkdirSync)((0, pathe.dirname)(path), { recursive: true });
++		(0, fs.writeFile)(path, code, function() {});
+ 	}
+ };
+ //#endregion
++//#region src/virtualModules/virtualRuntimeInitStatus.ts
++const virtualRuntimeInitStatus = new VirtualModule("runtimeInit");
++const MODULE_CACHE_GLOBAL_KEY = "__mf_module_cache__";
++function getRuntimeInitGlobalKey() {
++	return `__mf_init__${virtualRuntimeInitStatus.getImportId()}__`;
++}
++function getDeferredInitPromiseCode() {
++	return `let initResolve, initReject;
++  const initPromise = new Promise((re, rj) => {
++    initResolve = re;
++    initReject = rj;
++  });`;
++}
++function getSsrNoopResolveCode() {
++	return `if (typeof window === 'undefined') {
++    initResolve({
++      loadRemote: function() { return Promise.resolve(undefined); },
++      loadShare: function() { return Promise.resolve(undefined); },
++    });
++  }`;
++}
++function getRuntimeInitStateBootstrapCode(options) {
++	return `
++const ${options.globalKeyVar} = ${JSON.stringify(getRuntimeInitGlobalKey())};
++let ${options.stateVar} = globalThis[${options.globalKeyVar}];
++if (!${options.stateVar}) {
++  ${getDeferredInitPromiseCode()}
++  ${options.stateVar} = globalThis[${options.globalKeyVar}] = {
++    initPromise,
++    initResolve,
++    initReject,
++  };
++  ${getSsrNoopResolveCode()}
++}
++const ${options.exposedConst} = ${options.stateVar}.${options.exposedProperty};
++`;
++}
++function getRuntimeInitBootstrapCode() {
++	return `
++const globalKey = ${JSON.stringify(getRuntimeInitGlobalKey())};
++const moduleCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
++globalThis[moduleCacheGlobalKey] ||= { share: {}, remote: {} };
++globalThis[moduleCacheGlobalKey].share ||= {};
++globalThis[moduleCacheGlobalKey].remote ||= {};
++if (!globalThis[globalKey]) {
++  ${getDeferredInitPromiseCode()}
++  globalThis[globalKey] = {
++    initPromise,
++    initResolve,
++    initReject,
++    moduleCache: globalThis[moduleCacheGlobalKey],
++  };
++  ${getSsrNoopResolveCode()}
++}
++globalThis[globalKey].moduleCache ||= globalThis[moduleCacheGlobalKey];
++globalThis[globalKey].moduleCache.share ||= {};
++globalThis[globalKey].moduleCache.remote ||= {};
++`;
++}
++function getRuntimeModuleCacheBootstrapCode() {
++	return `
++const __mfCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
++globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
++globalThis[__mfCacheGlobalKey].share ||= {};
++globalThis[__mfCacheGlobalKey].remote ||= {};
++const __mfModuleCache = globalThis[__mfCacheGlobalKey];
++`;
++}
++function getRuntimeInitResolveBootstrapCode() {
++	return getRuntimeInitStateBootstrapCode({
++		globalKeyVar: "__mfResolveGlobalKey",
++		stateVar: "__mfResolveState",
++		exposedConst: "initResolve",
++		exposedProperty: "initResolve"
++	});
++}
++function writeRuntimeInitStatus(command) {
++	const exportStatement = command === "build" ? `const { initPromise, initResolve, initReject, moduleCache } = globalThis[globalKey];
++export { initPromise, initResolve, initReject, moduleCache };` : `module.exports = globalThis[globalKey];`;
++	virtualRuntimeInitStatus.writeSync(`
++${getRuntimeInitBootstrapCode()}
++${exportStatement}
++`);
++}
++//#endregion
++//#region src/utils/localSharedImportMap_temp.ts
++/**
++* https://github.com/module-federation/vite/issues/68
++*/
++function getLocalSharedImportMapPath_temp() {
++	const { name } = getNormalizeModuleFederationOptions();
++	return pathe.default.resolve(".__mf__temp", packageNameEncode(name), "localSharedImportMap");
++}
++function writeLocalSharedImportMap_temp(content) {
++	createFile(getLocalSharedImportMapPath_temp() + ".js", "\n// Windows temporarily needs this file, https://github.com/module-federation/vite/issues/68\n" + content);
++}
++function createFile(filePath, content) {
++	(0, fs.mkdirSync)(pathe.default.dirname(filePath), { recursive: true });
++	(0, fs.writeFileSync)(filePath, content);
++}
++//#endregion
+ //#region src/utils/serializeRuntimeOptions.ts
+ /**
+ * Serializes a JavaScript object into a string of source code that can be evaluated.
+@@ -619,154 +878,46 @@ function generateExposes(options) {
+   `;
+ }
+ //#endregion
+-//#region src/virtualModules/virtualRuntimeInitStatus.ts
+-const virtualRuntimeInitStatus = new VirtualModule("runtimeInit");
+-const MODULE_CACHE_GLOBAL_KEY = "__mf_module_cache__";
+-function getRuntimeInitGlobalKey() {
+-	return `__mf_init__${virtualRuntimeInitStatus.getImportId()}__`;
+-}
+-function getDeferredInitPromiseCode() {
+-	return `let initResolve, initReject;
+-  const initPromise = new Promise((re, rj) => {
+-    initResolve = re;
+-    initReject = rj;
+-  });`;
++//#region src/virtualModules/virtualShared_preBuild.ts
++/**
++* Even the resolveId hook cannot interfere with vite pre-build,
++* and adding query parameter virtual modules will also fail.
++* You can only proxy to the real file through alias
++*/
++/**
++* shared will be proxied:
++* 1. __prebuild__: export shareModule (pre-built source code of modules such as vue, react, etc.)
++* 2. __loadShare__: load shareModule (mfRuntime.loadShare('vue'))
++*/
++const JS_IDENTIFIER_REGEX = /* @__PURE__ */ new RegExp("^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$", "u");
++function escapeGeneratedStringLiteral(value) {
++	return JSON.stringify(value).replace(/[<>\u2028\u2029]/g, (char) => {
++		switch (char) {
++			case "<": return "\\u003C";
++			case ">": return "\\u003E";
++			case "\u2028": return "\\u2028";
++			case "\u2029": return "\\u2029";
++			default: return char;
++		}
++	});
+ }
+-let _ssrRemotes = [];
+-function setSsrRemotes(remotes) {
+-	_ssrRemotes = remotes;
++function isValidJsIdentifier(name) {
++	return JS_IDENTIFIER_REGEX.test(name);
+ }
+-function getSsrNoopResolveCode(enableSsrInit) {
+-	if (!enableSsrInit) return "";
+-	return `if (typeof window === 'undefined') {
+-    var _noop = { loadRemote: function() { return Promise.resolve(undefined); }, loadShare: function() { return Promise.resolve(undefined); } };
+-    import(/* @vite-ignore */ '@module-federation/runtime').then(function(runtimeMod) {
+-      return import(/* @vite-ignore */ '@module-federation/vite/ssrEntryLoader').then(
+-        function(loaderMod) { return [runtimeMod, [loaderMod.default()]]; },
+-        function() { return [runtimeMod, []]; }
+-      );
+-    }).then(function(pair) {
+-      var runtime = pair[0].init({ name: '__mf_ssr_host__', remotes: ${JSON.stringify(_ssrRemotes)}, shared: {}, plugins: pair[1] });
+-      initResolve(runtime);
+-    }, function() {
+-      initResolve(_noop);
+-    });
+-  }`;
++function isValidEsmExportName(name) {
++	return !!name && name !== "default" && name !== "__esModule" && isValidJsIdentifier(name);
+ }
+-function getRuntimeInitStateBootstrapCode(options) {
+-	return `
+-const ${options.globalKeyVar} = ${JSON.stringify(getRuntimeInitGlobalKey())};
+-let ${options.stateVar} = globalThis[${options.globalKeyVar}];
+-if (!${options.stateVar}) {
+-  ${getDeferredInitPromiseCode()}
+-  ${options.stateVar} = globalThis[${options.globalKeyVar}] = {
+-    initPromise,
+-    initResolve,
+-    initReject,
+-  };
+-  ${getSsrNoopResolveCode(options.enableSsrInit)}
+-}
+-const ${options.exposedConst} = ${options.stateVar}.${options.exposedProperty};
+-`;
+-}
+-function getRuntimeInitBootstrapCode(enableSsrInit = false) {
+-	return `
+-const globalKey = ${JSON.stringify(getRuntimeInitGlobalKey())};
+-const moduleCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
+-globalThis[moduleCacheGlobalKey] ||= { share: {}, remote: {} };
+-globalThis[moduleCacheGlobalKey].share ||= {};
+-globalThis[moduleCacheGlobalKey].remote ||= {};
+-if (!globalThis[globalKey]) {
+-  ${getDeferredInitPromiseCode()}
+-  globalThis[globalKey] = {
+-    initPromise,
+-    initResolve,
+-    initReject,
+-    moduleCache: globalThis[moduleCacheGlobalKey],
+-  };
+-  ${getSsrNoopResolveCode(enableSsrInit)}
+-}
+-globalThis[globalKey].moduleCache ||= globalThis[moduleCacheGlobalKey];
+-globalThis[globalKey].moduleCache.share ||= {};
+-globalThis[globalKey].moduleCache.remote ||= {};
+-`;
+-}
+-function getRuntimeModuleCacheBootstrapCode() {
+-	return `
+-const __mfCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
+-globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
+-globalThis[__mfCacheGlobalKey].share ||= {};
+-globalThis[__mfCacheGlobalKey].remote ||= {};
+-const __mfModuleCache = globalThis[__mfCacheGlobalKey];
+-`;
+-}
+-function getRuntimeInitPromiseBootstrapCode(enableSsrInit = false) {
+-	return getRuntimeInitStateBootstrapCode({
+-		globalKeyVar: "__mfPromiseGlobalKey",
+-		stateVar: "__mfPromiseState",
+-		exposedConst: "initPromise",
+-		exposedProperty: "initPromise",
+-		enableSsrInit
+-	});
+-}
+-function getRuntimeInitResolveBootstrapCode(enableSsrInit = false) {
+-	return getRuntimeInitStateBootstrapCode({
+-		globalKeyVar: "__mfResolveGlobalKey",
+-		stateVar: "__mfResolveState",
+-		exposedConst: "initResolve",
+-		exposedProperty: "initResolve",
+-		enableSsrInit
+-	});
+-}
+-function writeRuntimeInitStatus(command, enableSsrInit = false) {
+-	const exportStatement = command === "build" ? `const { initPromise, initResolve, initReject, moduleCache } = globalThis[globalKey];
+-export { initPromise, initResolve, initReject, moduleCache };` : `module.exports = globalThis[globalKey];`;
+-	virtualRuntimeInitStatus.writeSync(`
+-${getRuntimeInitBootstrapCode(enableSsrInit)}
+-${exportStatement}
+-`);
+-}
+-//#endregion
+-//#region src/virtualModules/virtualShared_preBuild.ts
+-/**
+-* Even the resolveId hook cannot interfere with vite pre-build,
+-* and adding query parameter virtual modules will also fail.
+-* You can only proxy to the real file through alias
+-*/
+-/**
+-* shared will be proxied:
+-* 1. __prebuild__: export shareModule (pre-built source code of modules such as vue, react, etc.)
+-* 2. __loadShare__: load shareModule (mfRuntime.loadShare('vue'))
+-*/
+-const JS_IDENTIFIER_REGEX = /* @__PURE__ */ new RegExp("^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$", "u");
+-function escapeGeneratedStringLiteral(value) {
+-	return JSON.stringify(value).replace(/[<>\u2028\u2029]/g, (char) => {
+-		switch (char) {
+-			case "<": return "\\u003C";
+-			case ">": return "\\u003E";
+-			case "\u2028": return "\\u2028";
+-			case "\u2029": return "\\u2029";
+-			default: return char;
+-		}
+-	});
+-}
+-function isValidJsIdentifier(name) {
+-	return JS_IDENTIFIER_REGEX.test(name);
+-}
+-function isValidEsmExportName(name) {
+-	return !!name && name !== "default" && name !== "__esModule" && isValidJsIdentifier(name);
+-}
+-const JS_IDENTIFIER_PATTERN = `[\$_\\p{ID_Start}][\$_\\u200C\\u200D\\p{ID_Continue}]*`;
+-const localRequire = (0, module$1.createRequire)(require("url").pathToFileURL(__filename).href);
+-function resolvePackageEntryFromProjectRoot(pkg) {
+-	try {
+-		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(require_packageUtils.getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
+-	} catch {
+-		return;
+-	}
++const JS_IDENTIFIER_PATTERN = `[\$_\\p{ID_Start}][\$_\\u200C\\u200D\\p{ID_Continue}]*`;
++const localRequire = (0, module$1.createRequire)(require("url").pathToFileURL(__filename).href);
++function resolvePackageEntryFromProjectRoot(pkg) {
++	try {
++		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
++	} catch {
++		return;
++	}
+ }
+ function getPackageEsmEntryPath(pkg) {
+-	return require_packageUtils.getInstalledPackageEntry(pkg, {
++	return getInstalledPackageEntry(pkg, {
+ 		conditions: [
+ 			"browser",
+ 			"import",
+@@ -776,9 +927,11 @@ function getPackageEsmEntryPath(pkg) {
+ 		resolveSubpathWithRequire: false
+ 	}) || resolvePackageEntryFromProjectRoot(pkg);
+ }
+-function getEsmNamedExportsFromFile(entryPath) {
++function getEsmNamedExports(pkg) {
+ 	let source = "";
++	let entryPath;
+ 	try {
++		entryPath = getPackageEsmEntryPath(pkg);
+ 		if (!entryPath) return [];
+ 		const { initSync, parse } = localRequire("es-module-lexer");
+ 		initSync();
+@@ -793,48 +946,6 @@ function getEsmNamedExportsFromFile(entryPath) {
+ 		return source ? getNamedExportsViaRegex(source, entryPath) : [];
+ 	}
+ }
+-function getEsmNamedExports(pkg) {
+-	return getEsmNamedExportsFromFile(getPackageEsmEntryPath(pkg));
+-}
+-function resolveConfiguredImportPath(importSource) {
+-	if (pathe.default.isAbsolute(importSource)) return resolveFileLikeModule(importSource);
+-	const projectRoot = require_packageUtils.getPackageDetectionCwd();
+-	if (importSource.startsWith(".")) return resolveFileLikeModule(pathe.default.resolve(projectRoot, importSource));
+-	const esmEntry = require_packageUtils.getInstalledPackageEntry(importSource, {
+-		conditions: [
+-			"browser",
+-			"import",
+-			"module",
+-			"default"
+-		],
+-		resolveSubpathWithRequire: false
+-	});
+-	if (esmEntry) return esmEntry;
+-	try {
+-		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(projectRoot, "package.json")}`)).resolve(importSource);
+-	} catch {
+-		return;
+-	}
+-}
+-function resolveFileLikeModule(filePath) {
+-	if ((0, fs.existsSync)(filePath) && !(0, fs.statSync)(filePath).isDirectory()) return filePath;
+-	const extensions = [
+-		".ts",
+-		".tsx",
+-		".js",
+-		".jsx",
+-		".mjs",
+-		".mts"
+-	];
+-	for (const ext of extensions) {
+-		const candidate = filePath + ext;
+-		if ((0, fs.existsSync)(candidate) && !(0, fs.statSync)(candidate).isDirectory()) return candidate;
+-	}
+-	for (const ext of extensions) {
+-		const candidate = pathe.default.join(filePath, "index" + ext);
+-		if ((0, fs.existsSync)(candidate) && !(0, fs.statSync)(candidate).isDirectory()) return candidate;
+-	}
+-}
+ function resolveRelativeModule(filePath, specifier) {
+ 	const dir = pathe.default.dirname(filePath);
+ 	const exact = pathe.default.resolve(dir, specifier);
+@@ -861,25 +972,12 @@ function getNamedExportsViaRegex(source, filePath, visited) {
+ 	const names = /* @__PURE__ */ new Set();
+ 	visited = visited || /* @__PURE__ */ new Set();
+ 	if (filePath) visited.add(filePath);
+-	const declRegex = new RegExp(`export\\s+(?:async\\s+)?(?:function(?:\\*\\s*|\\s+\\*?\\s*)|const\\s+|let\\s+|var\\s+|class\\s+|enum\\s+|namespace\\s+)(${JS_IDENTIFIER_PATTERN})`, "gu");
++	const declRegex = new RegExp(`export\\s+(?:async\\s+)?(?:function(?:\\*\\s*|\\s+\\*?\\s*)|const\\s+|let\\s+|var\\s+|class\\s+)(${JS_IDENTIFIER_PATTERN})`, "gu");
+ 	let match;
+ 	while ((match = declRegex.exec(source)) !== null) {
+ 		const name = match[1];
+ 		if (isValidEsmExportName(name)) names.add(name);
+ 	}
+-	const destructureRegex = /export\s+(?:const|let|var)\s+(\{[^}]*\}|\[[^\]]*\])\s*=/g;
+-	const bindingNameRegex = new RegExp(`^(${JS_IDENTIFIER_PATTERN})`, "u");
+-	while ((match = destructureRegex.exec(source)) !== null) {
+-		const inner = match[1].slice(1, -1);
+-		for (const part of inner.split(",")) {
+-			let token = part.split("=")[0].trim();
+-			if (token.startsWith("...")) token = token.slice(3).trim();
+-			if (!token) continue;
+-			if (token.includes(":")) token = token.slice(token.indexOf(":") + 1).trim();
+-			const bindingMatch = token.match(bindingNameRegex);
+-			if (bindingMatch && isValidEsmExportName(bindingMatch[1])) names.add(bindingMatch[1]);
+-		}
+-	}
+ 	const listRegex = /export\s*\{([^}]+)\}/g;
+ 	const typeOnlySpecifierRegex = new RegExp(`^type\\s+${JS_IDENTIFIER_PATTERN}(?:\\s+as\\s+${JS_IDENTIFIER_PATTERN})?$`, "u");
+ 	const exportSpecifierRegex = new RegExp(`(?:\\S+\\s+as\\s+)?(${JS_IDENTIFIER_PATTERN})$`, "u");
+@@ -911,60 +1009,36 @@ function getNamedExportsViaRegex(source, filePath, visited) {
+ }
+ function getPackageNamedExports(pkg) {
+ 	try {
+-		const mod = (0, module$1.createRequire)(new URL(`file://${pathe.default.join(require_packageUtils.getPackageDetectionCwd(), "package.json")}`))(pkg);
++		const mod = (0, module$1.createRequire)(new URL(`file://${pathe.default.join(getPackageDetectionCwd(), "package.json")}`))(pkg);
+ 		return Object.keys(mod).filter((k) => isValidEsmExportName(k));
+ 	} catch {
+ 		return getEsmNamedExports(pkg);
+ 	}
+ }
+-function getSharedNamedExports(pkg, shareItem) {
+-	const configuredImport = shareItem?.shareConfig.import;
+-	if (typeof configuredImport === "string") {
+-		const configuredNamedExports = getEsmNamedExportsFromFile(resolveConfiguredImportPath(configuredImport));
+-		if (configuredNamedExports.length > 0) return configuredNamedExports;
+-	}
+-	return getPackageNamedExports(pkg);
+-}
+ function getLocalProviderImportPath(pkg) {
+ 	try {
+-		const resolved = (0, module$1.createRequire)(new URL(`file://${pathe.default.join(require_packageUtils.getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
++		const resolved = (0, module$1.createRequire)(new URL(`file://${pathe.default.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
+ 		return isWorkspaceFilePath(resolved) ? resolved : void 0;
+ 	} catch {
+-		const resolved = require_packageUtils.getInstalledPackageEntry(pkg, {
+-			conditions: [
+-				"browser",
+-				"import",
+-				"module",
+-				"default"
+-			],
+-			resolveSubpathWithRequire: false
+-		});
+-		return isWorkspaceFilePath(resolved) ? resolved : void 0;
++		return;
+ 	}
+ }
+ function getProjectResolvedImportPath(pkg) {
+-	if (pkg === require_packageUtils.getPackageName(pkg)) {
+-		const esmEntry = getPackageEsmEntryPath(pkg);
+-		if (esmEntry) return esmEntry;
+-	}
++	const esmEntry = getPackageEsmEntryPath(pkg);
++	if (esmEntry) return esmEntry;
+ 	try {
+-		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(require_packageUtils.getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
++		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
+ 	} catch {
+ 		return;
+ 	}
+ }
+ function isWorkspaceFilePath(resolved) {
+-	if (!resolved) return false;
+-	let realResolved = resolved;
+-	try {
+-		realResolved = fs.realpathSync.native(resolved);
+-	} catch {}
+-	return !realResolved.includes("/node_modules/") && !realResolved.includes("\\node_modules\\");
++	return !!resolved && !resolved.includes("/node_modules/") && !resolved.includes("\\node_modules\\");
+ }
+ function isWorkspacePackageEntry(pkg, resolved) {
+ 	if (!resolved || !pathe.default.isAbsolute(resolved) || !isWorkspaceFilePath(resolved)) return false;
+-	return !!require_packageUtils.getInstalledPackageJson(pkg, {
+-		packageName: require_packageUtils.getPackageName(pkg),
++	return !!getInstalledPackageJson(pkg, {
++		packageName: getPackageName(pkg),
+ 		fromResolvedEntry: resolved
+ 	});
+ }
+@@ -978,7 +1052,7 @@ function tryResolveImportFromPackageRoot(pkg, root) {
+ function getConcreteSharedImportSource(pkg, shareItem) {
+ 	const configuredImport = shareItem?.shareConfig.import;
+ 	if (typeof configuredImport === "string") return configuredImport;
+-	const projectRoot = require_packageUtils.getPackageDetectionCwd();
++	const projectRoot = getPackageDetectionCwd();
+ 	if (tryResolveImportFromPackageRoot(pkg, projectRoot)) return;
+ 	let currentDir = pathe.default.dirname(projectRoot);
+ 	while (currentDir !== pathe.default.dirname(currentDir)) {
+@@ -992,23 +1066,9 @@ const preBuildCacheMap = {};
+ const preBuildShareItemMap = {};
+ const PREBUILD_TAG = "__prebuild__";
+ function writePreBuildLibPath(pkg, shareItem) {
+-	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG, ".js");
++	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG);
+ 	preBuildShareItemMap[pkg] = shareItem;
+ 	const importSource = getConcreteSharedImportSource(pkg, shareItem) || pkg;
+-	if (pkg === "react/compiler-runtime") {
+-		preBuildCacheMap[pkg].writeSync(`
+-    const __mfCacheGlobalKey = "__mf_module_cache__";
+-    export const c = function(size) {
+-      const cache = globalThis[__mfCacheGlobalKey]?.share;
+-      const sharedReact = cache?.['react'];
+-      const reactExports = sharedReact?.default ?? sharedReact;
+-      const internals = reactExports?.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+-      return internals?.H?.useMemoCache(size);
+-    };
+-    export default { c };
+-  `, true);
+-		return;
+-	}
+ 	if (pkg === "react/jsx-dev-runtime") {
+ 		preBuildCacheMap[pkg].writeSync(`
+     import __mfPrebuildDefault from ${escapeGeneratedStringLiteral(importSource)};
+@@ -1029,20 +1089,6 @@ function writePreBuildLibPath(pkg, shareItem) {
+     export const jsx = __mfPrebuildExports.jsx;
+     export const jsxs = __mfPrebuildExports.jsxs;
+     export default __mfPrebuildExports;
+-  `, true);
+-		return;
+-	}
+-	const namedExports = getSharedNamedExports(pkg, shareItem);
+-	if (namedExports.length > 0) {
+-		const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+-		const declarations = namedExports.map((name, i) => `const ${namedExportVars[i]} = __mfPrebuildExports[${escapeGeneratedStringLiteral(name)}];`).join("\n    ");
+-		const namedExportLine = `export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(", ")} };`;
+-		preBuildCacheMap[pkg].writeSync(`
+-    import * as __mfPrebuildNamespace from ${escapeGeneratedStringLiteral(importSource)};
+-    const __mfPrebuildExports = __mfPrebuildNamespace;
+-    ${declarations}
+-    ${namedExportLine}
+-    export default __mfPrebuildExports;
+   `, true);
+ 		return;
+ 	}
+@@ -1053,7 +1099,7 @@ function writePreBuildLibPath(pkg, shareItem) {
+   `, true);
+ }
+ function getPreBuildLibImportId(pkg) {
+-	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG, ".js");
++	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG);
+ 	return preBuildCacheMap[pkg].getImportId();
+ }
+ function getPreBuildShareItem(pkg) {
+@@ -1070,84 +1116,25 @@ function getLoadShareImportId(pkg, _isRolldown) {
+ }
+ function getLoadShareModulePath(pkg, isRolldown) {
+ 	if (!loadShareCacheMap[pkg]) getLoadShareImportId(pkg, isRolldown);
+-	return loadShareCacheMap[pkg].getImportId();
++	return loadShareCacheMap[pkg].getPath();
+ }
+-function toViteOptimizedDepVirtualId(id) {
+-	return toViteEncodedId(id);
+-}
+-function getCachedLoadSharePkg(id) {
+-	const normalized = normalizeVirtualModuleId(id);
+-	if (!normalized.startsWith("virtual:mf:")) return;
+-	const pkg = VirtualModule.findName(LOAD_SHARE_TAG, normalized);
+-	if (!pkg) return;
+-	return pkg;
+-}
+-function materializeCachedLoadShareModule(options) {
+-	const pkg = getCachedLoadSharePkg(options.id);
+-	if (!pkg) return;
+-	const key = options.findSharedKey(pkg, options.shared);
+-	if (!key) return;
+-	const shareItem = options.shared[key];
+-	writeLoadShareModule(pkg, shareItem, options.command, options.isRolldown);
+-	if (shareItem.shareConfig?.import !== false) writePreBuildLibPath(pkg, shareItem);
+-	options.addUsedShares(pkg);
+-	options.writeLocalSharedImportMap();
+-}
+-function generateDeferredHostProvidedExports(namedExports, pkg, cacheKey) {
+-	const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+-	const declarations = ["let __mf_default;", ...namedExportVars.map((name) => `let ${name};`)].join("\n    ");
+-	const assignments = [...namedExports.map((name, i) => `${namedExportVars[i]} = exportModule[${escapeGeneratedStringLiteral(name)}];`), "__mf_default = exportModule.default ?? exportModule;"].join("\n      ");
+-	const namedExportLine = namedExports.length > 0 ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(", ")} };` : "";
+-	return `${declarations}
+-    const __mfApplyHostProvidedExports = (exportModule) => {
+-      ${assignments}
+-    };
+-    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}];
+-    if (exportModule === undefined) {
+-      initPromise.then(() => {
+-        exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}];
+-        if (exportModule === undefined) {
+-          throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.");
+-        }
+-        __mfApplyHostProvidedExports(exportModule);
+-      });
+-    } else {
+-      __mfApplyHostProvidedExports(exportModule);
+-    }
+-    export { __mf_default as default };${namedExportLine}`;
+-}
+-function generateShareModuleUnwrapCode({ source, preserveNamedExports, stopWithReturn }) {
+-	return `let current = ${source};
+-      for (let i = 0; i < 5; i++) {
+-        const defaultExport = current?.default;
+-        ${stopWithReturn ? `if (!defaultExport || typeof defaultExport !== "object") return ${stopWithReturn};` : `if (!defaultExport || typeof defaultExport !== "object") break;`}${preserveNamedExports ? `
+-        const namedValues = Object.keys(current).filter((key) => key !== "default").map((key) => current[key]);
+-        if (namedValues.length > 0 && namedValues.some((value) => value !== undefined)) break;` : ""}
+-        current = defaultExport;
+-      }
+-      return current;`;
+-}
+-const normalizeLocalShareModuleCode = `const __mfNormalizeShareModule = (mod) => {
+-      ${generateShareModuleUnwrapCode({
+-	source: "mod",
+-	preserveNamedExports: true
+-})}
+-    };`;
+ function writeLoadShareModule(pkg, shareItem, command, _isRolldown) {
+ 	if (!loadShareCacheMap[pkg]) loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, ".mjs");
+ 	const importLine = getRuntimeModuleCacheBootstrapCode();
+-	const cacheKey = require_packageUtils.getSharedCacheKey(pkg, shareItem);
+ 	if (shareItem.shareConfig.import === false) {
+ 		const namedExports = getPackageNamedExports(pkg);
+ 		let exportLine;
+-		if (namedExports.length > 0) exportLine = generateDeferredHostProvidedExports(namedExports, pkg, cacheKey);
++		if (namedExports.length > 0) exportLine = `export default exportModule.default ?? exportModule;\n    ${`const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(", ")} } = exportModule;`}\n    ${`export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(", ")} };`}`;
+ 		else {
+-			require_packageUtils.mfWarn(`Shared dependency "${pkg}" has import: false but is not installed locally.\n  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n  Install it as a devDependency to enable named export detection.`);
+-			exportLine = generateDeferredHostProvidedExports([], pkg, cacheKey);
++			mfWarn(`Shared dependency "${pkg}" has import: false but is not installed locally.\n  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n  Install it as a devDependency to enable named export detection.`);
++			exportLine = "export default exportModule.default ?? exportModule";
+ 		}
+ 		loadShareCacheMap[pkg].writeSync(`
+-    ${getRuntimeInitPromiseBootstrapCode()}
+     ${importLine}
++    const exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
++    if (exportModule === undefined) {
++      throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.")
++    }
+     ${exportLine}
+   `, true);
+ 		return;
+@@ -1159,36 +1146,22 @@ function writeLoadShareModule(pkg, shareItem, command, _isRolldown) {
+ 	const isWorkspacePackage = isWorkspacePackageEntry(pkg, localProviderPath) || isWorkspacePackageEntry(pkg, concreteSharedImportSource);
+ 	const lazyLocalFallbackSource = concreteSharedImportSource || localProviderPath || sharedImportSource;
+ 	const skipServePrebuildWarmup = command !== "build" && (pkg === "lit" || pkg.startsWith("lit/"));
+-	const usesLazyLocalFallback = isWorkspacePackage && shareItem.shareConfig.singleton === true;
+-	const namedExports = getSharedNamedExports(pkg, shareItem);
++	const namedExports = getPackageNamedExports(pkg);
+ 	let exportLine;
+-	if (namedExports.length > 0) {
+-		const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(", ")} } = exportModule;`;
+-		const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(", ")} };`;
+-		exportLine = `const __mfDefaultExport = (() => {
+-      ${generateShareModuleUnwrapCode({
+-			source: "exportModule",
+-			preserveNamedExports: false,
+-			stopWithReturn: "defaultExport ?? current"
+-		})}
+-    })();
+-    export default __mfDefaultExport;
+-    ${destructure}
+-    ${namedExportLine}`;
+-	} else if (usesLazyLocalFallback) exportLine = `export default exportModule.default ?? exportModule`;
++	if (namedExports.length > 0) exportLine = `export default exportModule.default ?? exportModule;\n    ${`const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(", ")} } = exportModule;`}\n    ${`export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(", ")} };`}`;
+ 	else exportLine = `export default exportModule.default ?? exportModule\n    export * from ${escapeGeneratedStringLiteral(sharedImportSource)}`;
+-	const prebuildImportLine = usesLazyLocalFallback || isWorkspacePackage && command !== "build" ? "" : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(skipServePrebuildWarmup ? devImportSource : sharedImportSource)};`;
++	const usesLazyLocalFallback = isWorkspacePackage && shareItem.shareConfig.singleton === true;
++	const prebuildImportLine = usesLazyLocalFallback || isWorkspacePackage && command !== "build" || skipServePrebuildWarmup ? "" : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(sharedImportSource)};`;
+ 	const devDynamicImportLine = isWorkspacePackage ? "" : command !== "build" && !skipServePrebuildWarmup ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});` : "";
+ 	loadShareCacheMap[pkg].writeSync(`
+     ${prebuildImportLine}
+     ${devDynamicImportLine}
+     ${importLine}
+-    ${normalizeLocalShareModuleCode}
+-    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}]
++    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
+     if (exportModule === undefined) {
+-      ${usesLazyLocalFallback ? `exportModule = __mfNormalizeShareModule(await import(${escapeGeneratedStringLiteral(lazyLocalFallbackSource)}));
+-      __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;` : `exportModule = __mfNormalizeShareModule(__mfLocalShare);
+-      __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;`}
++      ${usesLazyLocalFallback ? `exportModule = await import(${escapeGeneratedStringLiteral(lazyLocalFallbackSource)});
++      __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}] = exportModule;` : `exportModule = __mfLocalShare;
++      __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}] = exportModule;`}
+     }
+     ${exportLine}
+   `, true);
+@@ -1202,29 +1175,20 @@ function getUsedShares() {
+ function addUsedShares(pkg) {
+ 	usedShares.add(pkg);
+ }
+-const LOCAL_SHARED_IMPORT_MAP_ID = "virtual:mf-localSharedImportMap";
+ function getLocalSharedImportMapPath() {
+-	const { internalName, name } = getNormalizeModuleFederationOptions();
+-	return `${LOCAL_SHARED_IMPORT_MAP_ID}:${require_packageUtils.packageNameEncode(internalName || name)}`;
+-}
+-function getResolvedLocalSharedImportMapId() {
+-	return `\0${getLocalSharedImportMapPath()}`;
+-}
+-let invalidateLocalSharedImportMap;
+-function setLocalSharedImportMapInvalidator(invalidator) {
+-	invalidateLocalSharedImportMap = invalidator;
++	return getLocalSharedImportMapPath_temp();
+ }
+ let prevLocalSharedImportMapContent;
+ function writeLocalSharedImportMap() {
+ 	const nextContent = generateLocalSharedImportMap();
+ 	if (prevLocalSharedImportMapContent !== nextContent) {
+ 		prevLocalSharedImportMapContent = nextContent;
+-		invalidateLocalSharedImportMap?.();
++		writeLocalSharedImportMap_temp(nextContent);
+ 	}
+ }
+ function shouldUseDirectReactImport() {
+-	const isVinext = require_packageUtils.hasPackageDependency("vinext");
+-	const isAstro = require_packageUtils.hasPackageDependency("astro");
++	const isVinext = hasPackageDependency("vinext");
++	const isAstro = hasPackageDependency("astro");
+ 	return isVinext || isAstro;
+ }
+ function getLocalSharedPackagePath(pkg, shareItem) {
+@@ -1260,7 +1224,7 @@ function generateLocalSharedImportMap() {
+             version: ${JSON.stringify(shareItem.version)},
+             scope: [${JSON.stringify(shareItem.scope)}],
+             loaded: false,
+-            from: ${JSON.stringify(options.name)},
++            from: ${JSON.stringify(options.internalName)},
+             async get () {
+               if (${shareItem.shareConfig.import === false}) {
+                 throw new Error(\`[Module Federation] Shared module '\${${JSON.stringify(key)}}' must be provided by host\`);
+@@ -1328,7 +1292,7 @@ function getOrderedUsedShares() {
+ 	const shares = new Set(getUsedShares());
+ 	try {
+ 		Object.keys(getNormalizeModuleFederationOptions().shared).forEach((pkg) => {
+-			if (!pkg.endsWith("/")) shares.add(pkg);
++			shares.add(pkg.endsWith("/") ? pkg.slice(0, -1) : pkg);
+ 		});
+ 	} catch {}
+ 	return Array.from(shares).sort((a, b) => {
+@@ -1337,72 +1301,30 @@ function getOrderedUsedShares() {
+ 	});
+ }
+ function getShareItemForPreload(pkg) {
+-	const shared = getNormalizeModuleFederationOptions().shared;
+-	const wildcardKey = `${pkg.startsWith("@") ? pkg.split("/").slice(0, 2).join("/") : pkg.split("/")[0]}/`;
+-	if (isExplicitSharedKey(pkg)) return shared[pkg];
+-	if (isExplicitSharedKey(wildcardKey)) return shared[wildcardKey];
+-}
+-function generateSharedCacheSeedItem(pkg, shareItem, importPath) {
+-	const cacheKey = require_packageUtils.getSharedCacheKey(pkg, shareItem);
+-	return `if (__mfModuleCache.share[${JSON.stringify(cacheKey)}] === undefined) {
++	return getNormalizeShareItem(pkg) || getNormalizeShareItem(`${pkg}/`);
++}
++function generateDirectSharedCacheSeedCode(command = "build") {
++	return getOrderedUsedShares().map((pkg) => {
++		const shareItem = getShareItemForPreload(pkg);
++		if (!shareItem || shareItem.shareConfig.import === false) return null;
++		const importPath = command === "serve" ? getLocalSharedPackagePath(pkg, shareItem) : getDirectSharedCacheSeedImportPath(pkg, shareItem);
++		return `if (__mfModuleCache.share[${JSON.stringify(pkg)}] === undefined) {
+         const mod = await import(${JSON.stringify(importPath)});
+-        ${normalizeRuntimeShareCode}
+-        const normalizedModule = __mfNormalizeRuntimeShare(mod);
+-        const exportModule = normalizedModule === mod ? {...mod} : normalizedModule;
++        const exportModule = ${JSON.stringify(shouldUseDirectReactImport())} && ${JSON.stringify(pkg)} === "react"
++          ? (mod?.default ?? mod)
++          : {...mod};
+         Object.defineProperty(exportModule, "__esModule", {
+           value: true,
+           enumerable: false
+         });
+-        __mfModuleCache.share[${JSON.stringify(cacheKey)}] = exportModule;
++        __mfModuleCache.share[${JSON.stringify(pkg)}] = exportModule;
+       }`;
+-}
+-const normalizeRuntimeShareCode = `const __mfNormalizeRuntimeShare = (mod) => {
+-            let current = mod;
+-            for (let i = 0; i < 5; i++) {
+-              const defaultExport = current?.default;
+-              if (!defaultExport || typeof defaultExport !== "object" || Object.keys(defaultExport).length === 0) break;
+-              const namedValues = Object.keys(current).filter((key) => key !== "default").map((key) => current[key]);
+-              if (namedValues.length > 0 && namedValues.some((value) => value !== undefined)) break;
+-              current = defaultExport;
+-            }
+-            return current;
+-          };`;
+-function generateDirectSharedCacheSeedCode(command = "build") {
+-	return getOrderedUsedShares().map((pkg) => {
+-		const shareItem = getShareItemForPreload(pkg);
+-		if (!shareItem || shareItem.shareConfig.import === false) return null;
+-		return generateSharedCacheSeedItem(pkg, shareItem, command === "serve" ? getLocalSharedPackagePath(pkg, shareItem) : getDirectSharedCacheSeedImportPath(pkg, shareItem));
+-	}).filter((item) => item !== null).join("\n");
+-}
+-function getBrowserImportPath(importPath) {
+-	if (/^(?:[a-zA-Z]:[\\/]|\/)/.test(importPath) && !importPath.startsWith("/@")) return `/@fs/${importPath}`;
+-	return importPath;
+-}
+-function getHostAutoInitSharedSeedItems() {
+-	return getOrderedUsedShares().map((pkg) => ({
+-		pkg,
+-		shareItem: getShareItemForPreload(pkg)
+-	})).filter(({ shareItem }) => shareItem?.shareConfig.import === false).sort((a, b) => {
+-		const priority = (pkg) => pkg === "vue" ? 0 : pkg === "pinia" ? 1 : 2;
+-		const aIsLocal = !!getLocalProviderImportPath(a.pkg);
+-		const bIsLocal = !!getLocalProviderImportPath(b.pkg);
+-		return priority(a.pkg) - priority(b.pkg) || Number(aIsLocal) - Number(bIsLocal) || a.pkg.localeCompare(b.pkg);
+-	});
+-}
+-function generateHostAutoInitSharedCacheSeedCode(command = "build") {
+-	if (command === "build") return "";
+-	return getHostAutoInitSharedSeedItems().map(({ pkg, shareItem }) => {
+-		if (!shareItem) return null;
+-		return generateSharedCacheSeedItem(pkg, shareItem, getBrowserImportPath(getDirectSharedCacheSeedImportPath(pkg, shareItem)));
+ 	}).filter((item) => item !== null).join("\n");
+ }
+ const REMOTE_ENTRY_ID = "virtual:mf-REMOTE_ENTRY_ID";
+ function getRemoteEntryId(options) {
+ 	return `${REMOTE_ENTRY_ID}:${`${options.internalName}__${options.filename}`.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+ }
+-const SSR_ONLY_PLUGIN_SPECIFIERS = new Set(["@module-federation/vite/ssrEntryLoader"]);
+-const isSsrOnlyPlugin = (importStatement) => [...SSR_ONLY_PLUGIN_SPECIFIERS].some((s) => importStatement.includes(s));
+-const getSsrOnlyPluginSpecifier = (importStatement) => [...SSR_ONLY_PLUGIN_SPECIFIERS].find((s) => importStatement.includes(s));
+ function generateRemoteEntry(options, virtualExposesId = getVirtualExposesId(options), command = "build") {
+ 	const pluginImportNames = options.runtimePlugins.map((p, i) => {
+ 		if (typeof p === "string") return [
+@@ -1426,89 +1348,33 @@ function generateRemoteEntry(options, virtualExposesId = getVirtualExposesId(opt
+     globalThis.__VUE_HMR_RUNTIME__ = { createRecord() {}, rerender() {}, reload() {} };
+   }
+   import {init as runtimeInit, loadRemote} from "@module-federation/runtime";
+-  ${pluginImportNames.filter((item) => !isSsrOnlyPlugin(item[1])).map((item) => item[1]).join("\n")}
++  ${pluginImportNames.map((item) => item[1]).join("\n")}
+   ${command === "build" ? getRuntimeInitResolveBootstrapCode() : getRuntimeInitBootstrapCode() + "\n  const { initResolve } = globalThis[globalKey];"}
+   ${getRuntimeModuleCacheBootstrapCode()}
+   const initTokens = {}
+   const shareScopeName = ${JSON.stringify(options.shareScope)}
+-  const mfName = ${JSON.stringify(options.name)}
++  const mfName = ${JSON.stringify(options.internalName)}
+   let localSharedImportMapPromise
+   let exposesMapPromise
+-  const shouldRetrySharedInitError = ${command !== "build"} && ((error) => {
+-    const message = String((error && error.message) || error || '');
+-    return message.includes('Importing a module script failed') ||
+-      message.includes('Failed to fetch') ||
+-      message.includes('Load failed') ||
+-      message.includes('Outdated Optimize Dep');
+-  });
+-  const waitSharedInitRetry = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+-  async function retrySharedInit(fn) {
+-    for (let attempt = 0; ; attempt++) {
+-      try {
+-        return await fn();
+-      } catch (e) {
+-        const canRetry = typeof shouldRetrySharedInitError === 'function' && shouldRetrySharedInitError(e);
+-        if (!canRetry || attempt >= 19) throw e;
+-        await waitSharedInitRetry(250);
+-      }
+-    }
+-  }
+ 
+   async function getLocalSharedImportMap() {
+-    if (!localSharedImportMapPromise) {
+-      localSharedImportMapPromise = retrySharedInit(() => import("${getLocalSharedImportMapPath()}"))
+-        .catch((e) => { localSharedImportMapPromise = undefined; throw e; });
+-    }
++    localSharedImportMapPromise ??= import("${getLocalSharedImportMapPath()}")
+     return localSharedImportMapPromise
+   }
+ 
+   async function getExposesMap() {
+-    if (!exposesMapPromise) {
+-      exposesMapPromise = retrySharedInit(() => import("${virtualExposesId}"))
+-        .then((mod) => mod.default ?? mod)
+-        .catch((e) => { exposesMapPromise = undefined; throw e; });
+-    }
++    exposesMapPromise ??= import("${virtualExposesId}").then((mod) => mod.default ?? mod)
+     return exposesMapPromise
+   }
+ 
+   async function init(shared = {}, initScope = []) {
+     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
+-    try {
+-      const allInstances = globalThis.__FEDERATION__?.__SHARE__;
+-      if (allInstances) {
+-        ${normalizeRuntimeShareCode}
+-        for (const [, scopes] of Object.entries(allInstances)) {
+-          const scopeShare = scopes?.['${options.shareScope}'];
+-          if (!scopeShare) continue;
+-          for (const [pkg, versionMap] of Object.entries(scopeShare)) {
+-            for (const [version, provider] of Object.entries(versionMap)) {
+-              if (!provider.lib) continue;
+-              const cacheKey = provider.shareConfig?.singleton ? pkg : \`\${pkg}@\${version}\`;
+-              if (__mfModuleCache.share[cacheKey] !== undefined) continue;
+-              const mod = typeof provider.lib === "function" ? provider.lib() : provider.lib;
+-              const resolved = await Promise.resolve(mod);
+-              __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
+-            }
+-          }
+-        }
+-      }
+-    } catch (e) {
+-      console.error('[Module Federation] Failed to bridge external shared modules', e)
+-    }
+     ${generateDirectSharedCacheSeedCode(command)}
+-    const __browserPlugins = [${pluginImportNames.filter((item) => !isSsrOnlyPlugin(item[1])).map((item) => `${item[0]}(${item[2]})`).join(", ")}];
+-    const __ssrPlugins = typeof globalThis.window === 'undefined'
+-      ? await Promise.all([${pluginImportNames.filter((item) => isSsrOnlyPlugin(item[1])).map((item) => {
+-		const specifier = getSsrOnlyPluginSpecifier(item[1]);
+-		const opts = item[2];
+-		return `import(${JSON.stringify(specifier)}).then(m => (m.default ?? m)(${opts}))`;
+-	}).join(", ")}])
+-      : [];
+     const initRes = runtimeInit({
+       name: mfName,
+-      remotes: ${options.shareStrategy === "loaded-first" ? "[]" : "usedRemotes"},
++      remotes: usedRemotes,
+       shared: usedShared,
+-      plugins: [...__browserPlugins, ...__ssrPlugins],
++      plugins: [${pluginImportNames.map((item) => `${item[0]}(${item[2]})`).join(", ")}],
+       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ""}
+     });
+     // handling circular init calls
+@@ -1520,28 +1386,14 @@ function generateRemoteEntry(options, virtualExposesId = getVirtualExposesId(opt
+     initRes.initShareScopeMap('${options.shareScope}', shared);
+     initResolve(initRes)
+     try {
+-      await retrySharedInit(async () => {
+-        await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
+-          strategy: '${options.shareStrategy}',
+-          from: "build",
+-          initScope
+-        }));
+-      });
++      await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
++        strategy: '${options.shareStrategy}',
++        from: "build",
++        initScope
++      }));
+     } catch (e) {
+       console.error('[Module Federation]', e)
+     }
+-    for (const [pkg, share] of Object.entries(usedShared)) {
+-      const cacheKey = share.shareConfig?.singleton || !share.version ? pkg : \`\${pkg}@\${share.version}\`;
+-      if (share.shareConfig?.import !== false || __mfModuleCache.share[cacheKey] !== undefined) continue;
+-      ${normalizeRuntimeShareCode}
+-      const versions = shared?.[pkg];
+-      const provider = versions && versions[Object.keys(versions)[0]];
+-      if (!provider) continue;
+-      const factory = provider.lib || (provider.loading ? await provider.loading : await provider.get?.());
+-      const mod = typeof factory === "function" ? factory() : factory;
+-      const resolved = await Promise.resolve(mod);
+-      __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
+-    }
+     return initRes
+   }
+ 
+@@ -1560,22 +1412,17 @@ const hostAutoInitModule = new VirtualModule("hostAutoInit", "__H_A_I__");
+ let currentHostAutoInitRemoteEntryId = REMOTE_ENTRY_ID;
+ let currentHostAutoInitCommand = "build";
+ function generateHostAutoInitCode(remoteEntryImport, _command = "build") {
+-	const shouldPreloadShares = getNormalizeModuleFederationOptions().shareStrategy !== "loaded-first";
+ 	return `
+     ${getRuntimeModuleCacheBootstrapCode()}
+     let hostInitPromise;
+     async function initHost() {
+       if (!hostInitPromise) {
+         hostInitPromise = (async () => {
+-          ${generateHostAutoInitSharedCacheSeedCode(_command)}
+           const remoteEntry = await import(${remoteEntryImport});
+           const runtime = await remoteEntry.init();
+           const usedShared = ${generateUsedSharedPreloadConfig()};
+-          ${normalizeRuntimeShareCode}
+-          ${shouldPreloadShares ? `
+           for (const [pkg, share] of Object.entries(usedShared)) {
+-            const cacheKey = share.shareConfig?.singleton || !share.version ? pkg : \`\${pkg}@\${share.version}\`;
+-            if (__mfModuleCache.share[cacheKey] !== undefined) {
++            if (__mfModuleCache.share[pkg] !== undefined) {
+               continue;
+             }
+             await runtime.loadShare(pkg, {
+@@ -1583,11 +1430,10 @@ function generateHostAutoInitCode(remoteEntryImport, _command = "build") {
+             }).then((factory) => {
+               const mod = typeof factory === "function" ? factory() : factory;
+               return Promise.resolve(mod).then((resolved) => {
+-                __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
++                __mfModuleCache.share[pkg] = resolved;
+               });
+             });
+           }
+-          ` : ""}
+           const __mfRemotePreloads = [];
+           await Promise.all(__mfRemotePreloads);
+           return runtime;
+@@ -1613,19 +1459,18 @@ function getHostAutoInitImportId() {
+ 	return hostAutoInitModule.getImportId();
+ }
+ function getHostAutoInitPath() {
+-	return hostAutoInitModule.getImportId();
++	return hostAutoInitModule.getPath();
+ }
+ //#endregion
+ //#region src/virtualModules/virtualRemotes.ts
+ const cacheRemoteMap = {};
+ const LOAD_REMOTE_TAG = "__loadRemote__";
+-function getRemoteVirtualModule(remote, command, enableSsrInit = false) {
+-	const cacheKey = `${remote}__${command}__${enableSsrInit ? "ssr" : "no-ssr"}`;
+-	if (!cacheRemoteMap[cacheKey]) {
+-		cacheRemoteMap[cacheKey] = new VirtualModule(remote, LOAD_REMOTE_TAG, ".mjs");
+-		cacheRemoteMap[cacheKey].writeSync(generateRemotes(remote, command, enableSsrInit));
++function getRemoteVirtualModule(remote, command) {
++	if (!cacheRemoteMap[remote]) {
++		cacheRemoteMap[remote] = new VirtualModule(remote, LOAD_REMOTE_TAG, ".mjs");
++		cacheRemoteMap[remote].writeSync(generateRemotes(remote, command));
+ 	}
+-	return cacheRemoteMap[cacheKey];
++	return cacheRemoteMap[remote];
+ }
+ const usedRemotesMap = {};
+ function addUsedRemote(remoteKey, remoteModule) {
+@@ -1635,93 +1480,38 @@ function addUsedRemote(remoteKey, remoteModule) {
+ function getUsedRemotesMap() {
+ 	return usedRemotesMap;
+ }
+-function getRemoteFromId(id, remotes) {
+-	const remoteName = Object.keys(remotes).filter((name) => id === name || id.startsWith(name + "/")).sort((a, b) => b.length - a.length)[0];
+-	return remoteName ? remotes[remoteName] : void 0;
+-}
+-function generateRemotes(id, command, enableSsrInit = false) {
+-	const useReactProxy = require_packageUtils.hasPackageDependency("react");
+-	const options = getNormalizeModuleFederationOptions();
+-	const isLoadedFirst = options.shareStrategy === "loaded-first";
+-	const remote = getRemoteFromId(id, options.remotes);
+-	const registerRemoteCode = isLoadedFirst && remote ? `runtime.registerRemotes([${JSON.stringify({
+-		entryGlobalName: remote.entryGlobalName,
+-		name: remote.name,
+-		type: remote.type,
+-		entry: remote.entry,
+-		shareScope: remote.shareScope ?? "default"
+-	})}]);` : "";
+-	const reactImportLine = useReactProxy ? `import __mfReactDefault from "react";
+-    import * as __mfReactNamespace from "react";
+-    const __mfReact = __mfReactDefault ?? __mfReactNamespace.default ?? __mfReactNamespace;` : "";
++function generateRemotes(id, command) {
++	const useReactProxy = command === "serve" && hasPackageDependency("react");
++	const reactImportLine = useReactProxy ? `import * as __mfReact from "react";` : "";
+ 	const importLine = command === "build" ? `${getRuntimeModuleCacheBootstrapCode()}
+-    import { hostInitPromise as __mfHostInitPromise } from ${JSON.stringify(getHostAutoInitPath())};` : `${getRuntimeInitBootstrapCode(enableSsrInit)}
+-    const { initPromise, initResolve, initReject, moduleCache: __mfModuleCache } = globalThis[globalKey];
+-    if (typeof window !== "undefined") {
+-      import(${JSON.stringify(getHostAutoInitPath())})
+-        .then((mod) => mod.hostInitPromise)
+-        .then(initResolve, initReject);
+-    }`;
++    import { hostInitPromise as __mfHostInitPromise } from ${JSON.stringify(getHostAutoInitPath())};` : `${getRuntimeInitBootstrapCode()}
++    const { initPromise, moduleCache: __mfModuleCache } = globalThis[globalKey];`;
+ 	const exportLine = command === "serve" ? `if (__mfRemotePending) {
+-  __mfRemotePending = __mfRemotePending.then((mod) => {
+-    if (mod !== undefined) exportModule = mod;
+-    return exportModule;
+-  });
+-}
+-export { exportModule as __moduleExports };
+-export const __mf_remote_pending = __mfRemotePending || Promise.resolve(exportModule);
+-export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : command === "build" ? `if (__mfRemotePending) {
+-  __mfRemotePending = __mfRemotePending.then((mod) => {
+-    if (mod !== undefined) exportModule = mod;
+-    return exportModule;
+-  });
+-}
+-export { exportModule as __moduleExports };
+-export const __mf_remote_pending = __mfRemotePending || Promise.resolve(exportModule);
+-export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : "export default exportModule";
+-	const remoteLoadRuntimePromise = command === "build" ? "__mfHostInitPromise" : "initPromise";
+-	const remoteLoadFailureHandler = command === "build" ? `.catch((error) => {
+-            delete __mfModuleCache.remote[pendingKey];
+-            throw error;
+-          })` : `.catch(() => {
+-            delete __mfModuleCache.remote[pendingKey];
+-          })`;
++  const mod = await __mfRemotePending;
++  if (mod !== undefined) exportModule = mod;
++}
++export const __moduleExports = exportModule;
++export const __mf_remote_pending = Promise.resolve(exportModule);
++export default exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : command === "build" ? `if (__mfRemotePending) {
++  const mod = await __mfRemotePending;
++  if (mod !== undefined) exportModule = mod;
++}
++export const __moduleExports = exportModule;
++export const __mf_remote_pending = Promise.resolve(exportModule);
++export default exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : "export default exportModule";
+ 	return `
+     ${reactImportLine}
+     ${importLine}
+-    ${`
+-    function __mfStartRemoteLoad() {
+-      ${`
+-      const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};
+-      if (!__mfModuleCache.remote[pendingKey]) {
+-        __mfModuleCache.remote[pendingKey] = ${remoteLoadRuntimePromise}
+-          .then((runtime) => {
+-            ${registerRemoteCode}
+-            return runtime.loadRemote(${JSON.stringify(id)});
+-          })
+-          .then((mod) => {
+-            __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
+-            delete __mfModuleCache.remote[pendingKey];
+-            return mod;
+-          })
+-          ${remoteLoadFailureHandler};
+-      }
+-      return __mfModuleCache.remote[pendingKey];`}
+-    }
++    ${command !== "build" ? `
+     function __mfCreateRemoteProxy(pendingPromise) {
+       const listeners = new Set();
+-      const ensurePending = () => {
+-        pendingPromise ||= __mfStartRemoteLoad();
+-        pendingPromise?.finally(() => {
+-          for (const listener of listeners) listener();
+-        });
+-        return pendingPromise;
+-      };
++      pendingPromise?.finally(() => {
++        for (const listener of listeners) listener();
++      });
+       const getModule = () => __mfModuleCache.remote[${JSON.stringify(id)}];
+       const proxyTarget = function (...args) {
+         ${useReactProxy ? `const [, setVersion] = __mfReact.useState(0);
+         __mfReact.useEffect(() => {
+-          ensurePending();
+           const listener = () => setVersion((value) => value + 1);
+           listeners.add(listener);
+           if (getModule()) listener();
+@@ -1732,33 +1522,18 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
+         if (fn !== undefined && fn !== null) {
+           ${useReactProxy ? `return __mfReact.createElement(fn, args[0]);` : `return fn.apply(this, args);`}
+         }
+-        ${useReactProxy ? `return null;` : `throw ensurePending();`}
++        ${useReactProxy ? `return null;` : `throw pendingPromise;`}
+       };
+       return new Proxy(proxyTarget, {
+         get(_target, prop) {
+           if (prop === "__mf_is_remote_proxy") return true;
+           if (prop === "__esModule") return true;
+           if (prop === "then") return undefined;
+-          // Allow React's dev-mode console.warn to stringify the proxy without
+-          // throwing "Cannot convert object to primitive value".
+-          if (prop === Symbol.toPrimitive || prop === "toString")
+-            return () => "[MF remote proxy: pending]";
+           const mod = getModule();
+           if (mod) {
+             return prop in mod ? mod[prop] : mod.default?.[prop];
+           }
+-          // When the module is pending and React.lazy() checks for "default",
+-          // return the proxy function itself so React renders it (returns null)
+-          // rather than crashing on undefined.
+-          ${useReactProxy ? `if (prop === "default") return proxyTarget;
+-          return undefined;` : `throw ensurePending();`}
+-        },
+-        has(_target, prop) {
+-          const mod = getModule();
+-          if (mod) return prop in mod;
+-          // Tell React that "default" exists when module is pending so it
+-          // doesn't warn "lazy: Expected the result of a dynamic import()".
+-          ${useReactProxy ? `return prop === "default" || prop === "__esModule" || prop === "__mf_is_remote_proxy";` : `return false;`}
++          ${useReactProxy ? `return undefined;` : `throw pendingPromise;`}
+         },
+         ownKeys() {
+           const mod = getModule();
+@@ -1786,12 +1561,40 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
+           return target.apply(thisArg, args);
+         }
+       });
+-    }`}
++    }` : ""}
+     let __mfRemotePending;
+     let exportModule = __mfModuleCache.remote[${JSON.stringify(id)}]
+     if (exportModule === undefined) {
+-      __mfRemotePending = __mfStartRemoteLoad();
+-      exportModule = __mfCreateRemoteProxy(__mfRemotePending);
++      ${command !== "build" ? `const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};
++      if (!__mfModuleCache.remote[pendingKey]) {
++        __mfModuleCache.remote[pendingKey] = initPromise
++          .then((runtime) => runtime.loadRemote(${JSON.stringify(id)}))
++          .then((mod) => {
++            __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
++            delete __mfModuleCache.remote[pendingKey];
++            return mod;
++          })
++          .catch(() => {
++            delete __mfModuleCache.remote[pendingKey];
++          });
++      }` : ""}
++      ${command !== "build" ? `__mfRemotePending = __mfModuleCache.remote[pendingKey];
++      exportModule = __mfCreateRemoteProxy(__mfRemotePending);` : `const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};
++      if (!__mfModuleCache.remote[pendingKey]) {
++        __mfModuleCache.remote[pendingKey] = __mfHostInitPromise
++          .then((runtime) => runtime.loadRemote(${JSON.stringify(id)}))
++          .then((mod) => {
++            __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
++            delete __mfModuleCache.remote[pendingKey];
++            return mod;
++          })
++          .catch((error) => {
++            delete __mfModuleCache.remote[pendingKey];
++            throw error;
++          });
++      }
++      __mfRemotePending = __mfModuleCache.remote[pendingKey];
++      exportModule = {};`}
+     }
+     ${exportLine}
+   `;
+@@ -1801,41 +1604,9 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
+ function getFirstHtmlEntryFile(entryFiles) {
+ 	return entryFiles.find((file) => file.endsWith(".html"));
+ }
+-function stripQueryAndHash(file) {
+-	return file.split(/[?#]/)[0];
+-}
+-function getBuildInput(config) {
+-	return config.build?.rollupOptions?.input ?? config.build?.rolldownOptions?.input;
+-}
+-function patchHashEntryFileName(output, entryName, fileName) {
+-	const originalEntryFileNames = output.entryFileNames;
+-	output.entryFileNames = (chunkInfo, ...args) => {
+-		if (chunkInfo?.name === entryName) return fileName;
+-		if (typeof originalEntryFileNames === "function") return originalEntryFileNames(chunkInfo, ...args);
+-		return originalEntryFileNames || "assets/[name]-[hash].js";
+-	};
+-}
+-function patchHashEntryFileNames(config, entryName, fileName) {
+-	if (!fileName?.includes?.("[hash")) return;
+-	config.build ??= {};
+-	config.build.rollupOptions ??= {};
+-	config.build.rolldownOptions ??= {};
+-	const patchOutput = (output) => patchHashEntryFileName(output, entryName, fileName);
+-	const patchBundlerOutput = (bundlerOptions) => {
+-		const output = bundlerOptions.output;
+-		if (Array.isArray(output)) {
+-			output.forEach(patchOutput);
+-			return;
+-		}
+-		patchOutput(bundlerOptions.output ??= {});
+-	};
+-	patchBundlerOutput(config.build.rollupOptions);
+-	patchBundlerOutput(config.build.rolldownOptions);
+-}
+-const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClientInjected, skipTransformFor = [] }) => {
++const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClientInjected }) => {
+ 	const DEV_HTML_PROXY_PREFIX = "virtual:mf-html-entry-proxy?";
+-	const ENTRY_BOOTSTRAP_PARAM = "mf-entry-bootstrap";
+-	const ENTRY_BOOTSTRAP_QUERY = `?${ENTRY_BOOTSTRAP_PARAM}`;
++	const ENTRY_BOOTSTRAP_QUERY = "?mf-entry-bootstrap";
+ 	const waitsForInit = entryName === "hostInit";
+ 	const getEntryPath = () => typeof entryPath === "function" ? entryPath() : entryPath;
+ 	let devEntryPath = "";
+@@ -1846,15 +1617,11 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 	let viteConfig;
+ 	let clientInjected = forceClientInjected ?? false;
+ 	let emittedFileName;
+-	let skipTransformIds = /* @__PURE__ */ new Set();
+ 	function skipSvelteKitSsrBuild() {
+-		return (_command === "build" || viteConfig?.command === "build") && viteConfig?.build?.ssr && require_packageUtils.hasPackageDependency("@sveltejs/kit");
++		return (_command === "build" || viteConfig?.command === "build") && viteConfig?.build?.ssr && hasPackageDependency("@sveltejs/kit");
+ 	}
+ 	function isSvelteKitServerModule(id) {
+-		return require_packageUtils.hasPackageDependency("@sveltejs/kit") && (id.includes(".svelte-kit/generated/") || id.includes("/@sveltejs/kit/src/runtime/server/"));
+-	}
+-	function hasEntryBootstrapParam(id) {
+-		return id.includes(ENTRY_BOOTSTRAP_PARAM) || decodeURIComponent(id).includes(ENTRY_BOOTSTRAP_PARAM);
++		return hasPackageDependency("@sveltejs/kit") && (id.includes(".svelte-kit/generated/") || id.includes("/@sveltejs/kit/src/runtime/server/"));
+ 	}
+ 	function rewriteSvelteKitInlineStart(html, initPath) {
+ 		return html.replace(/<script>([\s\S]*?)<\/script>/gi, (scriptTag, body) => {
+@@ -1904,82 +1671,24 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		}
+ 		return patched;
+ 	}
+-	function getBootstrapSource(initSrc, entrySrc, useSystemImportFallback = false) {
+-		const importHelper = useSystemImportFallback ? `const __mfImport = (src) =>
+-  globalThis.System && typeof globalThis.System.import === 'function'
+-    ? globalThis.System.import(src)
+-    : import(src);
+-` : "";
+-		const importExpression = (src) => useSystemImportFallback ? `__mfImport(${JSON.stringify(src)})` : `import(${JSON.stringify(src)})`;
+-		const remotePreloads = getNormalizeModuleFederationOptions()?.shareStrategy !== "loaded-first" ? Object.entries(getUsedRemotesMap()).flatMap(([remoteKey, remotes]) => Array.from(remotes).filter((remote) => remote !== remoteKey)).sort().map((remote) => `__mfPreloadRemote(${JSON.stringify(remote)})`).join(",") : "";
+-		const preloadBlock = remotePreloads ? `
++	function getBootstrapSource(initSrc, entrySrc) {
++		const remotePreloads = Object.values(getUsedRemotesMap()).flatMap((remotes) => Array.from(remotes)).filter((remote) => remote.includes("/")).sort().map((remote) => `runtime.loadRemote(${JSON.stringify(remote)})`).join(",");
++		return `${getRuntimeModuleCacheBootstrapCode()}
++(async () => {
++  const { initHost } = await import(${JSON.stringify(initSrc)});
+   const runtime = await initHost();
+-  const __mfPreloadRemote = (remote) => {
+-    const pendingKey = "__mf_pending__" + remote;
+-    if (!__mfModuleCache.remote[pendingKey]) {
+-      __mfModuleCache.remote[pendingKey] = runtime.loadRemote(remote)
+-        .then((mod) => {
+-          __mfModuleCache.remote[remote] = mod;
+-          delete __mfModuleCache.remote[pendingKey];
+-          return mod;
+-        })
+-        .catch((error) => {
+-          delete __mfModuleCache.remote[pendingKey];
+-          throw error;
+-        });
+-    }
+-    return __mfModuleCache.remote[pendingKey];
+-  };
+   const __mfRemotePreloads = [${remotePreloads}];
+-  await Promise.allSettled(__mfRemotePreloads);` : `await initHost();`;
+-		const importCode = `
+-(async () => {
+-  const { initHost } = await ${importExpression(initSrc)};
+-  ${preloadBlock}
+-})().then(() => ${importExpression(entrySrc)});
++  await Promise.all(__mfRemotePreloads);
++})().then(() => import(${JSON.stringify(entrySrc)}));
+ `;
+-		return [
+-			getRuntimeModuleCacheBootstrapCode(),
+-			importHelper,
+-			importCode
+-		].join("\n");
+-	}
+-	function getSystemBootstrapSource(initSrc, entrySrc) {
+-		return getBootstrapSource(initSrc, entrySrc, true);
+ 	}
+ 	function injectHtml() {
+-		return inject === "html" && (htmlFilePath || require_packageUtils.hasPackageDependency("@sveltejs/kit"));
++		return inject === "html" && (htmlFilePath || hasPackageDependency("@sveltejs/kit"));
+ 	}
+ 	function injectEntry() {
+-		if (inject === "html" && require_packageUtils.hasPackageDependency("@sveltejs/kit")) return false;
++		if (inject === "html" && hasPackageDependency("@sveltejs/kit")) return false;
+ 		return inject === "entry" || !htmlFilePath;
+ 	}
+-	function normalizeDevHtmlProxyId(id) {
+-		return decodeViteId(id).replace(/^\0/, "");
+-	}
+-	function normalizeModuleId(id) {
+-		return id.split("?")[0].replace(/\\/g, "/");
+-	}
+-	function resolveProjectId(id) {
+-		if (id.startsWith("\0") || id.startsWith("virtual:")) return normalizeModuleId(id);
+-		return normalizeModuleId(pathe.isAbsolute(id) ? id : pathe.resolve(viteConfig.root, id));
+-	}
+-	function addEntryFile(file) {
+-		const normalized = normalizeModuleId(file);
+-		if (!entryFiles.includes(normalized)) entryFiles.push(normalized);
+-	}
+-	function addHtmlScriptEntries(htmlPath) {
+-		if (!fs.existsSync(htmlPath)) return;
+-		const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+-		const scriptRegex = /<script\b(?=[^>]*\btype=["']module["'])(?=[^>]*\bsrc=["']([^"']+)["'])[^>]*>/gi;
+-		let match;
+-		while ((match = scriptRegex.exec(htmlContent)) !== null) {
+-			const scriptSrc = stripQueryAndHash(match[1]);
+-			if (/^(?:[a-z]+:)?\/\//i.test(scriptSrc)) continue;
+-			addEntryFile(scriptSrc);
+-			addEntryFile(scriptSrc.startsWith("/") ? pathe.resolve(viteConfig.root, scriptSrc.slice(1)) : pathe.resolve(pathe.dirname(htmlPath), scriptSrc));
+-		}
+-	}
+ 	return [{
+ 		name: "add-entry",
+ 		apply: "serve",
+@@ -1989,30 +1698,16 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		configResolved(config) {
+ 			viteConfig = config;
+ 			const resolvedEntryPath = getEntryPath();
+-			if (resolvedEntryPath.startsWith("virtual:mf")) devEntryPath = config.base + VITE_ID_PREFIX.slice(1) + resolvedEntryPath;
++			if (resolvedEntryPath.startsWith("virtual:mf")) devEntryPath = config.base + "@id/" + resolvedEntryPath;
+ 			else {
+ 				const normalized = resolvedEntryPath.replace(/\\\\?/g, "/");
+ 				const root = config.root.replace(/\\\\?/g, "/").replace(/\/$/, "");
+ 				const relativePath = normalized.startsWith(root + "/") ? normalized.slice(root.length) : "/" + normalized.replace(/^[A-Za-z]:[\\/]/, "");
+ 				devEntryPath = config.base + relativePath.replace(/^\//, "");
+ 			}
+-			skipTransformIds = new Set(skipTransformFor.map(resolveProjectId));
+ 		},
+ 		configureServer(server) {
+-			server.middlewares.use((req, res, next) => {
+-				const rawUrl = req.url?.split("#")[0] ?? "";
+-				if (normalizeDevHtmlProxyId(rawUrl.split("?")[0]) === DEV_HTML_PROXY_PREFIX.slice(0, -1)) {
+-					const query = rawUrl.slice(rawUrl.indexOf("?") + 1);
+-					const params = new URLSearchParams(query);
+-					const initSrc = params.get("init");
+-					const entrySrc = params.get("entry");
+-					if (initSrc && entrySrc) {
+-						res.statusCode = 200;
+-						res.setHeader("Content-Type", "application/javascript");
+-						res.end(getBootstrapSource(initSrc, entrySrc));
+-						return;
+-					}
+-				}
++			server.middlewares.use((req, _res, next) => {
+ 				if (!fileName) {
+ 					next();
+ 					return;
+@@ -2024,27 +1719,25 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		transformIndexHtml: {
+ 			order: "pre",
+ 			handler(c) {
+-				const shouldWrapEntryHtml = _command === "serve" && inject === "entry" && waitsForInit;
+-				if (!injectHtml() && !shouldWrapEntryHtml) return;
++				if (!injectHtml()) return;
+ 				clientInjected = true;
+ 				const base = viteConfig.base.replace(/\/$/, "");
+ 				const stripBase = (p) => base && p.startsWith(base + "/") ? p.slice(base.length) : p;
+ 				const html = rewriteEntryScripts(c, (originalSrc) => {
+-					return toViteEncodedId(`${DEV_HTML_PROXY_PREFIX}${new URLSearchParams({
++					return `/@id/${DEV_HTML_PROXY_PREFIX}${new URLSearchParams({
+ 						init: sanitizeDevEntryPath(stripBase(devEntryPath)),
+ 						entry: sanitizeDevEntryPath(stripBase(originalSrc))
+-					}).toString()}`);
++					}).toString()}`;
+ 				});
+ 				return html === c ? injectEntryScript(c, stripBase(devEntryPath)) : html;
+ 			}
+ 		},
+ 		resolveId(id) {
+-			if (normalizeDevHtmlProxyId(id).startsWith(DEV_HTML_PROXY_PREFIX)) return id;
++			if (id.startsWith(DEV_HTML_PROXY_PREFIX)) return id;
+ 		},
+ 		load(id) {
+-			const normalizedId = normalizeDevHtmlProxyId(id);
+-			if (!normalizedId.startsWith(DEV_HTML_PROXY_PREFIX)) return;
+-			const params = new URLSearchParams(normalizedId.slice(28));
++			if (!id.startsWith(DEV_HTML_PROXY_PREFIX)) return;
++			const params = new URLSearchParams(id.slice(28));
+ 			const initSrc = params.get("init");
+ 			const entrySrc = params.get("entry");
+ 			if (!initSrc || !entrySrc) return;
+@@ -2057,30 +1750,24 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 	}, {
+ 		name: "add-entry",
+ 		enforce: "post",
+-		applyToEnvironment() {
+-			return true;
+-		},
+-		config(config) {
+-			patchHashEntryFileNames(config, entryName, fileName);
+-		},
+ 		configResolved(config) {
+ 			viteConfig = config;
+-			skipTransformIds = new Set(skipTransformFor.map(resolveProjectId));
+-			const ctx = this;
+-			const envName = ctx != null && typeof ctx === "object" ? ctx["environment"] : void 0;
+-			if (envName?.name && envName.name !== "client") return;
+-			const inputOptions = getBuildInput(config);
++			const inputOptions = config.build.rollupOptions.input;
+ 			if (!inputOptions) htmlFilePath = pathe.resolve(config.root, "index.html");
+-			else if (typeof inputOptions === "string") entryFiles = [normalizeModuleId(inputOptions)];
+-			else if (Array.isArray(inputOptions)) entryFiles = inputOptions.map(normalizeModuleId);
+-			else if (typeof inputOptions === "object") entryFiles = Object.values(inputOptions).map((input) => normalizeModuleId(String(input)));
++			else if (typeof inputOptions === "string") entryFiles = [inputOptions];
++			else if (Array.isArray(inputOptions)) entryFiles = inputOptions;
++			else if (typeof inputOptions === "object") entryFiles = Object.values(inputOptions);
+ 			if (entryFiles.length > 0) htmlFilePath = getFirstHtmlEntryFile(entryFiles);
+-			if (htmlFilePath) addHtmlScriptEntries(htmlFilePath);
++			if (_command === "serve" && htmlFilePath && fs.existsSync(htmlFilePath)) {
++				const htmlContent = fs.readFileSync(htmlFilePath, "utf-8");
++				const scriptRegex = /<script\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
++				let match;
++				while ((match = scriptRegex.exec(htmlContent)) !== null) entryFiles.push(match[1]);
++			}
+ 		},
+ 		buildStart() {
+ 			if (_command === "serve") return;
+ 			if (skipSvelteKitSsrBuild()) return;
+-			if (this.environment?.name === "ssr") return;
+ 			const hasHash = fileName?.includes?.("[hash");
+ 			const emitFileOptions = {
+ 				name: entryName,
+@@ -2090,14 +1777,16 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 			};
+ 			if (!hasHash) emitFileOptions.fileName = fileName;
+ 			emitFileId = this.emitFile(emitFileOptions);
+-			if (htmlFilePath) addHtmlScriptEntries(htmlFilePath);
++			if (htmlFilePath && fs.existsSync(htmlFilePath)) {
++				const htmlContent = fs.readFileSync(htmlFilePath, "utf-8");
++				const scriptRegex = /<script\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
++				let match;
++				while ((match = scriptRegex.exec(htmlContent)) !== null) entryFiles.push(match[1]);
++			}
+ 		},
+ 		generateBundle(_options, bundle) {
+ 			if (skipSvelteKitSsrBuild()) return;
+ 			if (!injectHtml()) return;
+-			if (!emitFileId) return;
+-			const htmlFileNames = Object.keys(bundle).filter((fileName) => fileName.endsWith(".html"));
+-			if (htmlFileNames.length === 0) return;
+ 			const file = this.getFileName(emitFileId);
+ 			emittedFileName = file;
+ 			const resolvePath = (htmlFileName) => {
+@@ -2111,15 +1800,16 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 				if (typeof result === "string") return result;
+ 				if (result && typeof result === "object") {
+ 					if ("runtime" in result) {
+-						require_packageUtils.mfWarn("renderBuiltUrl returned runtime code for HTML injection. Runtime code cannot be used in <script src=\"\">. Falling back to base path.");
++						mfWarn("renderBuiltUrl returned runtime code for HTML injection. Runtime code cannot be used in <script src=\"\">. Falling back to base path.");
+ 						return viteConfig.base + file;
+ 					}
+ 					if (result.relative) return file;
+ 				}
+ 				return viteConfig.base + file;
+ 			};
++			const bootstrapDir = getEntryFileNamesDir(viteConfig.build?.rollupOptions?.output);
+ 			let bootstrapIndex = 0;
+-			for (const fileName of htmlFileNames) {
++			for (const fileName in bundle) if (fileName.endsWith(".html")) {
+ 				let htmlAsset = bundle[fileName];
+ 				if (htmlAsset.type === "chunk") return;
+ 				let htmlContent = htmlAsset.source.toString() || "";
+@@ -2128,13 +1818,11 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 				let rewritten = false;
+ 				htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
+ 					rewritten = true;
+-					const bootstrapSource = getSystemBootstrapSource(initPath, entrySrc);
+-					const bootstrapHash = (0, node_crypto.createHash)("sha256").update(bootstrapSource).digest("hex").slice(0, 8);
+-					const bootstrapFileName = `mf-entry-bootstrap-${bootstrapIndex++}-${bootstrapHash}.js`;
++					const bootstrapFileName = `${bootstrapDir}mf-entry-bootstrap-${bootstrapIndex++}.js`;
+ 					const bootstrapRef = this.emitFile({
+ 						type: "asset",
+ 						fileName: bootstrapFileName,
+-						source: bootstrapSource
++						source: getBootstrapSource(bootstrapDir ? rebaseImport(initPath, bootstrapDir) : initPath, bootstrapDir ? rebaseImport(entrySrc, bootstrapDir) : entrySrc)
+ 					});
+ 					const bootstrapPath = viteConfig.base + this.getFileName(bootstrapRef);
+ 					return scriptTag.replace(entrySrc, bootstrapPath);
+@@ -2165,19 +1853,8 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		transform(code, id) {
+ 			if (skipSvelteKitSsrBuild()) return;
+ 			if (isSvelteKitServerModule(id)) return;
+-			if (hasEntryBootstrapParam(id)) return;
+-			if (normalizeModuleId(id).endsWith(".html")) return;
+-			if (skipTransformIds.has(resolveProjectId(id))) return;
+-			const transformCtx = this;
+-			const transformEnv = transformCtx != null && typeof transformCtx === "object" ? transformCtx["environment"] : void 0;
+-			if (transformEnv?.name && transformEnv.name !== "client") return;
+-			const isVinext = require_packageUtils.hasPackageDependency("vinext");
+-			if (isVinext && inject === "html" && id.includes("virtual:vite-rsc/remove-duplicate-server-css")) {
+-				const namespaceReactImport = `import * as React from 'react';`;
+-				if (code.includes(namespaceReactImport)) return;
+-				const rewritten = code.replace(/import\s+React\s+from\s+['"]react['"];?/, namespaceReactImport);
+-				return rewritten === code ? void 0 : mapCodeToCodeWithSourcemap(rewritten);
+-			}
++			if (id.includes(ENTRY_BOOTSTRAP_QUERY)) return;
++			const isVinext = hasPackageDependency("vinext");
+ 			if (isVinext && inject === "html" && (id.includes("virtual:vite-rsc/entry-browser") || id.includes("virtual:vinext-app-browser-entry"))) {
+ 				const injection = `import ${JSON.stringify(getEntryPath())};\n`;
+ 				if (code.includes(injection.trim())) {
+@@ -2187,16 +1864,9 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 				clientInjected = true;
+ 				return mapCodeToCodeWithSourcemap(injection + code);
+ 			}
+-			if (_command === "serve" && inject === "entry" && waitsForInit && !clientInjected && /(?:^|\/)nuxt\/dist\/app\/entry\.js(?:\?|$)/.test(id) && code.includes("vueApp.mount(vueAppRootContainer);")) {
+-				clientInjected = true;
+-				const injection = `await import(${JSON.stringify(getEntryPath())}).then(({ initHost }) => initHost());\n      `;
+-				return mapCodeToCodeWithSourcemap(code.replace("vueApp.mount(vueAppRootContainer);", `${injection}vueApp.mount(vueAppRootContainer);`));
+-			}
+-			const isHydrationEntryFallback = inject === "entry" && entryFiles.length === 0 && (!htmlFilePath || !fs.existsSync(htmlFilePath)) && !clientInjected && !id.includes("node_modules") && (id.startsWith("\0") || /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) && /hydrateRoot|createRoot|ReactDOM\.render/.test(code);
+-			const isNuxtClientEntryFallback = _command === "serve" && inject === "entry" && entryFiles.length === 0 && (!htmlFilePath || !fs.existsSync(htmlFilePath)) && !clientInjected && !hasEntryBootstrapParam(id) && !id.includes("node_modules/.vite") && /(?:^|\/)nuxt\/dist\/app\/entry\.async\.js(?:\?|$)/.test(id) && code.includes("entry();");
+-			if (injectEntry() && entryFiles.some((file) => resolveProjectId(id) === file) || _command === "serve" && inject === "html" && !isVinext && !clientInjected && !id.startsWith("\0") && !id.includes("node_modules") && /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id) || isHydrationEntryFallback || isNuxtClientEntryFallback) {
++			if (injectEntry() && entryFiles.some((file) => id.endsWith(file)) || _command === "serve" && inject === "html" && !isVinext && !clientInjected && !id.startsWith("\0") && !id.includes("node_modules") && /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) {
+ 				clientInjected = true;
+-				if (!waitsForInit || _command === "serve" && inject === "entry" && isHydrationEntryFallback) return mapCodeToCodeWithSourcemap(`import ${JSON.stringify(getEntryPath())};\n` + code);
++				if (!waitsForInit) return mapCodeToCodeWithSourcemap(`import ${JSON.stringify(getEntryPath())};\n` + code);
+ 				const entrySrc = id.includes("?") ? `${id}&${ENTRY_BOOTSTRAP_QUERY.slice(1)}` : `${id}${ENTRY_BOOTSTRAP_QUERY}`;
+ 				return mapCodeToCodeWithSourcemap(getBootstrapSource(getEntryPath(), entrySrc));
+ 			}
+@@ -2228,27 +1898,28 @@ function checkAliasConflicts(options) {
+ 				const replacement = aliasEntry.replacement;
+ 				if (!matchesSharedKey(aliasEntry, sharedKey)) continue;
+ 				if (replacement === "$1") break;
+-				if (typeof replacement === "string") {
+-					if (require_packageUtils.getPackageNameFromNodeModulePath(replacement) === (sharedKey.endsWith("/") ? sharedKey.slice(0, -1) : sharedKey)) continue;
+-					conflicts.push({
+-						sharedModule: sharedKey,
+-						alias: String(aliasEntry.find),
+-						target: replacement
+-					});
+-				}
++				if (typeof replacement === "string") conflicts.push({
++					sharedModule: sharedKey,
++					alias: String(aliasEntry.find),
++					target: replacement
++				});
+ 			}
+ 			if (conflicts.length > 0) {
+-				require_packageUtils.mfWarn("Detected alias conflicts with shared modules:");
++				mfWarn("Detected alias conflicts with shared modules:");
+ 				conflicts.forEach(({ sharedModule, alias, target }) => {
+-					require_packageUtils.mfWarn(`Shared module "${sharedModule}" is aliased by "${alias}" to "${target}"`);
++					mfWarn(`Shared module "${sharedModule}" is aliased by "${alias}" to "${target}"`);
+ 				});
+-				require_packageUtils.mfWarn("This may cause runtime errors as the shared module will bypass Module Federation's sharing mechanism.");
++				mfWarn("This may cause runtime errors as the shared module will bypass Module Federation's sharing mechanism.");
+ 			}
+ 		}
+ 	};
+ }
+ //#endregion
+-//#region src/plugins/hmr/react.ts
++//#region src/plugins/pluginDevRemoteHmr.ts
++const REMOTE_HMR_ENDPOINT = "__mf_hmr";
++const REMOTE_HMR_EVENT = "mf:remote-update";
++const REMOTE_HMR_CONNECT_RETRY_DELAY_MS = 1e3;
++const REMOTE_HMR_CONNECT_MAX_RETRIES = 10;
+ /**
+ * Proxy module served for `/@react-refresh` on MF remote dev servers.
+ * Delegates to the host page's RefreshRuntime instance via
+@@ -2268,112 +1939,6 @@ const REACT_REFRESH_PROXY_MODULE = [
+ 	`export const __hmr_import = __rt.__hmr_import;`,
+ 	`export default __rt.default || __rt;`
+ ].join("\n");
+-const reactAdapter = {
+-	name: "react",
+-	pluginNames: ["vite:react-refresh", "vite:react-swc:refresh"],
+-	remote: { configureServer({ server }) {
+-		server.middlewares.use((req, res, next) => {
+-			if (req.url?.replace(/\?.*$/, "") !== "/@react-refresh") return next();
+-			res.setHeader("Content-Type", "application/javascript; charset=utf-8");
+-			res.setHeader("Access-Control-Allow-Origin", "*");
+-			res.end(REACT_REFRESH_PROXY_MODULE);
+-		});
+-	} }
+-};
+-//#endregion
+-//#region src/plugins/hmr/vue.ts
+-/**
+-* In dev mode each Vite dev server serves its own copy of Vue
+-* (`/node_modules/.vite/deps/vue.js`). When a remote module is loaded into the
+-* host page, the remote's Vue copy evaluates and runs:
+-*
+-*     globalThis.__VUE_HMR_RUNTIME__ = createHotReloadAPI()
+-*
+-* which silently overwrites the host's runtime. After that, `createRecord` for
+-* host components lives in the orphaned first runtime, but `reload(hmrId, ...)`
+-* goes through the second runtime — the lookup misses and HMR stops working.
+-*
+-* This guard pins `__VUE_HMR_RUNTIME__` to the first writer (the host's Vue)
+-* via a property trap on `globalThis`. Subsequent writes from remote-side Vue
+-* copies are silently dropped. Must execute before any Vue module loads —
+-* injected as a plain (non-module) script at `head-prepend`.
+-*
+-* `singleton: true` in `shared` is not sufficient: in dev mode MF's share-scope
+-* does not actually dedupe Vue across dev servers, so without this guard the
+-* last-loaded copy wins.
+-*/
+-const VUE_HMR_RUNTIME_GUARD_SCRIPT = `
+-(function () {
+-  var h = null;
+-  Object.defineProperty(globalThis, '__VUE_HMR_RUNTIME__', {
+-    get: function () { return h; },
+-    set: function (v) { if (h === null) h = v; },
+-    configurable: true,
+-    enumerable: true,
+-  });
+-})();`;
+-/**
+-* `@vitejs/plugin-vue` derives an SFC's `__hmrId` from a hash of the file path
+-* relative to Vite's `root`. With module federation, host and remote are
+-* separate Vite projects with independent roots — so an SFC at `src/App.vue`
+-* in both will hash to the same id. Once both copies of Vue collapse onto the
+-* shared `__VUE_HMR_RUNTIME__` (see the guard above), the host's instance and
+-* the remote's instance both register under that single id. A remote-only
+-* file change then calls `rerender(id, newRender)`, which iterates *every*
+-* instance under that id — including the host one — and applies the remote's
+-* render function to the host instance. The host's `setupState` doesn't have
+-* the remote's bindings, so the render throws and Vue falls back to a full
+-* reload required warning.
+-*
+-* Fix: rewrite the remote's emitted `__hmrId` literal to be prefixed with the
+-* federation `name`, so the remote's instances live under a distinct key. The
+-* accept callback emitted by plugin-vue reads `_sfc_main.__hmrId` /
+-* `updated.__hmrId` at runtime, so rewriting the literal once is enough.
+-*/
+-const SFC_HMR_ID_LITERAL_RE = /(\.__hmrId\s*=\s*["'`])([^"'`]+)(["'`])/g;
+-function rewriteSfcHmrId(code, federationName) {
+-	let matched = false;
+-	return {
+-		code: code.replace(SFC_HMR_ID_LITERAL_RE, (_match, prefix, id, suffix) => {
+-			matched = true;
+-			if (id.startsWith(`${federationName}-`)) return `${prefix}${id}${suffix}`;
+-			return `${prefix}${federationName}-${id}${suffix}`;
+-		}),
+-		matched
+-	};
+-}
+-let pluginVueRegressionWarned = false;
+-function warnPluginVueRegression() {
+-	if (pluginVueRegressionWarned) return;
+-	pluginVueRegressionWarned = true;
+-	require_packageUtils.mfWarn("Detected a Vue SFC module that calls `__VUE_HMR_RUNTIME__.createRecord(` but no `.__hmrId = \"...\"` literal could be rewritten. @vitejs/plugin-vue may have changed its output format — without the rewrite, host and remote SFCs that share a path will collide on the shared HMR runtime. Please report this to @module-federation/vite.");
+-}
+-const vueAdapter = {
+-	name: "vue",
+-	pluginNames: ["vite:vue", "vite:vue-jsx"],
+-	host: { transformIndexHtml() {
+-		return [{
+-			tag: "script",
+-			children: VUE_HMR_RUNTIME_GUARD_SCRIPT,
+-			injectTo: "head-prepend"
+-		}];
+-	} },
+-	remote: { transform(code, _id, ctx) {
+-		if (!code.includes("__VUE_HMR_RUNTIME__.createRecord(")) return;
+-		const { code: rewritten, matched } = rewriteSfcHmrId(code, ctx.options.name);
+-		if (!matched) {
+-			warnPluginVueRegression();
+-			return;
+-		}
+-		return rewritten === code ? void 0 : rewritten;
+-	} }
+-};
+-//#endregion
+-//#region src/plugins/hmr/fullReload.ts
+-const REMOTE_HMR_ENDPOINT = "__mf_hmr";
+-const REMOTE_HMR_EVENT = "mf:remote-update";
+-const REMOTE_HMR_CONNECT_RETRY_DELAY_MS = 1e3;
+-const REMOTE_HMR_CONNECT_MAX_RETRIES = 10;
+ function getBasePath$1(base) {
+ 	if (!base) return "/";
+ 	if (base.startsWith("http://") || base.startsWith("https://")) try {
+@@ -2392,6 +1957,9 @@ function getHmrWsPath(base, hmrPath) {
+ 	if (!normalizedPath || normalizedPath === "/") return normalizedBase;
+ 	return `${normalizedBase.endsWith("/") ? normalizedBase.slice(0, -1) : normalizedBase}/${normalizedPath.startsWith("/") ? normalizedPath.slice(1) : normalizedPath}`;
+ }
++function shouldIgnoreFile(file, options) {
++	return file.includes("/node_modules/") || file.includes("\\node_modules\\") || file.includes(`/${options.virtualModuleDir}/`) || file.includes(`\\${options.virtualModuleDir}\\`) || file.includes("/.vite/") || file.includes("\\.vite\\") || file.includes("/.__mf__temp/") || file.includes("\\.__mf__temp\\") || file.includes("/.mf/") || file.includes("\\.mf\\") || file.includes("/mf-manifest.json") || file.includes("\\mf-manifest.json") || file.includes("/mf-stats.json") || file.includes("\\mf-stats.json");
++}
+ function getRemoteHmrWsUrl(server) {
+ 	const hmr = server.config.server.hmr;
+ 	return `${hmr && typeof hmr === "object" && hmr.protocol ? hmr.protocol : server.config.server.https ? "wss" : "ws"}://${hmr && typeof hmr === "object" && hmr.host ? hmr.host : typeof server.config.server.host === "string" && server.config.server.host !== "0.0.0.0" ? server.config.server.host : "localhost"}:${hmr && typeof hmr === "object" && (hmr.clientPort || hmr.port) ? hmr.clientPort || hmr.port : server.config.server.port}${getHmrWsPath(server.config.base, hmr && typeof hmr === "object" ? hmr.path : "")}?token=${server.config.webSocketToken}`;
+@@ -2430,298 +1998,450 @@ function getStringPreview(value, max = 180) {
+ 	} catch {}
+ 	return rawValue.slice(0, max);
+ }
+-/**
+-* Installs the `/__mf_hmr` metadata endpoint on a remote dev server. The host
+-* fetches this to discover the remote's HMR WebSocket URL before opening a
+-* Node-to-Node relay socket. Always installed on remotes when `remoteHmr` is
+-* enabled — under `'native'` strategy the endpoint is unused but harmless;
+-* under `'full-reload'` it's the discovery hop for the host relay.
+-*/
+-function setupRemoteMetadataEndpoint(server, options) {
+-	const endpointPath = getRemoteHmrPath(server.config.base);
+-	const wsUrl = getRemoteHmrWsUrl(server);
+-	server.middlewares.use((req, res, next) => {
+-		if (req.url?.replace(/\?.*/, "") !== endpointPath) {
+-			next();
+-			return;
+-		}
+-		res.setHeader("Content-Type", "application/json");
+-		res.setHeader("Access-Control-Allow-Origin", "*");
+-		res.end(JSON.stringify({
+-			remote: options.name,
+-			event: REMOTE_HMR_EVENT,
+-			wsUrl
+-		}));
+-	});
++function isRemoteHmrEnabled(dev) {
++	return typeof dev === "object" && dev !== null && dev.remoteHmr === true;
+ }
+-/**
+-* Installs file-watcher broadcasts on a remote dev server. Every non-ignored
+-* change/add/unlink emits a `mf:remote-update` custom event on the remote's
+-* own WS channel. The host relay (see `setupHostFullReloadRelay`) listens
+-* for these events and triggers a host-side full reload in response.
+-*
+-* Only called under the `'full-reload'` strategy.
+-*/
+-function setupRemoteBroadcast(server, options) {
+-	const broadcast = (file) => {
+-		if (shouldIgnoreFile(file, options)) return;
+-		server.ws.send({
+-			type: "custom",
+-			event: REMOTE_HMR_EVENT,
+-			data: {
+-				remote: options.name,
+-				file,
+-				ts: Date.now()
++function pluginDevRemoteHmr(options) {
++	return {
++		name: "module-federation-dev-remote-hmr",
++		apply: "serve",
++		configureServer(server) {
++			if (!isRemoteHmrEnabled(options.dev)) return;
++			const isRemote = Object.keys(options.exposes).length > 0;
++			const isHost = Object.keys(options.remotes).length > 0;
++			if (isRemote) {
++				const endpointPath = getRemoteHmrPath(server.config.base);
++				const wsUrl = getRemoteHmrWsUrl(server);
++				server.middlewares.use((req, res, next) => {
++					if (req.url?.replace(/\?.*$/, "") !== "/@react-refresh") return next();
++					res.setHeader("Content-Type", "application/javascript; charset=utf-8");
++					res.setHeader("Access-Control-Allow-Origin", "*");
++					res.end(REACT_REFRESH_PROXY_MODULE);
++				});
++				server.middlewares.use((req, res, next) => {
++					if (req.url?.replace(/\?.*/, "") !== endpointPath) {
++						next();
++						return;
++					}
++					res.setHeader("Content-Type", "application/json");
++					res.setHeader("Access-Control-Allow-Origin", "*");
++					res.end(JSON.stringify({
++						remote: options.name,
++						event: REMOTE_HMR_EVENT,
++						wsUrl
++					}));
++				});
++				const broadcast = (file) => {
++					if (shouldIgnoreFile(file, options)) return;
++					server.ws.send({
++						type: "custom",
++						event: REMOTE_HMR_EVENT,
++						data: {
++							remote: options.name,
++							file,
++							ts: Date.now()
++						}
++					});
++				};
++				server.watcher.on("change", broadcast);
++				server.watcher.on("add", broadcast);
++				server.watcher.on("unlink", broadcast);
++				server.httpServer?.once("close", () => {
++					server.watcher.off("change", broadcast);
++					server.watcher.off("add", broadcast);
++					server.watcher.off("unlink", broadcast);
++				});
+ 			}
++			if (isHost) {
++				const connections = [];
++				const reconnectTimers = /* @__PURE__ */ new Map();
++				let isTearingDown = false;
++				const clearReconnectTimer = (remoteName) => {
++					const timer = reconnectTimers.get(remoteName);
++					if (!timer) return;
++					clearTimeout(timer);
++					reconnectTimers.delete(remoteName);
++				};
++				const scheduleReconnect = (remoteName, remote, attempt, reason) => {
++					if (isTearingDown) return;
++					if (attempt >= REMOTE_HMR_CONNECT_MAX_RETRIES) {
++						mfWarn(`Remote "${remoteName}" full HMR reconnect skipped after ${REMOTE_HMR_CONNECT_MAX_RETRIES} attempts: ${reason}`);
++						return;
++					}
++					clearReconnectTimer(remoteName);
++					const timer = setTimeout(() => {
++						reconnectTimers.delete(remoteName);
++						connectRemote(remoteName, remote, attempt + 1);
++					}, REMOTE_HMR_CONNECT_RETRY_DELAY_MS);
++					reconnectTimers.set(remoteName, timer);
++				};
++				const connectRemote = async (remoteName, remote, attempt = 0) => {
++					if (isTearingDown) return;
++					const endpoint = getRemoteHmrEndpoint(remote.entry, server);
++					if (!endpoint) {
++						mfWarn(`Failed to build HMR endpoint URL for remote "${remoteName}"`);
++						return;
++					}
++					try {
++						const metadataResponse = await fetch(endpoint);
++						if (!metadataResponse.ok) {
++							mfWarn(`Failed to fetch remote HMR metadata from "${remoteName}": ${metadataResponse.status}`);
++							scheduleReconnect(remoteName, remote, attempt, `HTTP ${metadataResponse.status}`);
++							return;
++						}
++						const metadata = await metadataResponse.json();
++						if (metadata.event !== REMOTE_HMR_EVENT || !metadata.wsUrl) {
++							mfWarn(`Remote "${remoteName}" returned unexpected HMR metadata shape`);
++							return;
++						}
++						const ws = new WebSocket(metadata.wsUrl, "vite-hmr");
++						ws.onmessage = (rawEvent) => {
++							const message = parseRemoteHmrMessage(rawEvent.data);
++							if (!message || message.event !== REMOTE_HMR_EVENT) return;
++							server.ws.send({ type: "full-reload" });
++						};
++						ws.onopen = () => clearReconnectTimer(remoteName);
++						ws.onerror = (error) => mfWarn(`Remote HMR socket error for "${remoteName}":`, error);
++						ws.onclose = () => scheduleReconnect(remoteName, remote, attempt, "socket closed");
++						connections.push(ws);
++					} catch (error) {
++						mfWarn(`Failed to connect remote HMR for "${remoteName}" on attempt ${attempt + 1}: ${getStringPreview(error)}`);
++						scheduleReconnect(remoteName, remote, attempt, getStringPreview(error));
++					}
++				};
++				const teardown = () => {
++					isTearingDown = true;
++					reconnectTimers.forEach((timer) => clearTimeout(timer));
++					reconnectTimers.clear();
++					connections.forEach((connection) => {
++						if (connection.readyState !== connection.CLOSING && connection.readyState !== connection.CLOSED) connection.close();
++					});
++					connections.length = 0;
++				};
++				for (const [remoteName, remote] of Object.entries(options.remotes)) connectRemote(remoteName, remote);
++				const triggerHostReload = (file) => {
++					if (shouldIgnoreFile(file, options)) return;
++					server.ws.send({ type: "full-reload" });
++				};
++				server.watcher.on("change", triggerHostReload);
++				server.watcher.on("add", triggerHostReload);
++				server.watcher.on("unlink", triggerHostReload);
++				server.httpServer?.once("close", teardown);
++			}
++		}
++	};
++}
++//#endregion
++//#region src/plugins/pluginDts.ts
++const DEFAULT_DEV_OPTIONS = {
++	disableLiveReload: true,
++	disableHotTypesReload: false,
++	disableDynamicRemoteTypeHints: false
++};
++const DYNAMIC_HINTS_PLUGIN = "@module-federation/dts-plugin/dynamic-remote-type-hints-plugin";
++const getIPv4 = () => process.env["FEDERATION_IPV4"] || "127.0.0.1";
++const DEV_TYPES_FOLDER = ".dev-server";
++const DEFAULT_PUBLIC_TYPES_FOLDER = "@mf-types";
++const forkDevWorkerPath = require.resolve("@module-federation/dts-plugin/dist/fork-dev-worker.js");
++var DevWorker = class {
++	worker = _module_federation_dts_plugin_core.rpc.createRpcWorker(forkDevWorkerPath, {}, void 0, false);
++	constructor(options) {
++		this.worker.connect(options);
++	}
++	update() {
++		this.worker.process?.send?.({
++			type: _module_federation_dts_plugin_core.rpc.RpcGMCallTypes.CALL,
++			id: this.worker.id,
++			args: [void 0, "update"]
+ 		});
++	}
++	exit() {
++		this.worker.terminate();
++	}
++};
++const normalizeDevOptions = (dev) => {
++	if (dev === false) return false;
++	if (dev === true || typeof dev === "undefined") return { ...DEFAULT_DEV_OPTIONS };
++	return {
++		...DEFAULT_DEV_OPTIONS,
++		...dev
+ 	};
+-	server.watcher.on("change", broadcast);
+-	server.watcher.on("add", broadcast);
+-	server.watcher.on("unlink", broadcast);
+-	server.httpServer?.once("close", () => {
+-		server.watcher.off("change", broadcast);
+-		server.watcher.off("add", broadcast);
+-		server.watcher.off("unlink", broadcast);
++};
++const buildDtsModuleFederationConfig = (options) => {
++	const exposes = {};
++	Object.entries(options.exposes).forEach(([key, value]) => {
++		if (value.import) exposes[key] = value.import;
+ 	});
+-}
+-/**
+-* Installs the host-side full-reload relay. For each configured remote:
+-*   1. Fetches the remote's `/__mf_hmr` metadata to get its WS URL.
+-*   2. Opens a Node-to-Node WebSocket to that URL.
+-*   3. On any `mf:remote-update` message, broadcasts `{ type: 'full-reload' }`
+-*      to the host's own browser-facing WS.
+-*
+-* Also reloads on local host file changes. Retries failed connections up to
+-* `REMOTE_HMR_CONNECT_MAX_RETRIES` times with a fixed delay.
+-*
+-* Only called under the `'full-reload'` strategy.
+-*/
+-function setupHostFullReloadRelay(server, options) {
+-	const connections = [];
+-	const reconnectTimers = /* @__PURE__ */ new Map();
+-	let isTearingDown = false;
+-	const clearReconnectTimer = (remoteName) => {
+-		const timer = reconnectTimers.get(remoteName);
+-		if (!timer) return;
+-		clearTimeout(timer);
+-		reconnectTimers.delete(remoteName);
++	const remotes = {};
++	Object.entries(options.remotes).forEach(([key, remote]) => {
++		if (!remote.entry) return;
++		remotes[key] = `${remote.entryGlobalName?.startsWith("http") || remote.entryGlobalName?.includes(".json") ? remote.name || key : remote.entryGlobalName || remote.name || key}@${remote.entry}`;
++	});
++	return {
++		...options,
++		exposes,
++		remotes
+ 	};
+-	const scheduleReconnect = (remoteName, remote, attempt, reason) => {
+-		if (isTearingDown) return;
+-		if (attempt >= REMOTE_HMR_CONNECT_MAX_RETRIES) {
+-			require_packageUtils.mfWarn(`Remote "${remoteName}" full HMR reconnect skipped after ${REMOTE_HMR_CONNECT_MAX_RETRIES} attempts: ${reason}`);
+-			return;
++};
++const resolveOutputDir = (config) => {
++	const { outDir } = config.build;
++	if (pathe.isAbsolute(outDir)) return pathe.relative(config.root, outDir);
++	return outDir;
++};
++const ensureRuntimePlugin = (options, pluginId) => {
++	if (!options.runtimePlugins.some((plugin) => {
++		if (typeof plugin === "string") return plugin === pluginId;
++		return plugin[0] === pluginId;
++	})) options.runtimePlugins.push(pluginId);
++};
++const getExposeImportPaths = (options) => {
++	return Object.values(options.exposes).map((value) => {
++		return value.import;
++	}).filter((value) => Boolean(value));
++};
++const usesVueSfcExposes = (options) => {
++	return getExposeImportPaths(options).some((value) => value.endsWith(".vue"));
++};
++const resolveDtsPluginOptions = (dts, options, context) => {
++	if (dts === false) return false;
++	const inferredGenerateTypesDefaults = { generateAPITypes: true };
++	if (usesVueSfcExposes(options) && hasPackageDependency("vue-tsc", context)) inferredGenerateTypesDefaults.compilerInstance = "vue-tsc";
++	if (dts === true || typeof dts === "undefined") return { generateTypes: inferredGenerateTypesDefaults };
++	const generateTypes = dts.generateTypes;
++	return {
++		...dts,
++		generateTypes: generateTypes === false ? false : {
++			...inferredGenerateTypesDefaults,
++			...generateTypes === true || typeof generateTypes === "undefined" ? {} : generateTypes
+ 		}
+-		clearReconnectTimer(remoteName);
+-		const timer = setTimeout(() => {
+-			reconnectTimers.delete(remoteName);
+-			connectRemote(remoteName, remote, attempt + 1);
+-		}, REMOTE_HMR_CONNECT_RETRY_DELAY_MS);
+-		reconnectTimers.set(remoteName, timer);
+ 	};
+-	const connectRemote = async (remoteName, remote, attempt = 0) => {
+-		if (isTearingDown) return;
+-		const endpoint = getRemoteHmrEndpoint(remote.entry, server);
+-		if (!endpoint) {
+-			require_packageUtils.mfWarn(`Failed to build HMR endpoint URL for remote "${remoteName}"`);
++};
++const getBasePath = (base) => {
++	if (base.startsWith("http://") || base.startsWith("https://")) return new URL(base).pathname.replace(/\/$/, "") || "/";
++	return base.replace(/\/$/, "") || "/";
++};
++const joinBaseAndAsset = (base, assetFileName) => {
++	const basePath = getBasePath(base);
++	return `${basePath === "/" ? "" : basePath}/${assetFileName}`.replace(/\/{2,}/g, "/");
++};
++const getDevDtsAssetPaths = (options) => {
++	const { outputDir, publicTypesFolder, root, base } = options;
++	return {
++		apiFilePath: pathe.resolve(root, outputDir, `${DEV_TYPES_FOLDER}.d.ts`),
++		apiRequestPath: joinBaseAndAsset(base, `${publicTypesFolder}.d.ts`),
++		zipFilePath: pathe.resolve(root, outputDir, `${DEV_TYPES_FOLDER}.zip`),
++		zipRequestPath: joinBaseAndAsset(base, `${publicTypesFolder}.zip`)
++	};
++};
++const createDevDtsAssetMiddleware = (assetPaths) => {
++	return (req, res, next) => {
++		const requestPath = req.url?.split("?")[0];
++		const isZipRequest = requestPath === assetPaths.zipRequestPath;
++		const isApiRequest = requestPath === assetPaths.apiRequestPath;
++		if (!isZipRequest && !isApiRequest) {
++			next();
+ 			return;
+ 		}
+-		try {
+-			const metadataResponse = await fetch(endpoint);
+-			if (!metadataResponse.ok) {
+-				require_packageUtils.mfWarn(`Failed to fetch remote HMR metadata from "${remoteName}": ${metadataResponse.status}`);
+-				scheduleReconnect(remoteName, remote, attempt, `HTTP ${metadataResponse.status}`);
+-				return;
+-			}
+-			const metadata = await metadataResponse.json();
+-			if (metadata.event !== "mf:remote-update" || !metadata.wsUrl) {
+-				require_packageUtils.mfWarn(`Remote "${remoteName}" returned unexpected HMR metadata shape`);
+-				return;
+-			}
+-			const ws = new WebSocket(metadata.wsUrl, "vite-hmr");
+-			ws.onmessage = (rawEvent) => {
+-				const message = parseRemoteHmrMessage(rawEvent.data);
+-				if (!message || message.event !== "mf:remote-update") return;
+-				server.ws.send({ type: "full-reload" });
+-			};
+-			ws.onopen = () => clearReconnectTimer(remoteName);
+-			ws.onerror = (error) => require_packageUtils.mfWarn(`Remote HMR socket error for "${remoteName}":`, error);
+-			ws.onclose = () => scheduleReconnect(remoteName, remote, attempt, "socket closed");
+-			connections.push(ws);
+-		} catch (error) {
+-			require_packageUtils.mfWarn(`Failed to connect remote HMR for "${remoteName}" on attempt ${attempt + 1}: ${getStringPreview(error)}`);
+-			scheduleReconnect(remoteName, remote, attempt, getStringPreview(error));
++		const filePath = isZipRequest ? assetPaths.zipFilePath : assetPaths.apiFilePath;
++		if (!fs.default.existsSync(filePath)) {
++			res.statusCode = 404;
++			res.end();
++			return;
+ 		}
+-	};
+-	const teardown = () => {
+-		isTearingDown = true;
+-		reconnectTimers.forEach((timer) => clearTimeout(timer));
+-		reconnectTimers.clear();
+-		connections.forEach((connection) => {
+-			if (connection.readyState !== connection.CLOSING && connection.readyState !== connection.CLOSED) connection.close();
++		res.statusCode = 200;
++		res.setHeader("Content-Type", isZipRequest ? "application/x-gzip" : "application/typescript");
++		if (req.method === "HEAD") {
++			res.end();
++			return;
++		}
++		const stream = fs.default.createReadStream(filePath);
++		stream.on("error", () => {
++			if (!res.headersSent) res.statusCode = 500;
++			res.end();
+ 		});
+-		connections.length = 0;
+-	};
+-	for (const [remoteName, remote] of Object.entries(options.remotes)) connectRemote(remoteName, remote);
+-	const triggerHostReload = (file) => {
+-		if (shouldIgnoreFile(file, options)) return;
+-		server.ws.send({ type: "full-reload" });
+-	};
+-	server.watcher.on("change", triggerHostReload);
+-	server.watcher.on("add", triggerHostReload);
+-	server.watcher.on("unlink", triggerHostReload);
+-	server.httpServer?.once("close", teardown);
+-}
+-//#endregion
+-//#region src/plugins/pluginDevRemoteHmr.ts
+-/**
+-* Clears the federation runtime's `moduleCache` on every Vite `vite:beforeUpdate`
+-* event. Without this, after a remote SFC change Vite would patch the in-memory
+-* component, but `loadRemote()` would still return the cached stale module on
+-* the next call (e.g. after route navigation), making the patched version
+-* effectively unreachable.
+-*/
+-const FEDERATION_MODULE_CACHE_CLEAR_SCRIPT = `
+-if (import.meta.hot) {
+-  import.meta.hot.on('vite:beforeUpdate', function () {
+-    try {
+-      var f = globalThis.__FEDERATION__ || globalThis.__VMOK__;
+-      if (!f || !f.__INSTANCES__) return;
+-      for (var i = 0; i < f.__INSTANCES__.length; i++) {
+-        if (f.__INSTANCES__[i] && f.__INSTANCES__[i].moduleCache)
+-          f.__INSTANCES__[i].moduleCache.clear();
+-      }
+-    } catch (e) {}
+-  });
+-}`;
+-const HMR_ADAPTERS = [reactAdapter, vueAdapter];
+-function resolveAdapters(plugins) {
+-	const pluginNames = new Set(plugins.map((p) => p.name));
+-	return HMR_ADAPTERS.filter((adapter) => adapter.pluginNames.some((name) => pluginNames.has(name)));
+-}
+-function hasCrossFederationHmr(plugins) {
+-	return resolveAdapters(plugins).length > 0;
+-}
+-function isRemoteHmrEnabled(dev) {
+-	return typeof dev === "object" && dev !== null && !!dev.remoteHmr;
+-}
+-/**
+-* `'native'` — a matched framework adapter owns HMR through Vite's native
+-* channel (e.g. React Fast Refresh via the `/@react-refresh` proxy, Vue's
+-* patched `__VUE_HMR_RUNTIME__`). The broadcast/relay path stays idle.
+-*
+-* `'full-reload'` — no adapter matched, or the user explicitly opted in with
+-* `remoteHmr: 'full-reload'` to bypass adapters: the plugin's broadcast/relay
+-* machinery triggers a page reload on every remote file change.
+-*/
+-function resolveHmrStrategy(dev, plugins) {
+-	if (typeof dev === "object" && dev !== null && dev.remoteHmr === "full-reload") return "full-reload";
+-	return hasCrossFederationHmr(plugins) ? "native" : "full-reload";
+-}
+-function shouldIgnoreFile(file, options) {
+-	return file.includes("/node_modules/") || file.includes("\\node_modules\\") || file.includes(`/${options.virtualModuleDir}/`) || file.includes(`\\${options.virtualModuleDir}\\`) || file.includes("/.vite/") || file.includes("\\.vite\\") || file.includes("/.mf/") || file.includes("\\.mf\\") || file.includes("/mf-manifest.json") || file.includes("\\mf-manifest.json") || file.includes("/mf-stats.json") || file.includes("\\mf-stats.json");
+-}
+-function collectHostTags(server, options, adapters) {
+-	const ctx = {
+-		server,
+-		options
++		res.on("close", () => {
++			stream.destroy();
++		});
++		stream.pipe(res);
+ 	};
+-	const tags = [];
+-	for (const adapter of adapters) {
+-		const adapterTags = adapter.host?.transformIndexHtml?.(ctx);
+-		if (adapterTags) tags.push(...adapterTags);
+-	}
+-	tags.push({
+-		tag: "script",
+-		attrs: { type: "module" },
+-		children: FEDERATION_MODULE_CACHE_CLEAR_SCRIPT,
+-		injectTo: "head"
++};
++const normalizeDevDtsOptions = (dts, context) => {
++	return (0, _module_federation_sdk.normalizeOptions)((0, _module_federation_dts_plugin.isTSProject)(dts, context), {
++		generateTypes: { compileInChildProcess: true },
++		consumeTypes: { consumeAPITypes: true },
++		extraOptions: {},
++		displayErrorInTerminal: typeof dts === "object" && dts ? dts.displayErrorInTerminal : void 0
++	}, "mfOptions.dts")(dts);
++};
++const logDtsError = (error, dtsOptions) => {
++	if (dtsOptions === false) return;
++	if (typeof dtsOptions === "object" && dtsOptions && dtsOptions.displayErrorInTerminal === false) return;
++	mfError(error);
++};
++function pluginDts(options) {
++	if (options.dts === false) return [];
++	const baseDtsModuleFederationConfig = buildDtsModuleFederationConfig(options);
++	const getDtsModuleFederationConfig = (context) => ({
++		...baseDtsModuleFederationConfig,
++		dts: resolveDtsPluginOptions(options.dts, options, context)
+ 	});
+-	return tags;
+-}
+-function pluginDevRemoteHmr(options) {
+-	const isHost = Object.keys(options.remotes).length > 0;
+-	const isRemote = Object.keys(options.exposes).length > 0;
+-	let adapters = [];
+-	let strategy = "full-reload";
+-	return {
+-		name: "module-federation-dev-remote-hmr",
++	let resolvedConfig;
++	let devWorker;
++	let normalizedDevOptions;
++	let hasGeneratedBundle = false;
++	return [{
++		name: "module-federation-dts-dev",
+ 		apply: "serve",
++		config(config) {
++			normalizedDevOptions = normalizeDevOptions(options.dev);
++			if (!normalizedDevOptions) return;
++			if (normalizedDevOptions.disableDynamicRemoteTypeHints) return;
++			ensureRuntimePlugin(options, DYNAMIC_HINTS_PLUGIN);
++			const define = config.define ? { ...config.define } : {};
++			if (!("FEDERATION_IPV4" in define)) define.FEDERATION_IPV4 = JSON.stringify(getIPv4());
++			config.define = define;
++		},
+ 		configResolved(config) {
+-			adapters = resolveAdapters(config.plugins);
+-			strategy = resolveHmrStrategy(options.dev, config.plugins);
++			resolvedConfig = config;
+ 		},
+ 		configureServer(server) {
+-			if (!isRemoteHmrEnabled(options.dev)) return;
+-			if (isRemote) {
+-				for (const adapter of adapters) adapter.remote?.configureServer?.({
+-					server,
+-					options
++			if (!normalizedDevOptions || !resolvedConfig) return;
++			const devOptions = normalizedDevOptions;
++			if (devOptions.disableDynamicRemoteTypeHints && devOptions.disableHotTypesReload && devOptions.disableLiveReload) return;
++			if (!options.name) throw createModuleFederationError("name is required if you want to enable dev server!");
++			const outputDir = resolveOutputDir(resolvedConfig);
++			const dtsModuleFederationConfig = getDtsModuleFederationConfig(resolvedConfig.root);
++			const normalizedDtsOptions = normalizeDevDtsOptions(dtsModuleFederationConfig.dts, resolvedConfig.root);
++			if (typeof normalizedDtsOptions !== "object") return;
++			const normalizedGenerateTypes = (0, _module_federation_sdk.normalizeOptions)(Boolean(normalizedDtsOptions), { compileInChildProcess: true }, "mfOptions.dts.generateTypes")(normalizedDtsOptions.generateTypes);
++			const remote = normalizedGenerateTypes === false ? void 0 : {
++				implementation: normalizedDtsOptions.implementation,
++				context: resolvedConfig.root,
++				outputDir,
++				moduleFederationConfig: { ...dtsModuleFederationConfig },
++				hostRemoteTypesFolder: normalizedGenerateTypes.typesFolder || DEFAULT_PUBLIC_TYPES_FOLDER,
++				...normalizedGenerateTypes,
++				typesFolder: DEV_TYPES_FOLDER
++			};
++			if (remote) server.middlewares.use(createDevDtsAssetMiddleware(getDevDtsAssetPaths({
++				outputDir,
++				publicTypesFolder: remote.hostRemoteTypesFolder || DEFAULT_PUBLIC_TYPES_FOLDER,
++				root: resolvedConfig.root,
++				base: resolvedConfig.base
++			})));
++			if (remote && !remote.tsConfigPath && normalizedDtsOptions.tsConfigPath) remote.tsConfigPath = normalizedDtsOptions.tsConfigPath;
++			const normalizedConsumeTypes = (0, _module_federation_sdk.normalizeOptions)(Boolean(normalizedDtsOptions), { consumeAPITypes: true }, "mfOptions.dts.consumeTypes")(normalizedDtsOptions.consumeTypes);
++			const host = normalizedConsumeTypes === false ? void 0 : {
++				implementation: normalizedDtsOptions.implementation,
++				context: resolvedConfig.root,
++				moduleFederationConfig: dtsModuleFederationConfig,
++				typesFolder: normalizedConsumeTypes.typesFolder || "@mf-types",
++				abortOnError: false,
++				...normalizedConsumeTypes
++			};
++			const extraOptions = normalizedDtsOptions.extraOptions || {};
++			if (!remote && !host && devOptions.disableLiveReload) return;
++			const startDevWorker = async () => {
++				let remoteTypeUrls;
++				if (host) remoteTypeUrls = await new Promise((resolve) => {
++					(0, _module_federation_dts_plugin.consumeTypesAPI)({
++						host,
++						extraOptions,
++						displayErrorInTerminal: normalizedDtsOptions.displayErrorInTerminal
++					}, resolve);
+ 				});
+-				setupRemoteMetadataEndpoint(server, options);
+-				if (strategy === "full-reload") setupRemoteBroadcast(server, options);
++				devWorker = new DevWorker({
++					name: options.name,
++					remote,
++					host: host ? {
++						...host,
++						remoteTypeUrls
++					} : void 0,
++					extraOptions,
++					disableLiveReload: devOptions.disableLiveReload,
++					disableHotTypesReload: devOptions.disableHotTypesReload
++				});
++				const update = () => devWorker?.update();
++				server.watcher.on("change", update);
++				server.watcher.on("add", update);
++				server.watcher.on("unlink", update);
++				server.httpServer?.once("close", () => {
++					devWorker?.exit();
++					server.watcher.off("change", update);
++					server.watcher.off("add", update);
++					server.watcher.off("unlink", update);
++				});
++			};
++			startDevWorker().catch((error) => {
++				logDtsError(error, normalizedDtsOptions);
++			});
++		}
++	}, {
++		name: "module-federation-dts-build",
++		apply: "build",
++		configResolved(config) {
++			resolvedConfig = config;
++		},
++		async generateBundle() {
++			if (hasGeneratedBundle) return;
++			hasGeneratedBundle = true;
++			if (!resolvedConfig) return;
++			let normalizedDtsOptions;
++			try {
++				normalizedDtsOptions = (0, _module_federation_dts_plugin.normalizeDtsOptions)(getDtsModuleFederationConfig(resolvedConfig.root), resolvedConfig.root);
++			} catch (error) {
++				logDtsError(error, options.dts);
++				return;
+ 			}
+-			if (isHost) {
+-				for (const adapter of adapters) adapter.host?.configureServer?.({
+-					server,
+-					options
++			if (typeof normalizedDtsOptions !== "object") return;
++			const context = resolvedConfig.root;
++			const outputDir = resolveOutputDir(resolvedConfig);
++			let consumeOptions;
++			try {
++				consumeOptions = (0, _module_federation_dts_plugin.normalizeConsumeTypesOptions)({
++					context,
++					dtsOptions: normalizedDtsOptions,
++					pluginOptions: getDtsModuleFederationConfig(resolvedConfig.root)
+ 				});
+-				if (strategy === "full-reload") setupHostFullReloadRelay(server, options);
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
++				return;
+ 			}
+-		},
+-		transform: {
+-			order: "post",
+-			handler(code, id) {
+-				if (!isRemote || !isRemoteHmrEnabled(options.dev)) return;
+-				if (!adapters.length) return;
+-				let result = code;
+-				const adapterCtx = { options };
+-				for (const adapter of adapters) {
+-					const next = adapter.remote?.transform?.(result, id, adapterCtx);
+-					if (typeof next === "string") result = next;
+-				}
+-				return result === code ? void 0 : result;
++			if (consumeOptions?.host?.typesOnBuild) try {
++				await (0, _module_federation_dts_plugin.consumeTypesAPI)(consumeOptions);
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
+ 			}
+-		},
+-		transformIndexHtml: {
+-			order: "pre",
+-			handler(_html, ctx) {
+-				if (!isRemoteHmrEnabled(options.dev)) return;
+-				if (!isHost || !ctx.server) return;
+-				return collectHostTags(ctx.server, options, adapters);
++			let generateOptions;
++			try {
++				generateOptions = (0, _module_federation_dts_plugin.normalizeGenerateTypesOptions)({
++					context,
++					outputDir,
++					dtsOptions: normalizedDtsOptions,
++					pluginOptions: getDtsModuleFederationConfig(resolvedConfig.root)
++				});
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
++				return;
++			}
++			if (!generateOptions) return;
++			try {
++				await (0, _module_federation_dts_plugin.generateTypesAPI)({ dtsManagerOptions: generateOptions });
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
+ 			}
+ 		}
+-	};
++	}];
+ }
+ //#endregion
+ //#region src/virtualModules/index.ts
+-function initVirtualModules(command, remoteEntryId, enableSsrInit = false) {
++function initVirtualModules(command, remoteEntryId) {
+ 	writeLocalSharedImportMap();
+ 	writeHostAutoInit(remoteEntryId, command);
+-	writeRuntimeInitStatus(command, enableSsrInit);
++	writeRuntimeInitStatus(command);
+ }
+ //#endregion
+ //#region src/utils/bundleHelpers.ts
+-function isOutputChunk$1(chunk) {
+-	return chunk.type === "chunk";
+-}
+-function escapeRegExp(value) {
+-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+-}
+-function getProxyBaseName(fileName) {
+-	return fileName.replace(/^.*\//, "").replace(/\.js$/, "").replace(/-[A-Za-z0-9_-]+$/, "");
+-}
+-function extractFunctionDeclaration(code, functionName) {
+-	const funcRe = new RegExp(`function\\s+${functionName}\\s*\\([^)]*\\)\\s*\\{`);
+-	const funcStart = code.search(funcRe);
+-	if (funcStart < 0) return;
+-	let depth = 0;
+-	for (let i = code.indexOf("{", funcStart); i < code.length; i++) if (code[i] === "{") depth++;
+-	else if (code[i] === "}") {
+-		depth--;
+-		if (depth === 0) return code.slice(funcStart, i + 1);
+-	}
+-}
+ /**
+ * Resolve the local alias for a non-inlineable proxy binding.
+ * If Rollup's deconflict renamed the alias but didn't update references
+@@ -2733,157 +2453,16 @@ function resolveProxyAlias(binding, proxyLocal, code, fullImport, claimedLocals
+ 	const localUsedInCode = new RegExp(`\\b${escapedLocal}\\b`).test(codeWithoutImport);
+ 	const claimedImportLocals = /* @__PURE__ */ new Set();
+ 	const importRe = /import\s*\{([^}]+)\}\s*from\s*["'][^"']+["']\s*;?/g;
+-	let match;
+-	while ((match = importRe.exec(codeWithoutImport)) !== null) for (const spec of match[1].split(",")) {
+-		const parts = spec.trim().split(/\s+as\s+/);
+-		claimedImportLocals.add((parts[1] || parts[0]).trim());
+-	}
+-	const local = !localUsedInCode && !claimedLocals.has(proxyLocal) && !claimedImportLocals.has(proxyLocal) ? proxyLocal : binding.local;
+-	return {
+-		imported: binding.imported,
+-		local
+-	};
+-}
+-function collectLoadShareProxyChunks(bundle, loadShareTag) {
+-	const proxyChunks = /* @__PURE__ */ new Map();
+-	for (const [fileName, chunk] of Object.entries(bundle)) {
+-		if (!isOutputChunk$1(chunk)) continue;
+-		if (fileName.includes(loadShareTag) && fileName.includes("commonjs-proxy")) proxyChunks.set(fileName, {
+-			code: chunk.code,
+-			fileName
+-		});
+-	}
+-	return proxyChunks;
+-}
+-function collectSystemProxyInfos(proxyChunks, loadShareTag) {
+-	const systemProxyInfo = /* @__PURE__ */ new Map();
+-	for (const [proxyFileName, proxyInfo] of Array.from(proxyChunks.entries())) {
+-		const depsMatch = proxyInfo.code.match(/System\.register\(\[([\s\S]*?)\]/);
+-		if (!depsMatch) continue;
+-		const loadShareDep = Array.from(depsMatch[1].matchAll(/["']([^"']+)["']/g)).map((m) => m[1]).find((dep) => dep.includes(loadShareTag) && !dep.includes("commonjs-proxy"));
+-		if (!loadShareDep) continue;
+-		const loadShareBindings = {};
+-		for (const m of proxyInfo.code.matchAll(/([A-Za-z_$][\w$]*)\s*=\s*module\d+\.([A-Za-z_$][\w$]*)/g)) loadShareBindings[m[1]] = m[2];
+-		const exportMap = {};
+-		const objectExportMatch = proxyInfo.code.match(/exports\(\s*\{([\s\S]*?)\}\s*\)/);
+-		if (objectExportMatch) for (const m of objectExportMatch[1].matchAll(/([A-Za-z_$][\w$]*)\s*:\s*([A-Za-z_$][\w$]*)/g)) {
+-			const [, exported, local] = m;
+-			const funcBody = extractFunctionDeclaration(proxyInfo.code, local);
+-			if (funcBody) exportMap[exported] = {
+-				type: "helper",
+-				code: funcBody
+-			};
+-		}
+-		for (const m of proxyInfo.code.matchAll(/exports\(\s*["']([^"']+)["']\s*,([\s\S]*?)\);/g)) {
+-			const exported = m[1];
+-			const expression = m[2];
+-			for (const [local, exportName] of Object.entries(loadShareBindings).reverse()) if (new RegExp(`\\b${local}\\b`).test(expression)) {
+-				exportMap[exported] = {
+-					type: "reexport",
+-					exportName
+-				};
+-				break;
+-			}
+-		}
+-		if (Object.keys(exportMap).length > 0) systemProxyInfo.set(proxyFileName, {
+-			loadShareDep,
+-			exportMap
+-		});
+-	}
+-	return systemProxyInfo;
+-}
+-function rewriteEsmProxyConsumers(code, proxyChunks) {
+-	let nextCode = code;
+-	const claimedLocals = /* @__PURE__ */ new Set();
+-	for (const [proxyFileName, proxyInfo] of Array.from(proxyChunks.entries())) {
+-		const proxyBaseName = getProxyBaseName(proxyFileName);
+-		const importMatch = new RegExp(`import\\s*\\{([^}]+)\\}\\s*from\\s*["']([^"']*${escapeRegExp(proxyBaseName)}[^"']*)["']\\s*;?`).exec(nextCode);
+-		if (!importMatch) continue;
+-		const fullImport = importMatch[0];
+-		const bindings = importMatch[1].split(",").map((s) => {
+-			const parts = s.trim().split(/\s+as\s+/);
+-			return {
+-				imported: parts[0].trim(),
+-				local: (parts[1] || parts[0]).trim()
+-			};
+-		});
+-		const exportMapMatch = proxyInfo.code.match(/export\s*\{([^}]+)\}/);
+-		if (!exportMapMatch) continue;
+-		const exportMap = {};
+-		for (const entry of exportMapMatch[1].split(",")) {
+-			const parts = entry.trim().split(/\s+as\s+/);
+-			if (parts.length === 2) exportMap[parts[1].trim()] = parts[0].trim();
+-		}
+-		const inlineable = [];
+-		const nonInlineable = [];
+-		const pendingLocals = new Set(bindings.map((binding) => binding.local));
+-		for (const b of bindings) {
+-			pendingLocals.delete(b.local);
+-			const proxyLocal = exportMap[b.imported];
+-			if (!proxyLocal) {
+-				claimedLocals.add(b.local);
+-				nonInlineable.push(b);
+-				continue;
+-			}
+-			const funcBody = extractFunctionDeclaration(proxyInfo.code, proxyLocal);
+-			if (funcBody) {
+-				inlineable.push({
+-					local: b.local,
+-					funcBody: funcBody.replace(new RegExp(`function\\s+${proxyLocal}\\s*\\(`), `function ${b.local}(`)
+-				});
+-				claimedLocals.add(b.local);
+-			} else {
+-				const unavailableLocals = new Set(claimedLocals);
+-				pendingLocals.forEach((local) => unavailableLocals.add(local));
+-				const resolvedBinding = resolveProxyAlias(b, proxyLocal, nextCode, fullImport, unavailableLocals);
+-				claimedLocals.add(resolvedBinding.local);
+-				nonInlineable.push(resolvedBinding);
+-			}
+-		}
+-		const hasRenamedAlias = nonInlineable.some((b) => bindings.find((ob) => ob.imported === b.imported)?.local !== b.local);
+-		if (inlineable.length === 0 && !hasRenamedAlias) continue;
+-		let replacement = "";
+-		if (nonInlineable.length > 0) replacement = `import{${nonInlineable.map((b) => b.imported === b.local ? b.imported : `${b.imported} as ${b.local}`).join(",")}}from"${importMatch[2]}";`;
+-		replacement += inlineable.map((f) => f.funcBody).join("");
+-		nextCode = nextCode.replace(fullImport, () => replacement);
+-	}
+-	return nextCode;
+-}
+-function rewriteSystemProxyConsumers(code, systemProxyInfo) {
+-	if (!code.includes("System.register(")) return code;
+-	let nextCode = code;
+-	for (const [proxyFileName, proxyInfo] of Array.from(systemProxyInfo.entries())) {
+-		const proxyBaseName = getProxyBaseName(proxyFileName);
+-		const depMatch = new RegExp(`["']([^"']*${escapeRegExp(proxyBaseName)}[^"']*)["']`).exec(nextCode);
+-		if (!depMatch) continue;
+-		let setterIndex = 0;
+-		const depListMatch = nextCode.match(/System\.register\(\[([\s\S]*?)\]/);
+-		if (depListMatch) setterIndex = Array.from(depListMatch[1].matchAll(/["']([^"']+)["']/g)).map((m) => m[1]).findIndex((dep) => dep.includes(proxyBaseName));
+-		if (setterIndex < 0) continue;
+-		const settersStart = nextCode.indexOf("setters: [");
+-		if (settersStart < 0) continue;
+-		const setterMatch = Array.from(nextCode.slice(settersStart).matchAll(/\((module\d+)\)\s*=>\s*\{([\s\S]*?)\}/g))[setterIndex];
+-		if (!setterMatch) continue;
+-		const [fullSetter, moduleLocal, setterBody] = setterMatch;
+-		const helpersToInline = [];
+-		const nextSetterBody = setterBody.replace(new RegExp(`([A-Za-z_$][\\w$]*)\\s*=\\s*${moduleLocal}\\.([A-Za-z_$][\\w$]*);?`, "g"), (assignment, local, imported) => {
+-			const mapped = proxyInfo.exportMap[imported];
+-			if (!mapped) return assignment;
+-			if (mapped.type === "helper") {
+-				helpersToInline.push(mapped.code.replace(new RegExp(`function\\s+${imported}\\s*\\(`), `function ${local}(`));
+-				return "";
+-			}
+-			return `${local} = ${moduleLocal}.${mapped.exportName};`;
+-		});
+-		if (nextSetterBody === setterBody && helpersToInline.length === 0) continue;
+-		const nextSetter = fullSetter.replace(setterBody, () => nextSetterBody);
+-		nextCode = nextCode.replace(fullSetter, () => nextSetter);
+-		nextCode = nextCode.replace(depMatch[0], JSON.stringify(proxyInfo.loadShareDep));
+-		if (helpersToInline.length > 0) nextCode = nextCode.replace("execute: (function() {", () => {
+-			return `execute: (function() {${helpersToInline.join("")}`;
+-		});
++	let match;
++	while ((match = importRe.exec(codeWithoutImport)) !== null) for (const spec of match[1].split(",")) {
++		const parts = spec.trim().split(/\s+as\s+/);
++		claimedImportLocals.add((parts[1] || parts[0]).trim());
+ 	}
+-	return nextCode;
++	const local = !localUsedInCode && !claimedLocals.has(proxyLocal) && !claimedImportLocals.has(proxyLocal) ? proxyLocal : binding.local;
++	return {
++		imported: binding.imported,
++		local
++	};
+ }
+ function findRemoteEntryFile(filename, bundle) {
+ 	for (const [_, fileData] of Object.entries(bundle)) if (filename.replace(/[\[\]]/g, "_").replace(/\.[^/.]+$/, "") === fileData.name || fileData.name === "remoteEntry") return fileData.fileName;
+@@ -2979,19 +2558,9 @@ const processModuleAssets = (bundle, filesMap, moduleMatcher, options = {}) => {
+ 				foundCssViaMetadata = true;
+ 			}
+ 			if (!foundCssViaMetadata && chunkContainsCssModules(fileData.modules)) for (const cssAsset of Array.from(bundleCssAssets)) trackAsset(filesMap, matchKey, cssAsset, false, "css");
+-			const visited = /* @__PURE__ */ new Set();
+-			const queue = [fileName];
+-			for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+-				const cur = queue[queueIndex];
+-				if (visited.has(cur)) continue;
+-				visited.add(cur);
+-				const chunk = bundle[cur];
+-				if (!chunk || chunk.type !== "chunk") continue;
+-				if (chunk.dynamicImports) for (const dynamicImport of chunk.dynamicImports) {
+-					if (!bundle[dynamicImport]) continue;
+-					trackAsset(filesMap, matchKey, dynamicImport, true, isCSSFile(dynamicImport) ? "css" : "js");
+-				}
+-				if (chunk.imports) for (const imp of chunk.imports) queue.push(imp);
++			if (fileData.dynamicImports) for (const dynamicImport of fileData.dynamicImports) {
++				if (!bundle[dynamicImport]) continue;
++				trackAsset(filesMap, matchKey, dynamicImport, true, isCSSFile(dynamicImport) ? "css" : "js");
+ 			}
+ 		}
+ 	}
+@@ -3037,56 +2606,7 @@ const buildFileToShareKeyMap = async (shareKeys, resolveFn) => {
+ 	return fileToShareKey;
+ };
+ //#endregion
+-//#region src/utils/pathNormalization.ts
+-const COMMON_SHARED_SUBPATHS = {
+-	react: [
+-		"react/jsx-runtime",
+-		"react/jsx-dev-runtime",
+-		"react/compiler-runtime"
+-	],
+-	"react-dom": [
+-		"react-dom/client",
+-		"react-dom/server",
+-		"react-dom/server.browser"
+-	],
+-	"solid-js": [
+-		"solid-js/web",
+-		"solid-js/store",
+-		"solid-js/html",
+-		"solid-js/h"
+-	]
+-};
+-function removeTrailingSlash(value) {
+-	return value.endsWith("/") ? value.slice(0, -1) : value;
+-}
+-function ensureTrailingSlash(value) {
+-	return `${removeTrailingSlash(value)}/`;
+-}
+-function getBasePath(base) {
+-	return removeTrailingSlash(base || "/");
+-}
+-function isNuxtClientBase(base) {
+-	return getBasePath(base).endsWith("/_nuxt");
+-}
+-function normalizeNodeModulePath(source) {
+-	return source.replace(/\\/g, "/").replace(/\?.*$/, "");
+-}
+-function isNodeModulePath(source) {
+-	return source.includes("/node_modules/") || source.includes("\\node_modules\\");
+-}
+-function filterId(id) {
+-	return typeof id === "string" && !id.includes("\0");
+-}
+-function getMatchingNodeModuleSubpath(source, candidates) {
+-	const normalized = normalizeNodeModulePath(source);
+-	return [...candidates].sort((a, b) => b.length - a.length).find((candidate) => normalized.includes(`/node_modules/${candidate}/`) || normalized.includes(`/node_modules/${candidate}.`));
+-}
+-function getCommonSharedSubpaths(sharedKey) {
+-	return COMMON_SHARED_SUBPATHS[removeTrailingSlash(sharedKey)] || [];
+-}
+-function getCommonSharedSubpathFromNodeModulePath(source, sharedKey) {
+-	return getMatchingNodeModuleSubpath(source, getCommonSharedSubpaths(removeTrailingSlash(sharedKey)));
+-}
++//#region src/utils/publicPath.ts
+ /**
+ * Resolves the public path for remote entries
+ * @param options - Module Federation options
+@@ -3096,121 +2616,11 @@ function getCommonSharedSubpathFromNodeModulePath(source, sharedKey) {
+ */
+ function resolvePublicPath(options, viteBase, originalBase) {
+ 	if (options.publicPath && options.publicPath !== "auto") return options.publicPath;
+-	if (!originalBase) return "auto";
+-	if (viteBase) return ensureTrailingSlash(viteBase);
++	if (originalBase === "") return "auto";
++	if (viteBase) return viteBase.replace(/\/?$/, "/");
+ 	return "auto";
+ }
+ //#endregion
+-//#region src/virtualModules/virtualExposesSSR.ts
+-/**
+-* Virtual module ID for the SSR exposes map.
+-* Separate from the browser exposes: no CSS injection, no document references,
+-* and shared packages are imported as bare specifiers (externals in the SSR build).
+-*/
+-function getVirtualExposesSSRId(options) {
+-	return `virtual:mf-exposes-ssr:${`${options.internalName}__${options.filename}`.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+-}
+-/**
+-* Generates the SSR exposes map module.
+-*
+-* Differences from the browser version (virtualExposes.ts):
+-* - No CSS asset injection (document APIs unavailable on Node)
+-* - Shared packages (react, react-dom, etc.) must be externals in the SSR
+-*   build so Node resolves them via its own module cache — this is what
+-*   guarantees the React singleton is shared with react-dom/server.
+-*/
+-function generateExposesSSR(options) {
+-	return `
+-    export default {
+-    ${Object.keys(options.exposes).map((key) => {
+-		return `
+-        ${JSON.stringify(key)}: async () => {
+-          const importModule = await import(${JSON.stringify(options.exposes[key].import)})
+-          const exportModule = {}
+-          Object.assign(exportModule, importModule)
+-          Object.defineProperty(exportModule, "__esModule", {
+-            value: true,
+-            enumerable: false
+-          })
+-          return exportModule
+-        }
+-      `;
+-	}).join(",")}
+-  }
+-  `;
+-}
+-//#endregion
+-//#region src/virtualModules/virtualRemoteEntrySSR.ts
+-const REMOTE_ENTRY_SSR_ID = "virtual:mf-REMOTE_ENTRY_SSR_ID";
+-function getRemoteEntrySSRId(options) {
+-	return `${REMOTE_ENTRY_SSR_ID}:${`${options.internalName}__${options.filename}`.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+-}
+-function getSsrRemoteEntryFileName(browserFilename) {
+-	const ext = browserFilename.match(/\.[^.]+$/)?.[0] || ".js";
+-	return `${browserFilename.slice(0, browserFilename.length - ext.length)}.ssr${ext}`;
+-}
+-/**
+-* Generates the SSR remote entry module.
+-*
+-* This is intentionally minimal — no HMR shim, no loadShare virtual modules,
+-* no browser globals. Shared packages (react, react-dom, etc.) are imported
+-* as externals by the SSR build, so Node's require cache provides the singleton.
+-*
+-* The container API (init / get) mirrors the browser entry so the MF runtime
+-* can call it the same way on the server.
+-*/
+-function generateRemoteEntrySSR(options) {
+-	const virtualExposesSSRId = getVirtualExposesSSRId(options);
+-	return `
+-  import { init as runtimeInit } from "@module-federation/runtime";
+-
+-  let exposesMapPromise;
+-
+-  async function getExposesMap() {
+-    exposesMapPromise ??= import(${JSON.stringify(virtualExposesSSRId)}).then((mod) => mod.default ?? mod);
+-    return exposesMapPromise;
+-  }
+-
+-  /**
+-   * Called by the MF runtime on the host to register this remote's share scope.
+-   * On the server the host has already initialised the runtime, so we just need
+-   * to set up a minimal runtime instance for the remote container.
+-   */
+-  async function init(shared = {}, initScope = []) {
+-    const initRes = runtimeInit({
+-      name: ${JSON.stringify(options.name)},
+-      remotes: [],
+-      shared: {},
+-    });
+-    const initToken = { from: ${JSON.stringify(options.name)} };
+-    if (initScope.indexOf(initToken) >= 0) return;
+-    initScope.push(initToken);
+-    initRes.initShareScopeMap(${JSON.stringify(options.shareScope)}, shared);
+-    try {
+-      await Promise.all(
+-        await initRes.initializeSharing(${JSON.stringify(options.shareScope)}, {
+-          strategy: ${JSON.stringify(options.shareStrategy ?? "version-first")},
+-          from: 'build',
+-          initScope,
+-        })
+-      );
+-    } catch (e) {
+-      console.error('[Module Federation SSR]', e);
+-    }
+-    return initRes;
+-  }
+-
+-  async function getExposes(moduleName) {
+-    const exposesMap = await getExposesMap();
+-    if (!(moduleName in exposesMap))
+-      throw new Error(\`[Module Federation] Module \${moduleName} does not exist in container.\`);
+-    return exposesMap[moduleName]().then((res) => () => res);
+-  }
+-
+-  export { init, getExposes as get };
+-  `;
+-}
+-//#endregion
+ //#region src/plugins/pluginMFManifest.ts
+ /**
+ * Resolves the build version for the module federation manifest.
+@@ -3241,7 +2651,6 @@ const Manifest = () => {
+ 	};
+ 	let root;
+ 	let remoteEntryFile;
+-	let ssrRemoteEntryFile;
+ 	let publicPath;
+ 	let _command;
+ 	let _originalConfigBase;
+@@ -3278,8 +2687,8 @@ const Manifest = () => {
+ 								type: "module"
+ 							},
+ 							ssrRemoteEntry: {
+-								name: getSsrRemoteEntryFileName(filename),
+-								path: "/__mf_ssr__/",
++								name: filename,
++								path: "",
+ 								type: "module"
+ 							},
+ 							varRemoteEntry: varFilename ? {
+@@ -3310,7 +2719,6 @@ const Manifest = () => {
+ 			_originalConfigBase = config.base;
+ 		},
+ 		configResolved(config) {
+-			viteConfig = config;
+ 			root = config.root;
+ 			let base = config.base;
+ 			if (_command === "serve") base = (config.server.origin || "") + config.base;
+@@ -3320,10 +2728,7 @@ const Manifest = () => {
+ 			if (!mfManifestName) return;
+ 			let filesMap = {};
+ 			const foundRemoteEntryFile = findRemoteEntryFile(mfOptions.filename, bundle);
+-			const expectedSsrRemoteEntryFile = getSsrRemoteEntryFileName(mfOptions.filename);
+-			const foundSsrRemoteEntryFile = Object.values(bundle).find((file) => file.fileName === expectedSsrRemoteEntryFile)?.fileName;
+ 			if (foundRemoteEntryFile) remoteEntryFile = foundRemoteEntryFile;
+-			ssrRemoteEntryFile = foundSsrRemoteEntryFile || expectedSsrRemoteEntryFile;
+ 			const allCssAssets = mfOptions.bundleAllCSS && !disableAssetsAnalyze ? collectCssAssets(bundle) : /* @__PURE__ */ new Set();
+ 			if (!disableAssetsAnalyze) {
+ 				const exposesModules = Object.keys(mfOptions.exposes).map((item) => mfOptions.exposes[item].import);
+@@ -3365,11 +2770,6 @@ const Manifest = () => {
+ 			path: "",
+ 			type: "module"
+ 		};
+-		const ssrRemoteEntry = {
+-			name: ssrRemoteEntryFile || getSsrRemoteEntryFileName(filename),
+-			path: _command === "serve" ? "/__mf_ssr__/" : "",
+-			type: "module"
+-		};
+ 		const varRemoteEntry = varFilename ? {
+ 			name: varFilename,
+ 			path: "",
+@@ -3381,11 +2781,10 @@ const Manifest = () => {
+ 			alias: remoteKey,
+ 			entry: "*"
+ 		})));
+-		const shared = Array.from(getUsedShares()).flatMap((shareKey) => {
++		const shared = Array.from(getUsedShares()).map((shareKey) => {
+ 			const shareItem = getNormalizeShareItem(shareKey);
+-			if (!shareItem) return [];
+ 			const assets = preloadMap[shareKey] || createEmptyAssetMap();
+-			return [{
++			return {
+ 				id: `${name}:${shareKey}`,
+ 				name: shareKey,
+ 				version: shareItem.version,
+@@ -3401,7 +2800,7 @@ const Manifest = () => {
+ 						sync: assets.css.sync
+ 					}
+ 				}
+-			}];
++			};
+ 		});
+ 		const exposes = Object.entries(options.exposes).map(([key, value]) => {
+ 			const formatKey = key.replace("./", "");
+@@ -3433,7 +2832,7 @@ const Manifest = () => {
+ 					buildName: name
+ 				},
+ 				remoteEntry,
+-				ssrRemoteEntry,
++				ssrRemoteEntry: remoteEntry,
+ 				varRemoteEntry,
+ 				types: {
+ 					path: "",
+@@ -3500,14 +2899,14 @@ function resetParseState() {
+ }
+ function setParseTimeout(timeout) {
+ 	if (!_parseTimeout) _parseTimeout = setTimeout(() => {
+-		require_packageUtils.mfWarn(`Parse timeout (${timeout}s) - forcing resolve`);
++		mfWarn(`Parse timeout (${timeout}s) - forcing resolve`);
+ 		_resolve?.(1);
+ 	}, timeout * 1e3);
+ }
+ function resetIdleTimeout(timeout) {
+ 	clearParseTimeout();
+ 	_parseTimeout = setTimeout(() => {
+-		require_packageUtils.mfWarn(`moduleParseIdleTimeout: no module activity for ${timeout}s, forcing resolve. Some shared/remote dependencies may be missing. Consider increasing moduleParseIdleTimeout.`);
++		mfWarn(`moduleParseIdleTimeout: no module activity for ${timeout}s, forcing resolve. Some shared/remote dependencies may be missing. Consider increasing moduleParseIdleTimeout.`);
+ 		_resolve?.(1);
+ 	}, timeout * 1e3);
+ }
+@@ -3553,6 +2952,7 @@ function pluginModuleParseEnd_default(excludeFn, options) {
+ }
+ //#endregion
+ //#region src/plugins/pluginProxyRemoteEntry.ts
++const filter$1 = (0, _rollup_pluginutils.createFilter)();
+ function pluginProxyRemoteEntry_default({ options, remoteEntryId, virtualExposesId }) {
+ 	let viteConfig, _command, root;
+ 	return {
+@@ -3592,15 +2992,14 @@ function pluginProxyRemoteEntry_default({ options, remoteEntryId, virtualExposes
+ 		},
+ 		transform(code, id) {
+ 			return mapCodeToCodeWithSourcemap((() => {
+-				if (!filterId(id)) return;
++				if (!filter$1(id)) return;
+ 				if (id.includes(remoteEntryId)) return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
+ 				if (id === virtualExposesId) return generateExposes(options);
+ 				if (id.includes(getHostAutoInitPath())) {
+ 					if (_command === "serve") {
+ 						const host = typeof viteConfig.server?.host === "string" && viteConfig.server.host !== "0.0.0.0" ? viteConfig.server.host : "localhost";
+-						const resolvedPublicPath = resolvePublicPath(options, viteConfig.base);
+-						const publicPath = JSON.stringify((resolvedPublicPath === "auto" ? "/" : resolvedPublicPath) + options.filename);
+-						const fallbackOrigin = `//${host}:${viteConfig.server?.port}`;
++						const publicPath = JSON.stringify(resolvePublicPath(options, viteConfig.base) + options.filename);
++						const fallbackOrigin = `http://${host}:${viteConfig.server?.port}`;
+ 						const ssrRemoteEntry = "data:text/javascript," + encodeURIComponent("export async function init(){return {loadRemote:async()=>({}),loadShare:async()=>({})}}");
+ 						return `
+           const origin = typeof window !== 'undefined' && (${!options.ignoreOrigin}) ? window.origin : ${JSON.stringify(fallbackOrigin)};
+@@ -3651,59 +3050,39 @@ function pluginProxyRemoteEntry_default({ options, remoteEntryId, virtualExposes
+ }
+ //#endregion
+ //#region src/plugins/pluginProxyRemotes.ts
++const filter = (0, _rollup_pluginutils.createFilter)();
+ function isNodeModulesImporter(importer) {
+ 	return importer?.includes("/node_modules/") || importer?.includes("\\node_modules\\");
+ }
+-function appendAlias(config, alias) {
+-	config.resolve ??= {};
+-	const existingAlias = config.resolve.alias;
+-	if (!existingAlias) {
+-		config.resolve.alias = [alias];
+-		return;
+-	}
+-	if (Array.isArray(existingAlias)) {
+-		existingAlias.push(alias);
+-		return;
+-	}
+-	config.resolve.alias = [...Object.entries(existingAlias).map(([find, replacement]) => ({
+-		find,
+-		replacement
+-	})), alias];
+-}
+ function pluginProxyRemotes_default(options) {
+ 	let command;
+ 	let root = process.cwd();
+-	let enableSsrInit = false;
+ 	const { remotes } = options;
+ 	function resolveRemoteId(source, importer, remoteName) {
+ 		if (source === remoteName) {
+-			const installedPackageEntry = require_packageUtils.getInstalledPackageEntry(source, { cwd: root });
++			const installedPackageEntry = getInstalledPackageEntry(source, { cwd: root });
+ 			if (installedPackageEntry && (importer === void 0 || isNodeModulesImporter(importer))) return installedPackageEntry;
+ 		}
+-		const remoteModule = getRemoteVirtualModule(source, command, enableSsrInit);
++		const remoteModule = getRemoteVirtualModule(source, command);
+ 		addUsedRemote(remoteName, source);
+ 		refreshHostAutoInit();
+-		return remoteModule.getImportId();
++		return remoteModule.getPath();
+ 	}
+ 	return {
+ 		name: "proxyRemotes",
+-		enforce: "pre",
+ 		config(config, { command: _command }) {
+ 			command = _command;
+ 			root = config.root || process.cwd();
+ 			Object.keys(remotes).forEach((key) => {
+ 				const remote = remotes[key];
+-				appendAlias(config, {
++				config.resolve.alias.push({
+ 					find: new RegExp(`^(${remote.name}(\/.*|$))`),
+ 					replacement: "$1"
+ 				});
+ 			});
+ 		},
+-		configResolved() {
+-			enableSsrInit = command === "serve" && parseInt(vite.version, 10) >= 8;
+-		},
+ 		resolveId(source, importer) {
+-			if (!filterId(source)) return;
++			if (!filter(source)) return;
+ 			for (const remote of Object.values(remotes)) {
+ 				if (source !== remote.name && !source.startsWith(`${remote.name}/`)) continue;
+ 				return resolveRemoteId(source, importer, remote.name);
+@@ -3749,10 +3128,10 @@ function getPrebuildResolutionSource(pkgName, shareItem) {
+ }
+ function tryResolveFromProjectRoot(source) {
+ 	if (pathe.default.isAbsolute(source) || source.startsWith(".") || source.startsWith("/")) return source;
+-	const browserEntry = require_packageUtils.getInstalledPackageEntry(source, { cwd: require_packageUtils.getPackageDetectionCwd() });
++	const browserEntry = getInstalledPackageEntry(source, { cwd: getPackageDetectionCwd() });
+ 	if (browserEntry) return browserEntry;
+ 	try {
+-		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(require_packageUtils.getPackageDetectionCwd(), "package.json")}`)).resolve(source);
++		return (0, module$1.createRequire)(new URL(`file://${pathe.default.join(getPackageDetectionCwd(), "package.json")}`)).resolve(source);
+ 	} catch {
+ 		return;
+ 	}
+@@ -3763,38 +3142,21 @@ function isBuildConfigImporter(importer) {
+ }
+ function matchesSharedSource(source, key) {
+ 	const keyBase = key.endsWith("/") ? key.slice(0, -1) : key;
+-	if (keyBase === "vue" && (source === "vue/dist/vue.esm-bundler.js" || source === "vue/dist/vue.runtime.esm-bundler.js")) return true;
+ 	if (key.endsWith("/")) return source === keyBase || source.startsWith(`${keyBase}/`);
+-	if (getCommonSharedSubpaths(keyBase).includes(source)) return true;
+ 	return source === keyBase;
+ }
+ function findSharedKey(source, shared) {
+-	const keys = Object.keys(shared || {});
+-	return keys.find((key) => source === key) ?? keys.find((key) => matchesSharedSource(source, key));
+-}
+-function findSharedKeyForSource(source, shared) {
+-	const key = findSharedKey(source, shared);
+-	if (key) return key;
+-	const explicitSharedSubpathKeys = Object.keys(shared || {}).filter((sharedKey) => require_packageUtils.getPackageName(sharedKey) !== sharedKey && !sharedKey.endsWith("/"));
+-	if (isNodeModulePath(source)) {
+-		const explicitSubpathKey = getMatchingNodeModuleSubpath(source, explicitSharedSubpathKeys);
+-		if (explicitSubpathKey) return explicitSubpathKey;
+-		const normalizedSource = normalizeNodeModulePath(source);
+-		const explicitSubpathEntryKey = explicitSharedSubpathKeys.find((sharedKey) => {
+-			const entry = require_packageUtils.getInstalledPackageEntry(sharedKey, { cwd: require_packageUtils.getPackageDetectionCwd() });
+-			return entry ? normalizeNodeModulePath(entry) === normalizedSource : false;
+-		});
+-		if (explicitSubpathEntryKey) return explicitSubpathEntryKey;
+-	}
+-	const packageName = require_packageUtils.getPackageNameFromNodeModulePath(source);
+-	return packageName ? findSharedKey(packageName, shared) : void 0;
++	return Object.keys(shared || {}).find((key) => matchesSharedSource(source, key));
++}
++function isNodeModulePath(source) {
++	return source.includes("/node_modules/") || source.includes("\\node_modules\\");
+ }
+ /**
+ * Reads the dependencies of an installed package from its package.json.
+ */
+ function getPackageDependencies(pkg) {
+-	const packageName = require_packageUtils.getPackageName(pkg);
+-	const installed = require_packageUtils.getInstalledPackageJson(packageName, { packageName });
++	const packageName = getPackageName(pkg);
++	const installed = getInstalledPackageJson(packageName, { packageName });
+ 	return Object.keys(installed?.packageJson.dependencies || {});
+ }
+ /**
+@@ -3812,8 +3174,7 @@ function excludeSharedSubDependencies(shared) {
+ 		for (const dep of deps) {
+ 			const depKey = sharedKeyByBase.get(dep);
+ 			if (depKey && depKey !== parentKey) {
+-				if (shared[depKey]?.shareConfig.singleton === true || shared[depKey]?.shareConfig.import === false) continue;
+-				require_packageUtils.mfWarn(`"${dep}" is a dependency of shared package "${parentKey}" and is also shared separately. This may cause initialization order issues in dev mode. Consider sharing only "${parentKey}".\n  Auto-excluding "${dep}" from shared modules for dev mode.`);
++				mfWarn(`"${dep}" is a dependency of shared package "${parentKey}" and is also shared separately. This may cause initialization order issues in dev mode. Consider sharing only "${parentKey}".\n  Auto-excluding "${dep}" from shared modules for dev mode.`);
+ 				delete shared[depKey];
+ 				sharedKeys.delete(depKey);
+ 				sharedKeyByBase.delete(dep);
+@@ -3828,38 +3189,25 @@ function proxySharedModule(options) {
+ 	let useDirectReactImport = false;
+ 	let useRolldown = false;
+ 	const savePrebuild = new PromiseStore();
+-	let devServer;
+-	const materializedLoadShareSources = /* @__PURE__ */ new Set();
+ 	return [
+ 		{
+ 			name: "generateLocalSharedImportMap",
+ 			enforce: "post",
+-			configureServer(server) {
+-				devServer = server;
+-				setLocalSharedImportMapInvalidator(() => {
+-					const module = server.moduleGraph.getModuleById(getResolvedLocalSharedImportMapId());
+-					if (module) server.moduleGraph.invalidateModule(module);
+-				});
+-			},
+-			resolveId(source) {
+-				if (source === getLocalSharedImportMapPath()) return getResolvedLocalSharedImportMapId();
+-			},
+ 			load(id) {
+-				if (id === getResolvedLocalSharedImportMapId()) return parsePromise.then((_) => generateLocalSharedImportMap());
++				if (id.includes(getLocalSharedImportMapPath())) return parsePromise.then((_) => generateLocalSharedImportMap());
+ 			},
+-			closeBundle() {
+-				if (devServer) return;
+-				setLocalSharedImportMapInvalidator(void 0);
++			transform(_, id) {
++				if (id.includes(getLocalSharedImportMapPath())) return mapCodeToCodeWithSourcemap(parsePromise.then((_) => generateLocalSharedImportMap()));
+ 			}
+ 		},
+ 		{
+ 			name: "proxyPreBuildShared",
+ 			enforce: "post",
+ 			config(config, { command }) {
+-				require_packageUtils.setPackageDetectionCwd(config.root || process.cwd());
+-				const isVinext = require_packageUtils.hasPackageDependency("vinext");
+-				const isAstro = require_packageUtils.hasPackageDependency("astro");
+-				const isRolldown = require_packageUtils.getIsRolldown(this);
++				setPackageDetectionCwd(config.root || process.cwd());
++				const isVinext = hasPackageDependency("vinext");
++				const isAstro = hasPackageDependency("astro");
++				const isRolldown = getIsRolldown(this);
+ 				_command = command;
+ 				useRolldown = isRolldown;
+ 				useDirectReactImport = isVinext || isAstro;
+@@ -3867,7 +3215,7 @@ function proxySharedModule(options) {
+ 			},
+ 			configResolved(config) {
+ 				_config = config;
+-				const isRolldown = require_packageUtils.getIsRolldown(this);
++				const isRolldown = getIsRolldown(this);
+ 				Object.keys(shared).forEach((key) => {
+ 					if (key.endsWith("/")) return;
+ 					if (useDirectReactImport && key === "react") {
+@@ -3886,13 +3234,7 @@ function proxySharedModule(options) {
+ 			name: "proxyPreBuildShared:resolve-shared-loadShare",
+ 			enforce: "pre",
+ 			async resolveId(source, importer) {
+-				function shouldSkipTaggedImporterProxy(sharedKey, tag) {
+-					if (!importer?.includes(tag)) return false;
+-					const taggedModule = VirtualModule.findModule(tag, importer);
+-					if (!taggedModule) return true;
+-					return taggedModule.name === sharedKey || matchesSharedSource(source, taggedModule.name);
+-				}
+-				const key = findSharedKeyForSource(source, shared);
++				const key = findSharedKey(source, shared);
+ 				if (!key) return;
+ 				if (useDirectReactImport && key === "react") return;
+ 				if (/\.css$/.test(source)) return;
+@@ -3900,18 +3242,15 @@ function proxySharedModule(options) {
+ 				if (useDirectReactImport && source === "react") return;
+ 				if (importer && importer.includes("localSharedImportMap")) return;
+ 				if (importer && (importer.includes("hostAutoInit") || importer.includes("__H_A_I__"))) return;
+-				if (shouldSkipTaggedImporterProxy(key, "__loadShare__")) return;
+-				if (shouldSkipTaggedImporterProxy(key, "__prebuild__")) return;
+-				const shareSource = key === "vue" && source.startsWith("vue/dist/") ? key : isNodeModulePath(source) ? getCommonSharedSubpathFromNodeModulePath(source, key) || key : source;
+-				const loadSharePath = getLoadShareModulePath(shareSource, useRolldown);
+-				if (!materializedLoadShareSources.has(shareSource)) {
+-					materializedLoadShareSources.add(shareSource);
+-					writeLoadShareModule(shareSource, shared[key], _command, useRolldown);
+-					if (shared[key].shareConfig.import !== false) writePreBuildLibPath(shareSource, shared[key]);
+-					addUsedShares(shareSource);
+-					writeLocalSharedImportMap();
+-					refreshHostAutoInit();
+-				}
++				if (importer && importer.includes("__loadShare__")) return;
++				if (importer && importer.includes("__prebuild__")) return;
++				if (key.endsWith("/") && source !== key.slice(0, -1)) return;
++				const loadSharePath = getLoadShareModulePath(source, useRolldown);
++				writeLoadShareModule(source, shared[key], _command, useRolldown);
++				if (shared[key].shareConfig.import !== false) writePreBuildLibPath(source, shared[key]);
++				addUsedShares(source);
++				writeLocalSharedImportMap();
++				refreshHostAutoInit();
+ 				return this.resolve(loadSharePath, importer, { skipSelf: true });
+ 			}
+ 		},
+@@ -3989,28 +3328,9 @@ function wrapDynamicImport(original) {
+ }
+ function applyRewrites(code, imports, id) {
+ 	if (imports.length === 0) return;
+-	const ms = new CodeRewriter(code);
++	const ms = new magic_string.default(code);
+ 	let changed = false;
+ 	let counter = 0;
+-	let namedProxyHelperDeclared = false;
+-	const namedProxyHelper = `function __mfCreateNamedRemoteProxy(ns, key) {
+-  const target = function (...args) {
+-    const value = ns[key];
+-    return typeof value === "function" ? value.apply(this, args) : value;
+-  };
+-  return new Proxy(target, {
+-    get(_target, prop) {
+-      if (prop === "then") return undefined;
+-      const value = ns[key];
+-      if (prop === Symbol.toPrimitive) return () => value;
+-      const item = value == null ? undefined : value[prop];
+-      return typeof item === "function" ? item.bind(value) : item;
+-    },
+-    apply(target, thisArg, args) {
+-      return target.apply(thisArg, args);
+-    }
+-  });
+-}`;
+ 	for (const imp of imports) switch (imp.kind) {
+ 		case "static": {
+ 			const src = JSON.stringify(imp.source);
+@@ -4020,23 +3340,9 @@ function applyRewrites(code, imports, id) {
+ 				const importParts = [];
+ 				if (imp.defaultLocal) importParts.push(`default as ${imp.defaultLocal}`);
+ 				importParts.push(`__moduleExports as ${nsId}`);
++				const destructParts = imp.named.map((s) => s.imported === s.local ? s.local : `${s.imported}: ${s.local}`);
+ 				let rewrite = `import { ${importParts.join(", ")} } from ${src};`;
+-				if (imp.named.length > 0) {
+-					const isProxyId = `__mf_is_proxy_${counter++}`;
+-					const tempNames = imp.named.map((_s) => `__mf_named_${counter++}`);
+-					const destructParts = imp.named.map((s, index) => `${s.imported}: ${tempNames[index]}`);
+-					const bindingLines = imp.named.map((s, index) => {
+-						const temp = tempNames[index];
+-						return `const ${s.local} = ${isProxyId} ? __mfCreateNamedRemoteProxy(${nsId}, ${JSON.stringify(s.imported)}) : ${temp};`;
+-					});
+-					if (!namedProxyHelperDeclared) {
+-						rewrite += `\n${namedProxyHelper}`;
+-						namedProxyHelperDeclared = true;
+-					}
+-					rewrite += `\nconst ${isProxyId} = ${nsId} && ${nsId}.__mf_is_remote_proxy;`;
+-					rewrite += `\nconst { ${destructParts.join(", ")} } = ${isProxyId} ? {} : ${nsId};`;
+-					rewrite += `\n${bindingLines.join("\n")}`;
+-				}
++				if (destructParts.length > 0) rewrite += `\nconst { ${destructParts.join(", ")} } = ${nsId};`;
+ 				ms.overwrite(imp.start, imp.end, rewrite);
+ 			}
+ 			changed = true;
+@@ -4070,7 +3376,7 @@ function applyRewrites(code, imports, id) {
+ 	if (!changed) return;
+ 	return {
+ 		code: ms.toString(),
+-		map: ms.generateMap(id)
++		map: ms.generateMap({ hires: true })
+ 	};
+ }
+ async function collectFromAST(ast, code, isRemoteImport) {
+@@ -4312,205 +3618,6 @@ function pluginRemoteNamedExports(options) {
+ 	};
+ }
+ //#endregion
+-//#region src/plugins/pluginSSRRemoteEntry.ts
+-/**
+-* Emits a Node-compatible SSR remote entry alongside the browser entry.
+-*
+-* Format strategy:
+-*  - Emit a dedicated ESM SSR entry alongside the browser entry.
+-*  - Keep the SSR entry out of the browser remote graph for Rollup builds by
+-*    emitting it as a generated asset.
+-*
+-* In both cases shared packages (react, react-dom, etc.) are marked as external
+-* so Node resolves them through its own module cache, guaranteeing the singleton
+-* is shared with react-dom/server.
+-*/
+-function pluginSSRRemoteEntry(options) {
+-	const remoteEntrySSRId = getRemoteEntrySSRId(options);
+-	const virtualExposesSSRId = getVirtualExposesSSRId(options);
+-	let isRolldown = false;
+-	let ssrOutputFilename = "";
+-	const ssrOnlyExternals = [
+-		"@module-federation/runtime",
+-		"@module-federation/runtime-core",
+-		"@module-federation/sdk",
+-		...options.ssrExternals ?? []
+-	];
+-	const ssrOnlyExternalPattern = new RegExp(`^(${ssrOnlyExternals.map((e) => e.replace(/[/\\^$*+?.()|[\]{}]/g, "\\$&")).join("|")})(\\/.*)?$`);
+-	const ssrModuleIds = new Set([remoteEntrySSRId, virtualExposesSSRId]);
+-	const resolvedAbsToPackage = /* @__PURE__ */ new Map();
+-	let isServe = false;
+-	let viteConfig;
+-	let isNuxtProject = false;
+-	const findNuxtExposesChunk = (bundle) => {
+-		const exposeKeys = Object.keys(options.exposes);
+-		if (exposeKeys.length === 0) return;
+-		return Object.values(bundle).find((file) => {
+-			if (file.type !== "chunk" || !file.fileName.startsWith("_nuxt/") || !file.fileName.endsWith(".js")) return false;
+-			const code = file.code || "";
+-			return exposeKeys.every((key) => code.includes(JSON.stringify(key)));
+-		})?.fileName;
+-	};
+-	return [{
+-		name: "mf:ssr-remote-entry:pre",
+-		enforce: "pre",
+-		configResolved(config) {
+-			isServe = config.command === "serve";
+-			for (const pkg of ssrOnlyExternals) {
+-				const aliasEntry = (config.resolve?.alias)?.find((a) => a.find === pkg || a.find instanceof RegExp && a.find.test(pkg));
+-				if (aliasEntry?.replacement) resolvedAbsToPackage.set(aliasEntry.replacement, pkg);
+-			}
+-		},
+-		resolveId(id, importer) {
+-			if (id === remoteEntrySSRId || id.startsWith(remoteEntrySSRId)) return id;
+-			if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) return id;
+-			if (!importer || !ssrModuleIds.has(importer)) return;
+-			if (ssrOnlyExternalPattern.test(id)) return {
+-				id,
+-				external: true
+-			};
+-			const pkg = resolvedAbsToPackage.get(id);
+-			if (pkg) return {
+-				id: pkg,
+-				external: true
+-			};
+-			if (id.startsWith(".") || id.startsWith("/") || id.startsWith("file:")) return this.resolve(id, importer, { skipSelf: true }).then((resolved) => {
+-				if (resolved) ssrModuleIds.add(resolved.id);
+-				return resolved;
+-			});
+-		}
+-	}, {
+-		name: "mf:ssr-remote-entry",
+-		configResolved(config) {
+-			viteConfig = config;
+-			isNuxtProject = require_packageUtils.isNuxtProjectRoot(config.root);
+-		},
+-		configureServer(server) {
+-			const base = "/__mf_ssr__";
+-			const basePath = getBasePath(viteConfig?.base);
+-			const ssrEntryFileName = getSsrRemoteEntryFileName(options.filename);
+-			if (isNuxtProject || isNuxtClientBase(basePath)) server.middlewares.use((req, _res, next) => {
+-				if (req.url?.replace(/\?.*/, "") === `${basePath}/${ssrEntryFileName}`) req.url = `${basePath}/__mf_ssr__/${ssrEntryFileName}`;
+-				next();
+-			});
+-			const ssrEnv = server.environments?.ssr;
+-			const clientEnv = server.environments?.client;
+-			if (typeof (ssrEnv?.fetchModule ?? clientEnv?.fetchModule) === "function") server.middlewares.use("/__mf_runner__", async (req, res) => {
+-				res.setHeader("Access-Control-Allow-Origin", "*");
+-				if (req.method === "OPTIONS") {
+-					res.setHeader("Access-Control-Allow-Methods", "POST");
+-					res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+-					res.statusCode = 204;
+-					res.end();
+-					return;
+-				}
+-				if (req.method !== "POST") {
+-					res.statusCode = 405;
+-					res.end("Method not allowed");
+-					return;
+-				}
+-				try {
+-					const chunks = [];
+-					await new Promise((resolve, reject) => {
+-						req.on("data", (chunk) => chunks.push(chunk));
+-						req.on("end", resolve);
+-						req.on("error", reject);
+-					});
+-					const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+-					if (body.name === "getBuiltins") {
+-						const builtins = (clientEnv ?? ssrEnv)?.config?.resolve?.builtins ?? [];
+-						res.setHeader("Content-Type", "application/json");
+-						res.end(JSON.stringify({ result: builtins }));
+-						return;
+-					}
+-					if (body.name !== "fetchModule") {
+-						res.statusCode = 400;
+-						res.end(JSON.stringify({ error: { message: `Unsupported invoke: ${body.name}` } }));
+-						return;
+-					}
+-					const [id, importer, opts] = body.data;
+-					const fetchEnv = ssrEnv ?? clientEnv;
+-					const fetchFn = fetchEnv.fetchModule.bind(fetchEnv);
+-					let result;
+-					try {
+-						result = await fetchFn(id, importer, opts);
+-					} catch (fetchErr) {
+-						const bareId = decodeViteId(id);
+-						try {
+-							const { createRequire } = await import("module");
+-							const resolved = createRequire(new URL(`file://${server.config.root}/package.json`)).resolve(bareId.replace(/^\0/, ""));
+-							const { pathToFileURL } = await import("url");
+-							result = {
+-								externalize: pathToFileURL(resolved).href,
+-								type: "module"
+-							};
+-						} catch {
+-							throw fetchErr;
+-						}
+-					}
+-					res.setHeader("Content-Type", "application/json");
+-					res.end(JSON.stringify({ result }));
+-				} catch (e) {
+-					res.setHeader("Content-Type", "application/json");
+-					res.end(JSON.stringify({ error: { message: String(e instanceof Error ? e.message : e) } }));
+-				}
+-			});
+-			const ssrPath = `${base}/${ssrEntryFileName}`;
+-			server.middlewares.use(ssrPath, (_req, res) => {
+-				const exposesUrl = `${base}/${options.filename.replace(/\.[^.]+$/, "")}.exposes.js`;
+-				const code = generateRemoteEntrySSR(options).replace(JSON.stringify(virtualExposesSSRId), JSON.stringify(exposesUrl));
+-				res.setHeader("Content-Type", "application/javascript");
+-				res.setHeader("Access-Control-Allow-Origin", "*");
+-				res.end(code);
+-			});
+-		},
+-		resolveId(id) {
+-			if (id === remoteEntrySSRId || id.startsWith(remoteEntrySSRId)) return id;
+-			if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) return id;
+-			if (id === `/__mf_ssr__/${getSsrRemoteEntryFileName(options.filename)}`) return remoteEntrySSRId;
+-			if (id === `/__mf_ssr__/${options.filename.replace(/\.[^.]+$/, "")}.exposes.js`) return virtualExposesSSRId;
+-		},
+-		load(id) {
+-			if (id === remoteEntrySSRId || id.startsWith(remoteEntrySSRId)) return generateRemoteEntrySSR(options);
+-			if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) return generateExposesSSR(options);
+-		},
+-		buildStart() {
+-			if (isServe) return;
+-			isRolldown = require_packageUtils.getIsRolldown(this);
+-			ssrOutputFilename = getSsrRemoteEntryFileName(options.filename);
+-			const environmentName = this.environment?.name;
+-			const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
+-			const isLegacySsrBuild = Boolean(this.environment?.config?.build?.ssr);
+-			if (hasSsrEnvironment) {
+-				if (isNuxtProject) {
+-					if (environmentName === "ssr") return;
+-				} else if (environmentName !== "ssr") return;
+-			} else if (isLegacySsrBuild) {} else if (environmentName && environmentName !== "client") return;
+-			if (Object.keys(options.exposes).length === 0) return;
+-			if (isRolldown) this.emitFile({
+-				type: "chunk",
+-				id: remoteEntrySSRId,
+-				name: "ssrRemoteEntry",
+-				fileName: ssrOutputFilename,
+-				preserveSignature: "strict"
+-			});
+-			else this.emitFile({
+-				type: "asset",
+-				fileName: ssrOutputFilename,
+-				source: generateRemoteEntrySSR(options)
+-			});
+-		},
+-		generateBundle(_options, bundle) {
+-			const exposesChunk = findNuxtExposesChunk(bundle);
+-			const ssrAsset = bundle[ssrOutputFilename];
+-			if (exposesChunk && ssrAsset?.type === "asset" && typeof ssrAsset.source === "string") ssrAsset.source = ssrAsset.source.replace(/import\("virtual:mf-exposes-ssr:[^"]+"\)/g, `import("./${exposesChunk}")`);
+-			if (!isRolldown) return;
+-			const chunk = bundle[ssrOutputFilename];
+-			if (!chunk || chunk.type !== "chunk") return;
+-		}
+-	}];
+-}
+-//#endregion
+ //#region src/plugins/pluginVarRemoteEntry.ts
+ const VarRemoteEntry = () => {
+ 	const mfOptions = getNormalizeModuleFederationOptions();
+@@ -4546,9 +3653,9 @@ const VarRemoteEntry = () => {
+ 		},
+ 		async generateBundle(_options, bundle) {
+ 			if (!varFilename) return;
+-			if (!isValidVarName(name)) require_packageUtils.mfWarn(`Provided remote name "${name}" is not valid for "var" remoteEntry type, thus it's placed in globalThis['${name}'].\nIt may cause problems, so you would better want to use valid var name (see https://www.w3schools.com/js/js_variables.asp).`);
++			if (!isValidVarName(name)) mfWarn(`Provided remote name "${name}" is not valid for "var" remoteEntry type, thus it's placed in globalThis['${name}'].\nIt may cause problems, so you would better want to use valid var name (see https://www.w3schools.com/js/js_variables.asp).`);
+ 			const remoteEntryFile = findRemoteEntryFile(mfOptions.filename, bundle);
+-			if (!remoteEntryFile) throw require_packageUtils.createModuleFederationError(`Couldn't find a remoteEntry chunk file for ${mfOptions.filename}, can't generate varRemoteEntry file`);
++			if (!remoteEntryFile) throw createModuleFederationError(`Couldn't find a remoteEntry chunk file for ${mfOptions.filename}, can't generate varRemoteEntry file`);
+ 			this.emitFile({
+ 				type: "asset",
+ 				fileName: varFilename,
+@@ -4690,32 +3797,17 @@ var normalizeOptimizeDeps_default = {
+ //#endregion
+ //#region src/index.ts
+ const patchedManualChunks = /* @__PURE__ */ new WeakSet();
+-const PRELOAD_HELPER_CHUNK = "vite-preload-helper";
+-const PRELOAD_HELPER_TEST = /\0?vite\/preload-helper/;
+-function normalizeVinextRscPreloadHints(code) {
+-	return code.replace(/(:HL\[[^\]\n]*?,)"stylesheet"/g, "$1\"style\"").replace(/(:HL\[[^\]\n]*?,)\\"stylesheet\\"/g, "$1\\\"style\\\"");
+-}
+-function ignoreFederationGeneratedFiles(config, options) {
+-	config.server ??= {};
+-	config.server.watch ??= {};
+-	const federationIgnore = (file) => shouldIgnoreFile(file, options);
+-	const ignored = config.server.watch.ignored;
+-	if (!ignored) {
+-		config.server.watch.ignored = federationIgnore;
+-		return;
+-	}
+-	if (Array.isArray(ignored)) {
+-		ignored.push(federationIgnore);
+-		return;
+-	}
+-	config.server.watch.ignored = [ignored, federationIgnore];
+-}
++const COMMON_PREFIX_SHARED_PREBUILDS = {
++	"react/": ["react/jsx-runtime", "react/jsx-dev-runtime"],
++	"react-dom/": [
++		"react-dom/client",
++		"react-dom/server",
++		"react-dom/server.browser"
++	]
++};
+ function isSharedResolverInternalImporter(importer) {
+ 	return !!importer && (importer.includes("__loadShare__") || importer.includes("__prebuild__"));
+ }
+-function isCommonJsImporter(importer) {
+-	return !!importer && (importer.endsWith(".cjs") || importer.includes("/cjs/"));
+-}
+ function isOutputChunk(chunk) {
+ 	return chunk.type === "chunk";
+ }
+@@ -4759,37 +3851,26 @@ function isFederationHtmlPreloadDependency(dep, includeSharedRuntime = false) {
+ 	if (file.includes("__mfe_internal__") || file.includes("virtual_mf-") || file.includes("virtualExposes") || file.includes("localSharedImportMap") || file.includes("hostInit")) return true;
+ 	return includeSharedRuntime && (file.includes("preload-helper") || file.includes("rolldown-runtime") || file.startsWith("dist-"));
+ }
+-function canResolveSharedSubpath(subpath, projectRoot) {
+-	try {
+-		(0, module$1.createRequire)(new URL(`file://${projectRoot}/package.json`)).resolve(subpath);
+-		return true;
+-	} catch {
+-		return false;
+-	}
+-}
+ /**
+-* Plugin that runs FIRST to register generated virtual modules in the config hook.
+-* This prevents 504 "Outdated Optimize Dep" errors by ensuring ids are known
++* Plugin that runs FIRST to create virtual module files in the config hook.
++* This prevents 504 "Outdated Optimize Dep" errors by ensuring files exist
+ * before Vite's optimization phase.
+ */
+ function createEarlyVirtualModulesPlugin(options) {
+-	const { shared, remotes } = options;
++	const { shared, remotes, virtualModuleDir } = options;
+ 	const isLitShare = (pkg) => pkg === "lit" || pkg.startsWith("lit/");
+ 	return {
+ 		name: "vite:module-federation-early-init",
+ 		enforce: "pre",
+ 		config(config, { command: _command }) {
+-			if (_command === "serve") ignoreFederationGeneratedFiles(config, options);
+ 			const root = config.root || process.cwd();
+-			require_packageUtils.setPackageDetectionCwd(root);
+-			const isVinext = require_packageUtils.hasPackageDependency("vinext");
+-			setSsrRemotes(Object.entries(options.remotes).map(([key, r]) => ({
+-				name: key,
+-				entry: r.entry,
+-				type: r.type ?? "module"
+-			})));
++			setPackageDetectionCwd(root);
++			const isVinext = hasPackageDependency("vinext");
++			initVirtualModuleInfrastructure(root, virtualModuleDir);
++			VirtualModule.setRoot(root);
++			VirtualModule.ensureVirtualPackageExists();
+ 			initVirtualModules(_command, getRemoteEntryId(options));
+-			const isRolldown = require_packageUtils.getIsRolldown(this);
++			const isRolldown = getIsRolldown(this);
+ 			if (remotes && Object.keys(remotes).length > 0) {
+ 				for (const key of Object.keys(remotes)) addUsedRemote(key, key);
+ 				if (_command === "serve") {
+@@ -4809,10 +3890,9 @@ function createEarlyVirtualModulesPlugin(options) {
+ 						optimizeDeps.rolldownOptions.plugins ??= [];
+ 						optimizeDeps.rolldownOptions.plugins.push({
+ 							name: "module-federation:optimize-shared-resolver",
+-							resolveId(source, importer, options) {
+-								if (options?.kind?.startsWith("require")) return;
++							resolveId(source, importer) {
+ 								if (isSharedResolverInternalImporter(importer)) return;
+-								if (isCommonJsImporter(importer)) return;
++								if (source !== "react/jsx-runtime" && source !== "react/jsx-dev-runtime") return;
+ 								const key = findSharedKey(source, shared);
+ 								if (!key) return;
+ 								if (source.endsWith(".css")) return;
+@@ -4833,10 +3913,6 @@ function createEarlyVirtualModulesPlugin(options) {
+ 						optimizeDeps.esbuildOptions.plugins.push({
+ 							name: "module-federation:optimize-shared-proxy",
+ 							setup(build) {
+-								build.onResolve({ filter: createViteEncodedIdPrefixRegExp("virtual:mf:") }, (args) => ({
+-									path: args.path,
+-									external: true
+-								}));
+ 								build.onResolve({ filter: /.*/ }, (args) => {
+ 									if (!args.importer || args.namespace === "mf-shared") return;
+ 									if (isSharedResolverInternalImporter(args.importer)) return;
+@@ -4853,21 +3929,22 @@ function createEarlyVirtualModulesPlugin(options) {
+ 									const key = findSharedKey(args.path, shared);
+ 									if (!key) return;
+ 									const shareItem = shared[key];
+-									const optimizedLoadSharePath = toViteOptimizedDepVirtualId(getLoadShareModulePath(args.path, isRolldown));
++									const loadSharePath = getLoadShareModulePath(args.path, isRolldown);
+ 									writeLoadShareModule(args.path, shareItem, _command, isRolldown);
+ 									if (shareItem.shareConfig?.import !== false) writePreBuildLibPath(args.path, shareItem);
+ 									addUsedShares(args.path);
+ 									return {
+ 										loader: "js",
+ 										resolveDir: root,
+-										contents: `import * as __mfShared from ${JSON.stringify(optimizedLoadSharePath)};
+-export * from ${JSON.stringify(optimizedLoadSharePath)};
++										contents: `import * as __mfShared from ${JSON.stringify(loadSharePath)};
++export * from ${JSON.stringify(loadSharePath)};
+ export default __mfShared.default ?? __mfShared;`
+ 									};
+ 								});
+ 							}
+ 						});
+ 					}
++					config.optimizeDeps.include.push(virtualRuntimeInitStatus.getImportId());
+ 				}
+ 				for (const key of Object.keys(shared)) {
+ 					const shareItem = shared[key];
+@@ -4875,11 +3952,10 @@ export default __mfShared.default ?? __mfShared;`
+ 						if (_command === "serve" && shareItem.shareConfig?.import !== false) {
+ 							const optimizeDeps = config.optimizeDeps ??= {};
+ 							optimizeDeps.include ??= [];
+-							optimizeDeps.exclude ??= [];
+-							for (const subpath of getCommonSharedSubpaths(key)) {
++							for (const subpath of COMMON_PREFIX_SHARED_PREBUILDS[key] || []) {
+ 								writePreBuildLibPath(subpath, shareItem);
+-								if (canResolveSharedSubpath(subpath, root)) optimizeDeps.include.push(subpath);
+-								else optimizeDeps.exclude.push(subpath);
++								optimizeDeps.include.push(subpath);
++								optimizeDeps.include.push(getPreBuildLibImportId(subpath));
+ 							}
+ 						}
+ 						continue;
+@@ -4896,99 +3972,28 @@ export default __mfShared.default ?? __mfShared;`
+ 						const optimizeDeps = config.optimizeDeps ??= {};
+ 						optimizeDeps.include ??= [];
+ 						optimizeDeps.exclude ??= [];
+-						if (isLitShare(key)) optimizeDeps.exclude.push(key);
+-						else optimizeDeps.include.push(key);
+-						for (const subpath of getCommonSharedSubpaths(key)) {
+-							getLoadShareModulePath(subpath, isRolldown);
+-							writeLoadShareModule(subpath, shareItem, _command, isRolldown);
+-							writePreBuildLibPath(subpath, shareItem);
+-							addUsedShares(subpath);
+-							if (canResolveSharedSubpath(subpath, root)) optimizeDeps.include.push(subpath);
+-							else optimizeDeps.exclude.push(subpath);
+-						}
++						const shouldBypassOptimizeDep = isLitShare(key);
++						if (isRolldown || shouldBypassOptimizeDep) optimizeDeps.exclude.push(key);
++						if (!isRolldown && !shouldBypassOptimizeDep) optimizeDeps.include.push(getLoadShareImportId(key, isRolldown));
++						optimizeDeps.include.push(getPreBuildLibImportId(key));
+ 					}
+ 				}
+ 				writeLocalSharedImportMap();
+ 			}
+-		},
+-		configResolved(config) {
+-			if (parseInt(vite.version, 10) < 8) return;
+-			if (!(Object.keys(options.exposes).length > 0 || Object.keys(options.remotes).length > 0)) return;
+-			if (options.runtimePlugins.some((p) => {
+-				return (typeof p === "string" ? p : p[0]) === "@module-federation/vite/ssrEntryLoader";
+-			})) return;
+-			const pluginRequire = (0, module$1.createRequire)(require("url").pathToFileURL(__filename).href);
+-			const projectRequire = (0, module$1.createRequire)(new URL(`file://${config.root}/package.json`));
+-			const sharedKeys = Object.keys(options.shared ?? {});
+-			const commonSharedPkgs = [
+-				"react",
+-				"react-dom",
+-				"react/jsx-runtime",
+-				"react/jsx-dev-runtime",
+-				"react/compiler-runtime",
+-				"@module-federation/runtime",
+-				"@module-federation/runtime-core",
+-				"@module-federation/sdk"
+-			];
+-			const resolvedShared = {};
+-			for (const pkg of [...commonSharedPkgs, ...sharedKeys]) try {
+-				resolvedShared[pkg] = projectRequire.resolve(pkg);
+-			} catch {
+-				try {
+-					resolvedShared[pkg] = pluginRequire.resolve(pkg);
+-				} catch {}
+-			}
+-			const ssrEntryLoaderSpecifier = "@module-federation/vite/ssrEntryLoader";
+-			try {
+-				pluginRequire.resolve(ssrEntryLoaderSpecifier);
+-				options.runtimePlugins.push([ssrEntryLoaderSpecifier, { resolvedShared }]);
+-			} catch {}
+ 		}
+ 	};
+ }
+-const SSR_ONLY_PLUGINS = new Set(["@module-federation/vite/ssrEntryLoader"]);
+-function loadPluginDts(options) {
+-	if (options.dts === false) return [];
+-	return [Promise.resolve().then(() => require("./pluginDts-7EoFboCu.cjs")).then(({ default: pluginDts }) => pluginDts(options))];
+-}
+ function federation(mfUserOptions) {
+ 	if (isTestEnv()) return [];
+ 	const options = normalizeModuleFederationOptions(mfUserOptions);
+-	const isVinext = require_packageUtils.hasPackageDependency("vinext");
++	const isVinext = hasPackageDependency("vinext");
+ 	const { name, shared, filename, hostInitInjectLocation } = options;
+-	if (!name) throw require_packageUtils.createModuleFederationError("name is required");
++	if (!name) throw createModuleFederationError("name is required");
+ 	const remoteEntryId = getRemoteEntryId(options);
+ 	const virtualExposesId = getVirtualExposesId(options);
+ 	let command;
+ 	let desiredRolldownOutput;
+ 	return [
+-		{
+-			name: "vite:module-federation-virtual-modules",
+-			enforce: "pre",
+-			resolveId(id) {
+-				let virtualModule = VirtualModule.findById(id);
+-				if (!virtualModule) {
+-					materializeCachedLoadShareModule({
+-						id,
+-						shared: options.shared,
+-						command,
+-						isRolldown: require_packageUtils.getIsRolldown(this),
+-						findSharedKey,
+-						addUsedShares,
+-						writeLocalSharedImportMap
+-					});
+-					virtualModule = VirtualModule.findById(id);
+-				}
+-				if (!virtualModule) return;
+-				return virtualModule.getResolvedId();
+-			},
+-			load(id) {
+-				const virtualModule = VirtualModule.findById(id);
+-				if (!virtualModule) return;
+-				if (command === "build" && (id.includes("__loadShare__") || id.includes("__loadRemote__"))) return;
+-				return virtualModule.code;
+-			}
+-		},
+ 		createEarlyVirtualModulesPlugin(options),
+ 		...isVinext ? [{
+ 			name: "module-federation-vinext-react-server-build-alias",
+@@ -4997,8 +4002,7 @@ function federation(mfUserOptions) {
+ 			resolveId(id) {
+ 				const reactServerEntryMap = {
+ 					"react/jsx-runtime": "react/cjs/react-jsx-runtime.production.js",
+-					"react/jsx-dev-runtime": "react/cjs/react-jsx-dev-runtime.production.js",
+-					"react/compiler-runtime": "react/cjs/react-compiler-runtime.production.js"
++					"react/jsx-dev-runtime": "react/cjs/react-jsx-dev-runtime.production.js"
+ 				};
+ 				if (!(id in reactServerEntryMap)) return;
+ 				const environmentName = this.environment?.name;
+@@ -5014,27 +4018,17 @@ function federation(mfUserOptions) {
+ 			config(_config, env) {
+ 				command = env.command;
+ 			},
+-			configResolved() {
+-				initVirtualModules(command, remoteEntryId, parseInt(vite.version, 10) >= 8);
++			configResolved(config) {
++				VirtualModule.setRoot(config.root);
++				VirtualModule.ensureVirtualPackageExists();
++				initVirtualModules(command, remoteEntryId);
+ 			}
+ 		},
+ 		aliasToArrayPlugin_default,
+ 		checkAliasConflicts({ shared }),
+ 		normalizeOptimizeDeps_default,
+-		...loadPluginDts(options),
++		...pluginDts(options),
+ 		pluginDevRemoteHmr(options),
+-		{
+-			name: "mf:normalize-entry-chunks",
+-			enforce: "pre",
+-			apply: "build",
+-			generateBundle(_options, bundle) {
+-				for (const chunk of Object.values(bundle)) {
+-					if (typeof chunk !== "object" || chunk === null || chunk.type !== "chunk" || !chunk.isEntry) continue;
+-					const facadeId = chunk.facadeModuleId ?? "";
+-					if (facadeId.includes("__mf__virtual") || facadeId.startsWith("virtual:mf-") || facadeId.startsWith("virtual:mf:") || facadeId.startsWith("\0virtual:mf-") || facadeId.startsWith("\0virtual:mf:")) chunk.isEntry = false;
+-				}
+-			}
+-		},
+ 		...addEntry({
+ 			entryName: "remoteEntry",
+ 			entryPath: remoteEntryId,
+@@ -5044,8 +4038,7 @@ function federation(mfUserOptions) {
+ 			entryName: "hostInit",
+ 			entryPath: () => getHostAutoInitPath(),
+ 			inject: hostInitInjectLocation,
+-			forceClientInjected: Object.keys(options.exposes).length > 0,
+-			skipTransformFor: Object.values(options.exposes).map((expose) => expose.import)
++			forceClientInjected: Object.keys(options.exposes).length > 0
+ 		}),
+ 		...addEntry({
+ 			entryName: "virtualExposes",
+@@ -5082,9 +4075,7 @@ function federation(mfUserOptions) {
+ 							const resolvedDeps = existingResolveDependencies ? existingResolveDependencies(filename, deps, context) : deps;
+ 							const hostFile = pathe.default.basename(context.hostId);
+ 							if (context.hostType === "js" && (hostFile === options.filename || hostFile.includes("hostInit") || hostFile.includes("virtualExposes") || hostFile.includes("localSharedImportMap"))) return [];
+-							const hasFederationHtmlDeps = context.hostType === "html" && resolvedDeps.some((dep) => isFederationHtmlPreloadDependency(dep));
+-							const hasFederationJsDeps = context.hostType === "js" && resolvedDeps.some((dep) => isFederationHtmlPreloadDependency(dep));
+-							return hasFederationHtmlDeps || hasFederationJsDeps ? resolvedDeps.filter((dep) => !isFederationHtmlPreloadDependency(dep, true)) : resolvedDeps;
++							return context.hostType === "html" && resolvedDeps.some((dep) => isFederationHtmlPreloadDependency(dep)) ? resolvedDeps.filter((dep) => !isFederationHtmlPreloadDependency(dep, true)) : resolvedDeps;
+ 						}
+ 					};
+ 				}
+@@ -5095,59 +4086,39 @@ function federation(mfUserOptions) {
+ 						delete output.codeSplitting;
+ 						if (warnedAboutCodeSplitting) return;
+ 						warnedAboutCodeSplitting = true;
+-						require_packageUtils.mfWarn("Ignoring `output.codeSplitting = false` because module federation requires chunk splitting.");
++						mfWarn("Ignoring `output.codeSplitting = false` because module federation requires chunk splitting.");
+ 						return;
+ 					}
+ 					if (!output?.codeSplitting || typeof output.codeSplitting !== "object") return;
+ 					if (!("groups" in output.codeSplitting)) return;
+-					const groups = output.codeSplitting.groups;
+-					if (Array.isArray(groups) && groups.some((group) => typeof group?.name === "function" && patchedManualChunks.has(group.name))) return;
+ 					delete output.codeSplitting.groups;
+ 					if (Object.keys(output.codeSplitting).length === 0) delete output.codeSplitting;
+ 					if (warnedAboutCodeSplittingGroups) return;
+ 					warnedAboutCodeSplittingGroups = true;
+-					require_packageUtils.mfWarn("Ignoring `output.codeSplitting.groups` because it conflicts with module federation. Grouping shared dependency init wrappers with their dependent modules can break runtime init order and cause standalone remotes to fail before mount.");
++					mfWarn("Ignoring `output.codeSplitting.groups` because it conflicts with module federation. Grouping shared dependency init wrappers with their dependent modules can break runtime init order and cause standalone remotes to fail before mount.");
+ 				};
+ 				let warnedAboutManualChunks = false;
+-				const applyManualChunks = (output, useCodeSplitting) => {
++				const applyManualChunks = (output) => {
+ 					ensureCodeSplitting(output);
+ 					const isPatchedByPlugin = typeof output.manualChunks === "function" && patchedManualChunks.has(output.manualChunks);
+ 					if (output.manualChunks && !isPatchedByPlugin && !warnedAboutManualChunks) {
+ 						warnedAboutManualChunks = true;
+-						require_packageUtils.mfWarn("Ignoring `output.manualChunks` because it conflicts with module federation. Module federation transforms shared dependency imports with async init wrappers, and grouping these transformed modules into a single chunk creates circular async dependencies that cause the application to silently hang.");
++						mfWarn("Ignoring `output.manualChunks` because it conflicts with module federation. Module federation transforms shared dependency imports with async init wrappers, and grouping these transformed modules into a single chunk creates circular async dependencies that cause the application to silently hang.");
+ 					}
+-					const mfChunkName = function(id) {
++					const mfManualChunks = function(id) {
+ 						if (id.includes(runtimeInitId)) return "runtimeInit";
+ 						if (id.includes("__loadShare__")) {
+ 							const match = id.match(/([^/\\]+__loadShare__[^/\\]+)/);
+ 							return match ? match[1] : "loadShare";
+ 						}
+-						return null;
+-					};
+-					patchedManualChunks.add(mfChunkName);
+-					if (!useCodeSplitting) {
+-						const mfManualChunks = function(id) {
+-							return mfChunkName(id) ?? void 0;
+-						};
+-						patchedManualChunks.add(mfManualChunks);
+-						output.manualChunks = mfManualChunks;
+-						return;
+-					}
+-					const groups = [{
+-						name: PRELOAD_HELPER_CHUNK,
+-						test: PRELOAD_HELPER_TEST,
+-						priority: 100
+-					}, { name: mfChunkName }];
+-					output.codeSplitting = {
+-						...output.codeSplitting || {},
+-						groups
+ 					};
+-					delete output.manualChunks;
++					patchedManualChunks.add(mfManualChunks);
++					output.manualChunks = mfManualChunks;
+ 				};
+ 				config.build.rollupOptions = config.build.rollupOptions || {};
+ 				const rollupOutput = config.build.rollupOptions.output;
+-				if (Array.isArray(rollupOutput)) rollupOutput.forEach((output) => applyManualChunks(output, false));
+-				else applyManualChunks(config.build.rollupOptions.output ||= {}, false);
++				if (Array.isArray(rollupOutput)) rollupOutput.forEach((output) => applyManualChunks(output));
++				else applyManualChunks(config.build.rollupOptions.output ||= {});
+ 				const buildWithRolldown = config.build;
+ 				buildWithRolldown.rolldownOptions = buildWithRolldown.rolldownOptions || {};
+ 				const rolldownOutput = buildWithRolldown.rolldownOptions.output;
+@@ -5157,10 +4128,10 @@ function federation(mfUserOptions) {
+ 					assetFileNames: output.assetFileNames
+ 				});
+ 				if (Array.isArray(rolldownOutput)) {
+-					rolldownOutput.forEach((output) => applyManualChunks(output, true));
++					rolldownOutput.forEach((output) => applyManualChunks(output));
+ 					desiredRolldownOutput = rolldownOutput.map((output) => snapshotRolldownOutput(output));
+ 				} else {
+-					applyManualChunks(buildWithRolldown.rolldownOptions.output ||= {}, true);
++					applyManualChunks(buildWithRolldown.rolldownOptions.output ||= {});
+ 					desiredRolldownOutput = [snapshotRolldownOutput(buildWithRolldown.rolldownOptions.output)];
+ 				}
+ 			},
+@@ -5190,8 +4161,9 @@ function federation(mfUserOptions) {
+ 				}
+ 			},
+ 			load(id) {
++				if (id.startsWith("\0")) return;
+ 				if (id.includes("__loadShare__") || id.includes("__loadRemote__")) {
+-					let code = VirtualModule.findById(id)?.code ?? (0, fs.readFileSync)(id, "utf-8");
++					let code = (0, fs.readFileSync)(id, "utf-8");
+ 					code = code.replace(/import\s+["'][^"']*__prebuild__[^"']*["']\s*;?/g, "");
+ 					code = code.replace(/export\s+\*\s+from\s+["'][^"']*__prebuild__[^"']*["']\s*;?/g, "");
+ 					/**
+@@ -5210,11 +4182,8 @@ function federation(mfUserOptions) {
+ 					*
+ 					* @see https://rollupjs.org/plugin-development/#synthetic-named-exports
+ 					*/
+-					if (!/\bexport\s+const\s+__moduleExports\b/.test(code) && !/\bexport\s*\{[^}]*__moduleExports/.test(code)) {
+-						const nextCode = code.replace("export default exportModule", "export const __moduleExports = exportModule;\nexport default exportModule.__esModule ? exportModule.default : exportModule");
+-						code = nextCode === code ? `${code}\nexport const __moduleExports = exportModule;\n` : nextCode;
+-					}
+-					if (require_packageUtils.getIsRolldown(this)) return { code };
++					if (!code.includes("__moduleExports")) code = code.replace("export default exportModule", "export const __moduleExports = exportModule;\nexport default exportModule.__esModule ? exportModule.default : exportModule");
++					if (getIsRolldown(this)) return { code };
+ 					return {
+ 						code,
+ 						syntheticNamedExports: "__moduleExports"
+@@ -5227,17 +4196,87 @@ function federation(mfUserOptions) {
+ 					if (!isFederationControlChunk(fileName, filename)) continue;
+ 					chunk.code = sanitizeFederationControlChunk(chunk.code, fileName, filename);
+ 				}
+-				const proxyChunks = collectLoadShareProxyChunks(bundle, LOAD_SHARE_TAG);
+-				if (proxyChunks.size > 0) {
+-					const systemProxyInfo = collectSystemProxyInfos(proxyChunks, LOAD_SHARE_TAG);
+-					for (const [fileName, chunk] of Object.entries(bundle)) {
+-						if (!isOutputChunk(chunk)) continue;
+-						if (proxyChunks.has(fileName)) continue;
+-						let code = chunk.code;
+-						if (!fileName.includes("__loadShare__")) code = rewriteEsmProxyConsumers(code, proxyChunks);
+-						code = rewriteSystemProxyConsumers(code, systemProxyInfo);
+-						if (code !== chunk.code) chunk.code = code;
++				const proxyChunks = /* @__PURE__ */ new Map();
++				for (const [fileName, chunk] of Object.entries(bundle)) {
++					if (!isOutputChunk(chunk)) continue;
++					if (fileName.includes("__loadShare__") && fileName.includes("commonjs-proxy")) proxyChunks.set(fileName, {
++						code: chunk.code,
++						fileName
++					});
++				}
++				if (proxyChunks.size > 0) for (const [fileName, chunk] of Object.entries(bundle)) {
++					if (!isOutputChunk(chunk)) continue;
++					if (fileName.includes("__loadShare__")) continue;
++					let code = chunk.code;
++					let modified = false;
++					const claimedLocals = /* @__PURE__ */ new Set();
++					for (const [proxyFileName, proxyInfo] of Array.from(proxyChunks.entries())) {
++						const proxyBaseName = proxyFileName.replace(/^.*\//, "").replace(/\.js$/, "").replace(/-[A-Za-z0-9_-]+$/, "");
++						const importMatch = new RegExp(`import\\s*\\{([^}]+)\\}\\s*from\\s*["']([^"']*${proxyBaseName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[^"']*)["']\\s*;?`).exec(code);
++						if (!importMatch) continue;
++						const fullImport = importMatch[0];
++						const bindings = importMatch[1].split(",").map((s) => {
++							const parts = s.trim().split(/\s+as\s+/);
++							return {
++								imported: parts[0].trim(),
++								local: (parts[1] || parts[0]).trim()
++							};
++						});
++						const proxyCode = proxyInfo.code;
++						const exportMapMatch = proxyCode.match(/export\s*\{([^}]+)\}/);
++						if (!exportMapMatch) continue;
++						const exportMap = {};
++						for (const entry of exportMapMatch[1].split(",")) {
++							const parts = entry.trim().split(/\s+as\s+/);
++							if (parts.length === 2) exportMap[parts[1].trim()] = parts[0].trim();
++						}
++						const inlineable = [];
++						const nonInlineable = [];
++						const pendingLocals = new Set(bindings.map((binding) => binding.local));
++						for (const b of bindings) {
++							pendingLocals.delete(b.local);
++							const proxyLocal = exportMap[b.imported];
++							if (!proxyLocal) {
++								claimedLocals.add(b.local);
++								nonInlineable.push(b);
++								continue;
++							}
++							const funcRe = new RegExp(`function\\s+${proxyLocal}\\s*\\([^)]*\\)\\s*\\{`);
++							if (funcRe.test(proxyCode)) {
++								const funcStart = proxyCode.search(funcRe);
++								let depth = 0;
++								let funcEnd = funcStart;
++								for (let i = proxyCode.indexOf("{", funcStart); i < proxyCode.length; i++) if (proxyCode[i] === "{") depth++;
++								else if (proxyCode[i] === "}") {
++									depth--;
++									if (depth === 0) {
++										funcEnd = i + 1;
++										break;
++									}
++								}
++								const renamedFunc = proxyCode.slice(funcStart, funcEnd).replace(new RegExp(`function\\s+${proxyLocal}\\s*\\(`), `function ${b.local}(`);
++								inlineable.push({
++									local: b.local,
++									funcBody: renamedFunc
++								});
++								claimedLocals.add(b.local);
++							} else {
++								const unavailableLocals = new Set(claimedLocals);
++								pendingLocals.forEach((local) => unavailableLocals.add(local));
++								const resolvedBinding = resolveProxyAlias(b, proxyLocal, code, fullImport, unavailableLocals);
++								claimedLocals.add(resolvedBinding.local);
++								nonInlineable.push(resolvedBinding);
++							}
++						}
++						const hasRenamedAlias = nonInlineable.some((b) => bindings.find((ob) => ob.imported === b.imported)?.local !== b.local);
++						if (inlineable.length === 0 && !hasRenamedAlias) continue;
++						let replacement = "";
++						if (nonInlineable.length > 0) replacement = `import{${nonInlineable.map((b) => b.imported === b.local ? b.imported : `${b.imported} as ${b.local}`).join(",")}}from"${importMatch[2]}";`;
++						replacement += inlineable.map((f) => f.funcBody).join("");
++						code = code.replace(fullImport, () => replacement);
++						modified = true;
+ 					}
++					if (modified) chunk.code = code;
+ 				}
+ 			}
+ 		},
+@@ -5268,64 +4307,48 @@ function federation(mfUserOptions) {
+ 			enforce: "post",
+ 			_options: options,
+ 			config(config, { command: _command }) {
+-				const isRolldown = require_packageUtils.getIsRolldown(this);
++				const isRolldown = getIsRolldown(this);
+ 				let implementation = options.implementation;
+ 				if (isRolldown) implementation = implementation.replace(/\.cjs(\.js)?$/, ".js");
+ 				appendResolveAlias(config, {
+ 					find: "@module-federation/runtime",
+ 					replacement: implementation
+ 				});
+-				config.build ||= {};
+-				config.build.commonjsOptions ||= {};
+-				config.build.commonjsOptions.strictRequires ??= "auto";
++				config.build = (0, defu.default)(config.build || {}, { commonjsOptions: { strictRequires: "auto" } });
++				const virtualDir = options.virtualModuleDir;
+ 				config.optimizeDeps ||= {};
+ 				config.optimizeDeps.include ||= [];
+ 				config.optimizeDeps.include.push("@module-federation/runtime");
++				config.optimizeDeps.include.push(virtualDir);
++				config.ssr ||= {};
++				config.ssr.noExternal ||= [];
++				if (Array.isArray(config.ssr.noExternal)) config.ssr.noExternal.push(virtualDir);
+ 				options.runtimePlugins.forEach((p) => {
+ 					const pluginPath = typeof p === "string" ? p : p[0];
+-					if (SSR_ONLY_PLUGINS.has(pluginPath)) return;
+ 					if (pluginPath && !pluginPath.startsWith(".") && !pluginPath.startsWith("/") && !pluginPath.startsWith("\0") && !pluginPath.startsWith("virtual:")) config.optimizeDeps.include.push(pluginPath);
+ 				});
+-				if (isRolldown) {
+-					config.build ??= {};
+-					config.build.target ??= "esnext";
++				if (isRolldown) config.build = (0, defu.default)(config.build || {}, { target: "esnext" });
++				else {
++					config.optimizeDeps.needsInterop ||= [];
++					config.optimizeDeps.needsInterop.push(virtualDir);
++					config.optimizeDeps.needsInterop.push(getLocalSharedImportMapPath());
+ 				}
+-				const isAstro = require_packageUtils.hasPackageDependency("astro");
++				const isAstro = hasPackageDependency("astro");
+ 				const resolvedTarget = options.target ?? (config.build?.ssr ? "node" : "web");
+ 				const envTargetDefineValue = !options.target && isAstro ? "undefined" : JSON.stringify(resolvedTarget);
+ 				if (!config.define) config.define = {};
+ 				if (!("ENV_TARGET" in config.define)) config.define["ENV_TARGET"] = envTargetDefineValue;
+-				if (options.target && "ENV_TARGET" in config.define && config.define["ENV_TARGET"] !== JSON.stringify(options.target)) require_packageUtils.mfWarn(`ENV_TARGET define (${config.define["ENV_TARGET"]}) differs from target option ("${options.target}"). ENV_TARGET will not be overridden.`);
++				if (options.target && "ENV_TARGET" in config.define && config.define["ENV_TARGET"] !== JSON.stringify(options.target)) mfWarn(`ENV_TARGET define (${config.define["ENV_TARGET"]}) differs from target option ("${options.target}"). ENV_TARGET will not be overridden.`);
+ 			}
+ 		},
+ 		...Manifest(),
+-		...pluginSSRRemoteEntry(options),
+ 		...VarRemoteEntry(),
+ 		{
+ 			name: "module-federation-vinext-fix-rsc-preload-as",
+ 			enforce: "post",
+-			configureServer(server) {
+-				if (!require_packageUtils.hasPackageDependency("vinext")) return;
+-				server.middlewares.use((req, res, next) => {
+-					if (!req.headers.accept?.includes("text/html")) {
+-						next();
+-						return;
+-					}
+-					const chunks = [];
+-					const end = res.end.bind(res);
+-					res.write = (chunk) => {
+-						if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+-						return true;
+-					};
+-					res.end = (chunk, ...args) => {
+-						if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+-						return end(normalizeVinextRscPreloadHints(Buffer.concat(chunks).toString()), ...args);
+-					};
+-					next();
+-				});
+-			},
++			apply: "build",
+ 			generateBundle(_, bundle, _isWrite) {
+-				if (!require_packageUtils.hasPackageDependency("vinext")) return;
++				if (!hasPackageDependency("vinext")) return;
+ 				for (const chunk of Object.values(bundle)) {
+ 					if (!isOutputChunk(chunk)) continue;
+ 					if (!chunk.code.includes("case\"L\"")) continue;
+@@ -5373,9 +4396,5 @@ function federation(mfUserOptions) {
+ 		})()
+ 	];
+ }
+-function createModuleFederationConfig(options) {
+-	return options;
+-}
+ //#endregion
+-exports.createModuleFederationConfig = createModuleFederationConfig;
+ exports.federation = federation;
+diff --git a/lib/index.d.cts b/lib/index.d.cts
+index f71bbb0554f885304db78eee948797cb4682e5e9..37617bba0b48166be6e3967c07f8dc5d99f0d28d 100644
+--- a/lib/index.d.cts
++++ b/lib/index.d.cts
+@@ -1,7 +1,1898 @@
+-import { ShareStrategy } from "@module-federation/runtime/types";
++import * as vite from "vite";
++import { ConfigEnv, Plugin, ResolvedConfig, UserConfig } from "vite";
++import { ShareStrategy, SharedConfig } from "@module-federation/runtime/types";
+ import { moduleFederationPlugin } from "@module-federation/sdk";
+ 
++//#region node_modules/.pnpm/rolldown@1.0.0-rc.7_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0/node_modules/rolldown/dist/shared/logging-C6h4g8dA.d.mts
++interface RolldownLog {
++  binding?: string;
++  cause?: unknown;
++  /**
++  * The log code for this log object.
++  * @example 'PLUGIN_ERROR'
++  */
++  code?: string;
++  exporter?: string;
++  frame?: string;
++  hook?: string;
++  id?: string;
++  ids?: string[];
++  loc?: {
++    column: number;
++    file?: string;
++    line: number;
++  };
++  /**
++  * The message for this log object.
++  * @example 'The "transform" hook used by the output plugin "rolldown-plugin-foo" is a build time hook and will not be run for that plugin. Either this plugin cannot be used as an output plugin, or it should have an option to configure it as an output plugin.'
++  */
++  message: string;
++  meta?: any;
++  names?: string[];
++  plugin?: string;
++  pluginCode?: unknown;
++  pos?: number;
++  reexporter?: string;
++  stack?: string;
++  url?: string;
++}
++/** @inline */
++/** @category Plugin APIs */
++interface RolldownError extends RolldownLog {
++  name?: string;
++  stack?: string;
++  watchFiles?: string[];
++}
++//#endregion
++//#region node_modules/.pnpm/@oxc-project+types@0.115.0/node_modules/@oxc-project/types/types.d.ts
++// Auto-generated code, DO NOT EDIT DIRECTLY!
++// To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`.
++interface Program extends Span {
++  type: "Program";
++  body: Array<Directive | Statement>;
++  sourceType: ModuleKind;
++  hashbang: Hashbang | null;
++  parent?: null;
++}
++type Expression = BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | V8IntrinsicExpression | MemberExpression;
++interface IdentifierName extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface IdentifierReference extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface BindingIdentifier extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface LabelIdentifier extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface ThisExpression extends Span {
++  type: "ThisExpression";
++  parent?: Node;
++}
++interface ArrayExpression extends Span {
++  type: "ArrayExpression";
++  elements: Array<ArrayExpressionElement>;
++  parent?: Node;
++}
++type ArrayExpressionElement = SpreadElement | null | Expression;
++interface ObjectExpression extends Span {
++  type: "ObjectExpression";
++  properties: Array<ObjectPropertyKind>;
++  parent?: Node;
++}
++type ObjectPropertyKind = ObjectProperty | SpreadElement;
++interface ObjectProperty extends Span {
++  type: "Property";
++  kind: PropertyKind;
++  key: PropertyKey;
++  value: Expression;
++  method: boolean;
++  shorthand: boolean;
++  computed: boolean;
++  optional?: false;
++  parent?: Node;
++}
++type PropertyKey = IdentifierName | PrivateIdentifier | Expression;
++type PropertyKind = "init" | "get" | "set";
++interface TemplateLiteral extends Span {
++  type: "TemplateLiteral";
++  quasis: Array<TemplateElement>;
++  expressions: Array<Expression>;
++  parent?: Node;
++}
++interface TaggedTemplateExpression extends Span {
++  type: "TaggedTemplateExpression";
++  tag: Expression;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  quasi: TemplateLiteral;
++  parent?: Node;
++}
++interface TemplateElement extends Span {
++  type: "TemplateElement";
++  value: TemplateElementValue;
++  tail: boolean;
++  parent?: Node;
++}
++interface TemplateElementValue {
++  raw: string;
++  cooked: string | null;
++}
++type MemberExpression = ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;
++interface ComputedMemberExpression extends Span {
++  type: "MemberExpression";
++  object: Expression;
++  property: Expression;
++  optional: boolean;
++  computed: true;
++  parent?: Node;
++}
++interface StaticMemberExpression extends Span {
++  type: "MemberExpression";
++  object: Expression;
++  property: IdentifierName;
++  optional: boolean;
++  computed: false;
++  parent?: Node;
++}
++interface PrivateFieldExpression extends Span {
++  type: "MemberExpression";
++  object: Expression;
++  property: PrivateIdentifier;
++  optional: boolean;
++  computed: false;
++  parent?: Node;
++}
++interface CallExpression extends Span {
++  type: "CallExpression";
++  callee: Expression;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  arguments: Array<Argument>;
++  optional: boolean;
++  parent?: Node;
++}
++interface NewExpression extends Span {
++  type: "NewExpression";
++  callee: Expression;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  arguments: Array<Argument>;
++  parent?: Node;
++}
++interface MetaProperty extends Span {
++  type: "MetaProperty";
++  meta: IdentifierName;
++  property: IdentifierName;
++  parent?: Node;
++}
++interface SpreadElement extends Span {
++  type: "SpreadElement";
++  argument: Expression;
++  parent?: Node;
++}
++type Argument = SpreadElement | Expression;
++interface UpdateExpression extends Span {
++  type: "UpdateExpression";
++  operator: UpdateOperator;
++  prefix: boolean;
++  argument: SimpleAssignmentTarget;
++  parent?: Node;
++}
++interface UnaryExpression extends Span {
++  type: "UnaryExpression";
++  operator: UnaryOperator;
++  argument: Expression;
++  prefix: true;
++  parent?: Node;
++}
++interface BinaryExpression extends Span {
++  type: "BinaryExpression";
++  left: Expression;
++  operator: BinaryOperator;
++  right: Expression;
++  parent?: Node;
++}
++interface PrivateInExpression extends Span {
++  type: "BinaryExpression";
++  left: PrivateIdentifier;
++  operator: "in";
++  right: Expression;
++  parent?: Node;
++}
++interface LogicalExpression extends Span {
++  type: "LogicalExpression";
++  left: Expression;
++  operator: LogicalOperator;
++  right: Expression;
++  parent?: Node;
++}
++interface ConditionalExpression extends Span {
++  type: "ConditionalExpression";
++  test: Expression;
++  consequent: Expression;
++  alternate: Expression;
++  parent?: Node;
++}
++interface AssignmentExpression extends Span {
++  type: "AssignmentExpression";
++  operator: AssignmentOperator;
++  left: AssignmentTarget;
++  right: Expression;
++  parent?: Node;
++}
++type AssignmentTarget = SimpleAssignmentTarget | AssignmentTargetPattern;
++type SimpleAssignmentTarget = IdentifierReference | TSAsExpression | TSSatisfiesExpression | TSNonNullExpression | TSTypeAssertion | MemberExpression;
++type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTarget;
++interface ArrayAssignmentTarget extends Span {
++  type: "ArrayPattern";
++  decorators?: [];
++  elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface ObjectAssignmentTarget extends Span {
++  type: "ObjectPattern";
++  decorators?: [];
++  properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface AssignmentTargetRest extends Span {
++  type: "RestElement";
++  decorators?: [];
++  argument: AssignmentTarget;
++  optional?: false;
++  typeAnnotation?: null;
++  value?: null;
++  parent?: Node;
++}
++type AssignmentTargetMaybeDefault = AssignmentTargetWithDefault | AssignmentTarget;
++interface AssignmentTargetWithDefault extends Span {
++  type: "AssignmentPattern";
++  decorators?: [];
++  left: AssignmentTarget;
++  right: Expression;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty;
++interface AssignmentTargetPropertyIdentifier extends Span {
++  type: "Property";
++  kind: "init";
++  key: IdentifierReference;
++  value: IdentifierReference | AssignmentTargetWithDefault;
++  method: false;
++  shorthand: true;
++  computed: false;
++  optional?: false;
++  parent?: Node;
++}
++interface AssignmentTargetPropertyProperty extends Span {
++  type: "Property";
++  kind: "init";
++  key: PropertyKey;
++  value: AssignmentTargetMaybeDefault;
++  method: false;
++  shorthand: false;
++  computed: boolean;
++  optional?: false;
++  parent?: Node;
++}
++interface SequenceExpression extends Span {
++  type: "SequenceExpression";
++  expressions: Array<Expression>;
++  parent?: Node;
++}
++interface Super extends Span {
++  type: "Super";
++  parent?: Node;
++}
++interface AwaitExpression extends Span {
++  type: "AwaitExpression";
++  argument: Expression;
++  parent?: Node;
++}
++interface ChainExpression extends Span {
++  type: "ChainExpression";
++  expression: ChainElement;
++  parent?: Node;
++}
++type ChainElement = CallExpression | TSNonNullExpression | MemberExpression;
++interface ParenthesizedExpression extends Span {
++  type: "ParenthesizedExpression";
++  expression: Expression;
++  parent?: Node;
++}
++type Statement = BlockStatement | BreakStatement | ContinueStatement | DebuggerStatement | DoWhileStatement | EmptyStatement | ExpressionStatement | ForInStatement | ForOfStatement | ForStatement | IfStatement | LabeledStatement | ReturnStatement | SwitchStatement | ThrowStatement | TryStatement | WhileStatement | WithStatement | Declaration | ModuleDeclaration;
++interface Directive extends Span {
++  type: "ExpressionStatement";
++  expression: StringLiteral;
++  directive: string;
++  parent?: Node;
++}
++interface Hashbang extends Span {
++  type: "Hashbang";
++  value: string;
++  parent?: Node;
++}
++interface BlockStatement extends Span {
++  type: "BlockStatement";
++  body: Array<Statement>;
++  parent?: Node;
++}
++type Declaration = VariableDeclaration | Function | Class | TSTypeAliasDeclaration | TSInterfaceDeclaration | TSEnumDeclaration | TSModuleDeclaration | TSGlobalDeclaration | TSImportEqualsDeclaration;
++interface VariableDeclaration extends Span {
++  type: "VariableDeclaration";
++  kind: VariableDeclarationKind;
++  declarations: Array<VariableDeclarator>;
++  declare?: boolean;
++  parent?: Node;
++}
++type VariableDeclarationKind = "var" | "let" | "const" | "using" | "await using";
++interface VariableDeclarator extends Span {
++  type: "VariableDeclarator";
++  id: BindingPattern;
++  init: Expression | null;
++  definite?: boolean;
++  parent?: Node;
++}
++interface EmptyStatement extends Span {
++  type: "EmptyStatement";
++  parent?: Node;
++}
++interface ExpressionStatement extends Span {
++  type: "ExpressionStatement";
++  expression: Expression;
++  directive?: string | null;
++  parent?: Node;
++}
++interface IfStatement extends Span {
++  type: "IfStatement";
++  test: Expression;
++  consequent: Statement;
++  alternate: Statement | null;
++  parent?: Node;
++}
++interface DoWhileStatement extends Span {
++  type: "DoWhileStatement";
++  body: Statement;
++  test: Expression;
++  parent?: Node;
++}
++interface WhileStatement extends Span {
++  type: "WhileStatement";
++  test: Expression;
++  body: Statement;
++  parent?: Node;
++}
++interface ForStatement extends Span {
++  type: "ForStatement";
++  init: ForStatementInit | null;
++  test: Expression | null;
++  update: Expression | null;
++  body: Statement;
++  parent?: Node;
++}
++type ForStatementInit = VariableDeclaration | Expression;
++interface ForInStatement extends Span {
++  type: "ForInStatement";
++  left: ForStatementLeft;
++  right: Expression;
++  body: Statement;
++  parent?: Node;
++}
++type ForStatementLeft = VariableDeclaration | AssignmentTarget;
++interface ForOfStatement extends Span {
++  type: "ForOfStatement";
++  await: boolean;
++  left: ForStatementLeft;
++  right: Expression;
++  body: Statement;
++  parent?: Node;
++}
++interface ContinueStatement extends Span {
++  type: "ContinueStatement";
++  label: LabelIdentifier | null;
++  parent?: Node;
++}
++interface BreakStatement extends Span {
++  type: "BreakStatement";
++  label: LabelIdentifier | null;
++  parent?: Node;
++}
++interface ReturnStatement extends Span {
++  type: "ReturnStatement";
++  argument: Expression | null;
++  parent?: Node;
++}
++interface WithStatement extends Span {
++  type: "WithStatement";
++  object: Expression;
++  body: Statement;
++  parent?: Node;
++}
++interface SwitchStatement extends Span {
++  type: "SwitchStatement";
++  discriminant: Expression;
++  cases: Array<SwitchCase>;
++  parent?: Node;
++}
++interface SwitchCase extends Span {
++  type: "SwitchCase";
++  test: Expression | null;
++  consequent: Array<Statement>;
++  parent?: Node;
++}
++interface LabeledStatement extends Span {
++  type: "LabeledStatement";
++  label: LabelIdentifier;
++  body: Statement;
++  parent?: Node;
++}
++interface ThrowStatement extends Span {
++  type: "ThrowStatement";
++  argument: Expression;
++  parent?: Node;
++}
++interface TryStatement extends Span {
++  type: "TryStatement";
++  block: BlockStatement;
++  handler: CatchClause | null;
++  finalizer: BlockStatement | null;
++  parent?: Node;
++}
++interface CatchClause extends Span {
++  type: "CatchClause";
++  param: BindingPattern | null;
++  body: BlockStatement;
++  parent?: Node;
++}
++interface DebuggerStatement extends Span {
++  type: "DebuggerStatement";
++  parent?: Node;
++}
++type BindingPattern = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
++interface AssignmentPattern extends Span {
++  type: "AssignmentPattern";
++  decorators?: [];
++  left: BindingPattern;
++  right: Expression;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface ObjectPattern extends Span {
++  type: "ObjectPattern";
++  decorators?: [];
++  properties: Array<BindingProperty | BindingRestElement>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface BindingProperty extends Span {
++  type: "Property";
++  kind: "init";
++  key: PropertyKey;
++  value: BindingPattern;
++  method: false;
++  shorthand: boolean;
++  computed: boolean;
++  optional?: false;
++  parent?: Node;
++}
++interface ArrayPattern extends Span {
++  type: "ArrayPattern";
++  decorators?: [];
++  elements: Array<BindingPattern | BindingRestElement | null>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface BindingRestElement extends Span {
++  type: "RestElement";
++  decorators?: [];
++  argument: BindingPattern;
++  optional?: false;
++  typeAnnotation?: null;
++  value?: null;
++  parent?: Node;
++}
++interface Function extends Span {
++  type: FunctionType;
++  id: BindingIdentifier | null;
++  generator: boolean;
++  async: boolean;
++  declare?: boolean;
++  typeParameters?: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType?: TSTypeAnnotation | null;
++  body: FunctionBody | null;
++  expression: false;
++  parent?: Node;
++}
++type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest;
++type FunctionType = "FunctionDeclaration" | "FunctionExpression" | "TSDeclareFunction" | "TSEmptyBodyFunctionExpression";
++interface FormalParameterRest extends Span {
++  type: "RestElement";
++  argument: BindingPattern;
++  decorators?: [];
++  optional?: boolean;
++  typeAnnotation?: TSTypeAnnotation | null;
++  value?: null;
++  parent?: Node;
++}
++type FormalParameter = {
++  decorators?: Array<Decorator>;
++} & BindingPattern;
++interface TSParameterProperty extends Span {
++  type: "TSParameterProperty";
++  accessibility: TSAccessibility | null;
++  decorators: Array<Decorator>;
++  override: boolean;
++  parameter: FormalParameter;
++  readonly: boolean;
++  static: boolean;
++  parent?: Node;
++}
++interface FunctionBody extends Span {
++  type: "BlockStatement";
++  body: Array<Directive | Statement>;
++  parent?: Node;
++}
++interface ArrowFunctionExpression extends Span {
++  type: "ArrowFunctionExpression";
++  expression: boolean;
++  async: boolean;
++  typeParameters?: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType?: TSTypeAnnotation | null;
++  body: FunctionBody | Expression;
++  id: null;
++  generator: false;
++  parent?: Node;
++}
++interface YieldExpression extends Span {
++  type: "YieldExpression";
++  delegate: boolean;
++  argument: Expression | null;
++  parent?: Node;
++}
++interface Class extends Span {
++  type: ClassType;
++  decorators: Array<Decorator>;
++  id: BindingIdentifier | null;
++  typeParameters?: TSTypeParameterDeclaration | null;
++  superClass: Expression | null;
++  superTypeArguments?: TSTypeParameterInstantiation | null;
++  implements?: Array<TSClassImplements>;
++  body: ClassBody;
++  abstract?: boolean;
++  declare?: boolean;
++  parent?: Node;
++}
++type ClassType = "ClassDeclaration" | "ClassExpression";
++interface ClassBody extends Span {
++  type: "ClassBody";
++  body: Array<ClassElement>;
++  parent?: Node;
++}
++type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition | AccessorProperty | TSIndexSignature;
++interface MethodDefinition extends Span {
++  type: MethodDefinitionType;
++  decorators: Array<Decorator>;
++  key: PropertyKey;
++  value: Function;
++  kind: MethodDefinitionKind;
++  computed: boolean;
++  static: boolean;
++  override?: boolean;
++  optional?: boolean;
++  accessibility?: TSAccessibility | null;
++  parent?: Node;
++}
++type MethodDefinitionType = "MethodDefinition" | "TSAbstractMethodDefinition";
++interface PropertyDefinition extends Span {
++  type: PropertyDefinitionType;
++  decorators: Array<Decorator>;
++  key: PropertyKey;
++  typeAnnotation?: TSTypeAnnotation | null;
++  value: Expression | null;
++  computed: boolean;
++  static: boolean;
++  declare?: boolean;
++  override?: boolean;
++  optional?: boolean;
++  definite?: boolean;
++  readonly?: boolean;
++  accessibility?: TSAccessibility | null;
++  parent?: Node;
++}
++type PropertyDefinitionType = "PropertyDefinition" | "TSAbstractPropertyDefinition";
++type MethodDefinitionKind = "constructor" | "method" | "get" | "set";
++interface PrivateIdentifier extends Span {
++  type: "PrivateIdentifier";
++  name: string;
++  parent?: Node;
++}
++interface StaticBlock extends Span {
++  type: "StaticBlock";
++  body: Array<Statement>;
++  parent?: Node;
++}
++type ModuleDeclaration = ImportDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | TSExportAssignment | TSNamespaceExportDeclaration;
++type AccessorPropertyType = "AccessorProperty" | "TSAbstractAccessorProperty";
++interface AccessorProperty extends Span {
++  type: AccessorPropertyType;
++  decorators: Array<Decorator>;
++  key: PropertyKey;
++  typeAnnotation?: TSTypeAnnotation | null;
++  value: Expression | null;
++  computed: boolean;
++  static: boolean;
++  override?: boolean;
++  definite?: boolean;
++  accessibility?: TSAccessibility | null;
++  declare?: false;
++  optional?: false;
++  readonly?: false;
++  parent?: Node;
++}
++interface ImportExpression extends Span {
++  type: "ImportExpression";
++  source: Expression;
++  options: Expression | null;
++  phase: ImportPhase | null;
++  parent?: Node;
++}
++interface ImportDeclaration extends Span {
++  type: "ImportDeclaration";
++  specifiers: Array<ImportDeclarationSpecifier>;
++  source: StringLiteral;
++  phase: ImportPhase | null;
++  attributes: Array<ImportAttribute>;
++  importKind?: ImportOrExportKind;
++  parent?: Node;
++}
++type ImportPhase = "source" | "defer";
++type ImportDeclarationSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier;
++interface ImportSpecifier extends Span {
++  type: "ImportSpecifier";
++  imported: ModuleExportName;
++  local: BindingIdentifier;
++  importKind?: ImportOrExportKind;
++  parent?: Node;
++}
++interface ImportDefaultSpecifier extends Span {
++  type: "ImportDefaultSpecifier";
++  local: BindingIdentifier;
++  parent?: Node;
++}
++interface ImportNamespaceSpecifier extends Span {
++  type: "ImportNamespaceSpecifier";
++  local: BindingIdentifier;
++  parent?: Node;
++}
++interface ImportAttribute extends Span {
++  type: "ImportAttribute";
++  key: ImportAttributeKey;
++  value: StringLiteral;
++  parent?: Node;
++}
++type ImportAttributeKey = IdentifierName | StringLiteral;
++interface ExportNamedDeclaration extends Span {
++  type: "ExportNamedDeclaration";
++  declaration: Declaration | null;
++  specifiers: Array<ExportSpecifier>;
++  source: StringLiteral | null;
++  exportKind?: ImportOrExportKind;
++  attributes: Array<ImportAttribute>;
++  parent?: Node;
++}
++interface ExportDefaultDeclaration extends Span {
++  type: "ExportDefaultDeclaration";
++  declaration: ExportDefaultDeclarationKind;
++  exportKind?: "value";
++  parent?: Node;
++}
++interface ExportAllDeclaration extends Span {
++  type: "ExportAllDeclaration";
++  exported: ModuleExportName | null;
++  source: StringLiteral;
++  attributes: Array<ImportAttribute>;
++  exportKind?: ImportOrExportKind;
++  parent?: Node;
++}
++interface ExportSpecifier extends Span {
++  type: "ExportSpecifier";
++  local: ModuleExportName;
++  exported: ModuleExportName;
++  exportKind?: ImportOrExportKind;
++  parent?: Node;
++}
++type ExportDefaultDeclarationKind = Function | Class | TSInterfaceDeclaration | Expression;
++type ModuleExportName = IdentifierName | IdentifierReference | StringLiteral;
++interface V8IntrinsicExpression extends Span {
++  type: "V8IntrinsicExpression";
++  name: IdentifierName;
++  arguments: Array<Argument>;
++  parent?: Node;
++}
++interface BooleanLiteral extends Span {
++  type: "Literal";
++  value: boolean;
++  raw: string | null;
++  parent?: Node;
++}
++interface NullLiteral extends Span {
++  type: "Literal";
++  value: null;
++  raw: "null" | null;
++  parent?: Node;
++}
++interface NumericLiteral extends Span {
++  type: "Literal";
++  value: number;
++  raw: string | null;
++  parent?: Node;
++}
++interface StringLiteral extends Span {
++  type: "Literal";
++  value: string;
++  raw: string | null;
++  parent?: Node;
++}
++interface BigIntLiteral extends Span {
++  type: "Literal";
++  value: bigint;
++  raw: string | null;
++  bigint: string;
++  parent?: Node;
++}
++interface RegExpLiteral extends Span {
++  type: "Literal";
++  value: RegExp | null;
++  raw: string | null;
++  regex: {
++    pattern: string;
++    flags: string;
++  };
++  parent?: Node;
++}
++interface JSXElement extends Span {
++  type: "JSXElement";
++  openingElement: JSXOpeningElement;
++  children: Array<JSXChild>;
++  closingElement: JSXClosingElement | null;
++  parent?: Node;
++}
++interface JSXOpeningElement extends Span {
++  type: "JSXOpeningElement";
++  name: JSXElementName;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  attributes: Array<JSXAttributeItem>;
++  selfClosing: boolean;
++  parent?: Node;
++}
++interface JSXClosingElement extends Span {
++  type: "JSXClosingElement";
++  name: JSXElementName;
++  parent?: Node;
++}
++interface JSXFragment extends Span {
++  type: "JSXFragment";
++  openingFragment: JSXOpeningFragment;
++  children: Array<JSXChild>;
++  closingFragment: JSXClosingFragment;
++  parent?: Node;
++}
++interface JSXOpeningFragment extends Span {
++  type: "JSXOpeningFragment";
++  attributes?: [];
++  selfClosing?: false;
++  parent?: Node;
++}
++interface JSXClosingFragment extends Span {
++  type: "JSXClosingFragment";
++  parent?: Node;
++}
++type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression;
++interface JSXNamespacedName extends Span {
++  type: "JSXNamespacedName";
++  namespace: JSXIdentifier;
++  name: JSXIdentifier;
++  parent?: Node;
++}
++interface JSXMemberExpression extends Span {
++  type: "JSXMemberExpression";
++  object: JSXMemberExpressionObject;
++  property: JSXIdentifier;
++  parent?: Node;
++}
++type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
++interface JSXExpressionContainer extends Span {
++  type: "JSXExpressionContainer";
++  expression: JSXExpression;
++  parent?: Node;
++}
++type JSXExpression = JSXEmptyExpression | Expression;
++interface JSXEmptyExpression extends Span {
++  type: "JSXEmptyExpression";
++  parent?: Node;
++}
++type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;
++interface JSXAttribute extends Span {
++  type: "JSXAttribute";
++  name: JSXAttributeName;
++  value: JSXAttributeValue | null;
++  parent?: Node;
++}
++interface JSXSpreadAttribute extends Span {
++  type: "JSXSpreadAttribute";
++  argument: Expression;
++  parent?: Node;
++}
++type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
++type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;
++interface JSXIdentifier extends Span {
++  type: "JSXIdentifier";
++  name: string;
++  parent?: Node;
++}
++type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
++interface JSXSpreadChild extends Span {
++  type: "JSXSpreadChild";
++  expression: Expression;
++  parent?: Node;
++}
++interface JSXText extends Span {
++  type: "JSXText";
++  value: string;
++  raw: string | null;
++  parent?: Node;
++}
++interface TSThisParameter extends Span {
++  type: "Identifier";
++  decorators: [];
++  name: "this";
++  optional: false;
++  typeAnnotation: TSTypeAnnotation | null;
++  parent?: Node;
++}
++interface TSEnumDeclaration extends Span {
++  type: "TSEnumDeclaration";
++  id: BindingIdentifier;
++  body: TSEnumBody;
++  const: boolean;
++  declare: boolean;
++  parent?: Node;
++}
++interface TSEnumBody extends Span {
++  type: "TSEnumBody";
++  members: Array<TSEnumMember>;
++  parent?: Node;
++}
++interface TSEnumMember extends Span {
++  type: "TSEnumMember";
++  id: TSEnumMemberName;
++  initializer: Expression | null;
++  computed: boolean;
++  parent?: Node;
++}
++type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral;
++interface TSTypeAnnotation extends Span {
++  type: "TSTypeAnnotation";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSLiteralType extends Span {
++  type: "TSLiteralType";
++  literal: TSLiteral;
++  parent?: Node;
++}
++type TSLiteral = BooleanLiteral | NumericLiteral | BigIntLiteral | StringLiteral | TemplateLiteral | UnaryExpression;
++type TSType = TSAnyKeyword | TSBigIntKeyword | TSBooleanKeyword | TSIntrinsicKeyword | TSNeverKeyword | TSNullKeyword | TSNumberKeyword | TSObjectKeyword | TSStringKeyword | TSSymbolKeyword | TSUndefinedKeyword | TSUnknownKeyword | TSVoidKeyword | TSArrayType | TSConditionalType | TSConstructorType | TSFunctionType | TSImportType | TSIndexedAccessType | TSInferType | TSIntersectionType | TSLiteralType | TSMappedType | TSNamedTupleMember | TSTemplateLiteralType | TSThisType | TSTupleType | TSTypeLiteral | TSTypeOperator | TSTypePredicate | TSTypeQuery | TSTypeReference | TSUnionType | TSParenthesizedType | JSDocNullableType | JSDocNonNullableType | JSDocUnknownType;
++interface TSConditionalType extends Span {
++  type: "TSConditionalType";
++  checkType: TSType;
++  extendsType: TSType;
++  trueType: TSType;
++  falseType: TSType;
++  parent?: Node;
++}
++interface TSUnionType extends Span {
++  type: "TSUnionType";
++  types: Array<TSType>;
++  parent?: Node;
++}
++interface TSIntersectionType extends Span {
++  type: "TSIntersectionType";
++  types: Array<TSType>;
++  parent?: Node;
++}
++interface TSParenthesizedType extends Span {
++  type: "TSParenthesizedType";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSTypeOperator extends Span {
++  type: "TSTypeOperator";
++  operator: TSTypeOperatorOperator;
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++type TSTypeOperatorOperator = "keyof" | "unique" | "readonly";
++interface TSArrayType extends Span {
++  type: "TSArrayType";
++  elementType: TSType;
++  parent?: Node;
++}
++interface TSIndexedAccessType extends Span {
++  type: "TSIndexedAccessType";
++  objectType: TSType;
++  indexType: TSType;
++  parent?: Node;
++}
++interface TSTupleType extends Span {
++  type: "TSTupleType";
++  elementTypes: Array<TSTupleElement>;
++  parent?: Node;
++}
++interface TSNamedTupleMember extends Span {
++  type: "TSNamedTupleMember";
++  label: IdentifierName;
++  elementType: TSTupleElement;
++  optional: boolean;
++  parent?: Node;
++}
++interface TSOptionalType extends Span {
++  type: "TSOptionalType";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSRestType extends Span {
++  type: "TSRestType";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++type TSTupleElement = TSOptionalType | TSRestType | TSType;
++interface TSAnyKeyword extends Span {
++  type: "TSAnyKeyword";
++  parent?: Node;
++}
++interface TSStringKeyword extends Span {
++  type: "TSStringKeyword";
++  parent?: Node;
++}
++interface TSBooleanKeyword extends Span {
++  type: "TSBooleanKeyword";
++  parent?: Node;
++}
++interface TSNumberKeyword extends Span {
++  type: "TSNumberKeyword";
++  parent?: Node;
++}
++interface TSNeverKeyword extends Span {
++  type: "TSNeverKeyword";
++  parent?: Node;
++}
++interface TSIntrinsicKeyword extends Span {
++  type: "TSIntrinsicKeyword";
++  parent?: Node;
++}
++interface TSUnknownKeyword extends Span {
++  type: "TSUnknownKeyword";
++  parent?: Node;
++}
++interface TSNullKeyword extends Span {
++  type: "TSNullKeyword";
++  parent?: Node;
++}
++interface TSUndefinedKeyword extends Span {
++  type: "TSUndefinedKeyword";
++  parent?: Node;
++}
++interface TSVoidKeyword extends Span {
++  type: "TSVoidKeyword";
++  parent?: Node;
++}
++interface TSSymbolKeyword extends Span {
++  type: "TSSymbolKeyword";
++  parent?: Node;
++}
++interface TSThisType extends Span {
++  type: "TSThisType";
++  parent?: Node;
++}
++interface TSObjectKeyword extends Span {
++  type: "TSObjectKeyword";
++  parent?: Node;
++}
++interface TSBigIntKeyword extends Span {
++  type: "TSBigIntKeyword";
++  parent?: Node;
++}
++interface TSTypeReference extends Span {
++  type: "TSTypeReference";
++  typeName: TSTypeName;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++type TSTypeName = IdentifierReference | TSQualifiedName | ThisExpression;
++interface TSQualifiedName extends Span {
++  type: "TSQualifiedName";
++  left: TSTypeName;
++  right: IdentifierName;
++  parent?: Node;
++}
++interface TSTypeParameterInstantiation extends Span {
++  type: "TSTypeParameterInstantiation";
++  params: Array<TSType>;
++  parent?: Node;
++}
++interface TSTypeParameter extends Span {
++  type: "TSTypeParameter";
++  name: BindingIdentifier;
++  constraint: TSType | null;
++  default: TSType | null;
++  in: boolean;
++  out: boolean;
++  const: boolean;
++  parent?: Node;
++}
++interface TSTypeParameterDeclaration extends Span {
++  type: "TSTypeParameterDeclaration";
++  params: Array<TSTypeParameter>;
++  parent?: Node;
++}
++interface TSTypeAliasDeclaration extends Span {
++  type: "TSTypeAliasDeclaration";
++  id: BindingIdentifier;
++  typeParameters: TSTypeParameterDeclaration | null;
++  typeAnnotation: TSType;
++  declare: boolean;
++  parent?: Node;
++}
++type TSAccessibility = "private" | "protected" | "public";
++interface TSClassImplements extends Span {
++  type: "TSClassImplements";
++  expression: IdentifierReference | ThisExpression | MemberExpression;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++interface TSInterfaceDeclaration extends Span {
++  type: "TSInterfaceDeclaration";
++  id: BindingIdentifier;
++  typeParameters: TSTypeParameterDeclaration | null;
++  extends: Array<TSInterfaceHeritage>;
++  body: TSInterfaceBody;
++  declare: boolean;
++  parent?: Node;
++}
++interface TSInterfaceBody extends Span {
++  type: "TSInterfaceBody";
++  body: Array<TSSignature>;
++  parent?: Node;
++}
++interface TSPropertySignature extends Span {
++  type: "TSPropertySignature";
++  computed: boolean;
++  optional: boolean;
++  readonly: boolean;
++  key: PropertyKey;
++  typeAnnotation: TSTypeAnnotation | null;
++  accessibility: null;
++  static: false;
++  parent?: Node;
++}
++type TSSignature = TSIndexSignature | TSPropertySignature | TSCallSignatureDeclaration | TSConstructSignatureDeclaration | TSMethodSignature;
++interface TSIndexSignature extends Span {
++  type: "TSIndexSignature";
++  parameters: Array<TSIndexSignatureName>;
++  typeAnnotation: TSTypeAnnotation;
++  readonly: boolean;
++  static: boolean;
++  accessibility: null;
++  parent?: Node;
++}
++interface TSCallSignatureDeclaration extends Span {
++  type: "TSCallSignatureDeclaration";
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation | null;
++  parent?: Node;
++}
++type TSMethodSignatureKind = "method" | "get" | "set";
++interface TSMethodSignature extends Span {
++  type: "TSMethodSignature";
++  key: PropertyKey;
++  computed: boolean;
++  optional: boolean;
++  kind: TSMethodSignatureKind;
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation | null;
++  accessibility: null;
++  readonly: false;
++  static: false;
++  parent?: Node;
++}
++interface TSConstructSignatureDeclaration extends Span {
++  type: "TSConstructSignatureDeclaration";
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation | null;
++  parent?: Node;
++}
++interface TSIndexSignatureName extends Span {
++  type: "Identifier";
++  decorators: [];
++  name: string;
++  optional: false;
++  typeAnnotation: TSTypeAnnotation;
++  parent?: Node;
++}
++interface TSInterfaceHeritage extends Span {
++  type: "TSInterfaceHeritage";
++  expression: Expression;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++interface TSTypePredicate extends Span {
++  type: "TSTypePredicate";
++  parameterName: TSTypePredicateName;
++  asserts: boolean;
++  typeAnnotation: TSTypeAnnotation | null;
++  parent?: Node;
++}
++type TSTypePredicateName = IdentifierName | TSThisType;
++interface TSModuleDeclaration extends Span {
++  type: "TSModuleDeclaration";
++  id: BindingIdentifier | StringLiteral | TSQualifiedName;
++  body: TSModuleBlock | null;
++  kind: TSModuleDeclarationKind;
++  declare: boolean;
++  global: false;
++  parent?: Node;
++}
++type TSModuleDeclarationKind = "module" | "namespace";
++interface TSGlobalDeclaration extends Span {
++  type: "TSModuleDeclaration";
++  id: IdentifierName;
++  body: TSModuleBlock;
++  kind: "global";
++  declare: boolean;
++  global: true;
++  parent?: Node;
++}
++interface TSModuleBlock extends Span {
++  type: "TSModuleBlock";
++  body: Array<Directive | Statement>;
++  parent?: Node;
++}
++interface TSTypeLiteral extends Span {
++  type: "TSTypeLiteral";
++  members: Array<TSSignature>;
++  parent?: Node;
++}
++interface TSInferType extends Span {
++  type: "TSInferType";
++  typeParameter: TSTypeParameter;
++  parent?: Node;
++}
++interface TSTypeQuery extends Span {
++  type: "TSTypeQuery";
++  exprName: TSTypeQueryExprName;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++type TSTypeQueryExprName = TSImportType | TSTypeName;
++interface TSImportType extends Span {
++  type: "TSImportType";
++  source: StringLiteral;
++  options: ObjectExpression | null;
++  qualifier: TSImportTypeQualifier | null;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++type TSImportTypeQualifier = IdentifierName | TSImportTypeQualifiedName;
++interface TSImportTypeQualifiedName extends Span {
++  type: "TSQualifiedName";
++  left: TSImportTypeQualifier;
++  right: IdentifierName;
++  parent?: Node;
++}
++interface TSFunctionType extends Span {
++  type: "TSFunctionType";
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation;
++  parent?: Node;
++}
++interface TSConstructorType extends Span {
++  type: "TSConstructorType";
++  abstract: boolean;
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation;
++  parent?: Node;
++}
++interface TSMappedType extends Span {
++  type: "TSMappedType";
++  key: BindingIdentifier;
++  constraint: TSType;
++  nameType: TSType | null;
++  typeAnnotation: TSType | null;
++  optional: TSMappedTypeModifierOperator | false;
++  readonly: TSMappedTypeModifierOperator | null;
++  parent?: Node;
++}
++type TSMappedTypeModifierOperator = true | "+" | "-";
++interface TSTemplateLiteralType extends Span {
++  type: "TSTemplateLiteralType";
++  quasis: Array<TemplateElement>;
++  types: Array<TSType>;
++  parent?: Node;
++}
++interface TSAsExpression extends Span {
++  type: "TSAsExpression";
++  expression: Expression;
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSSatisfiesExpression extends Span {
++  type: "TSSatisfiesExpression";
++  expression: Expression;
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSTypeAssertion extends Span {
++  type: "TSTypeAssertion";
++  typeAnnotation: TSType;
++  expression: Expression;
++  parent?: Node;
++}
++interface TSImportEqualsDeclaration extends Span {
++  type: "TSImportEqualsDeclaration";
++  id: BindingIdentifier;
++  moduleReference: TSModuleReference;
++  importKind: ImportOrExportKind;
++  parent?: Node;
++}
++type TSModuleReference = TSExternalModuleReference | IdentifierReference | TSQualifiedName;
++interface TSExternalModuleReference extends Span {
++  type: "TSExternalModuleReference";
++  expression: StringLiteral;
++  parent?: Node;
++}
++interface TSNonNullExpression extends Span {
++  type: "TSNonNullExpression";
++  expression: Expression;
++  parent?: Node;
++}
++interface Decorator extends Span {
++  type: "Decorator";
++  expression: Expression;
++  parent?: Node;
++}
++interface TSExportAssignment extends Span {
++  type: "TSExportAssignment";
++  expression: Expression;
++  parent?: Node;
++}
++interface TSNamespaceExportDeclaration extends Span {
++  type: "TSNamespaceExportDeclaration";
++  id: IdentifierName;
++  parent?: Node;
++}
++interface TSInstantiationExpression extends Span {
++  type: "TSInstantiationExpression";
++  expression: Expression;
++  typeArguments: TSTypeParameterInstantiation;
++  parent?: Node;
++}
++type ImportOrExportKind = "value" | "type";
++interface JSDocNullableType extends Span {
++  type: "TSJSDocNullableType";
++  typeAnnotation: TSType;
++  postfix: boolean;
++  parent?: Node;
++}
++interface JSDocNonNullableType extends Span {
++  type: "TSJSDocNonNullableType";
++  typeAnnotation: TSType;
++  postfix: boolean;
++  parent?: Node;
++}
++interface JSDocUnknownType extends Span {
++  type: "TSJSDocUnknownType";
++  parent?: Node;
++}
++type AssignmentOperator = "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | ">>>=" | "|=" | "^=" | "&=" | "||=" | "&&=" | "??=";
++type BinaryOperator = "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "+" | "-" | "*" | "/" | "%" | "**" | "<<" | ">>" | ">>>" | "|" | "^" | "&" | "in" | "instanceof";
++type LogicalOperator = "||" | "&&" | "??";
++type UnaryOperator = "+" | "-" | "!" | "~" | "typeof" | "void" | "delete";
++type UpdateOperator = "++" | "--";
++interface Span {
++  start: number;
++  end: number;
++  range?: [number, number];
++}
++type ModuleKind = "script" | "module" | "commonjs";
++type Node = Program | IdentifierName | IdentifierReference | BindingIdentifier | LabelIdentifier | ThisExpression | ArrayExpression | ObjectExpression | ObjectProperty | TemplateLiteral | TaggedTemplateExpression | TemplateElement | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression | CallExpression | NewExpression | MetaProperty | SpreadElement | UpdateExpression | UnaryExpression | BinaryExpression | PrivateInExpression | LogicalExpression | ConditionalExpression | AssignmentExpression | ArrayAssignmentTarget | ObjectAssignmentTarget | AssignmentTargetRest | AssignmentTargetWithDefault | AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty | SequenceExpression | Super | AwaitExpression | ChainExpression | ParenthesizedExpression | Directive | Hashbang | BlockStatement | VariableDeclaration | VariableDeclarator | EmptyStatement | ExpressionStatement | IfStatement | DoWhileStatement | WhileStatement | ForStatement | ForInStatement | ForOfStatement | ContinueStatement | BreakStatement | ReturnStatement | WithStatement | SwitchStatement | SwitchCase | LabeledStatement | ThrowStatement | TryStatement | CatchClause | DebuggerStatement | AssignmentPattern | ObjectPattern | BindingProperty | ArrayPattern | BindingRestElement | Function | FunctionBody | ArrowFunctionExpression | YieldExpression | Class | ClassBody | MethodDefinition | PropertyDefinition | PrivateIdentifier | StaticBlock | AccessorProperty | ImportExpression | ImportDeclaration | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ImportAttribute | ExportNamedDeclaration | ExportDefaultDeclaration | ExportAllDeclaration | ExportSpecifier | V8IntrinsicExpression | BooleanLiteral | NullLiteral | NumericLiteral | StringLiteral | BigIntLiteral | RegExpLiteral | JSXElement | JSXOpeningElement | JSXClosingElement | JSXFragment | JSXOpeningFragment | JSXClosingFragment | JSXNamespacedName | JSXMemberExpression | JSXExpressionContainer | JSXEmptyExpression | JSXAttribute | JSXSpreadAttribute | JSXIdentifier | JSXSpreadChild | JSXText | TSThisParameter | TSEnumDeclaration | TSEnumBody | TSEnumMember | TSTypeAnnotation | TSLiteralType | TSConditionalType | TSUnionType | TSIntersectionType | TSParenthesizedType | TSTypeOperator | TSArrayType | TSIndexedAccessType | TSTupleType | TSNamedTupleMember | TSOptionalType | TSRestType | TSAnyKeyword | TSStringKeyword | TSBooleanKeyword | TSNumberKeyword | TSNeverKeyword | TSIntrinsicKeyword | TSUnknownKeyword | TSNullKeyword | TSUndefinedKeyword | TSVoidKeyword | TSSymbolKeyword | TSThisType | TSObjectKeyword | TSBigIntKeyword | TSTypeReference | TSQualifiedName | TSTypeParameterInstantiation | TSTypeParameter | TSTypeParameterDeclaration | TSTypeAliasDeclaration | TSClassImplements | TSInterfaceDeclaration | TSInterfaceBody | TSPropertySignature | TSIndexSignature | TSCallSignatureDeclaration | TSMethodSignature | TSConstructSignatureDeclaration | TSIndexSignatureName | TSInterfaceHeritage | TSTypePredicate | TSModuleDeclaration | TSGlobalDeclaration | TSModuleBlock | TSTypeLiteral | TSInferType | TSTypeQuery | TSImportType | TSImportTypeQualifiedName | TSFunctionType | TSConstructorType | TSMappedType | TSTemplateLiteralType | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSImportEqualsDeclaration | TSExternalModuleReference | TSNonNullExpression | Decorator | TSExportAssignment | TSNamespaceExportDeclaration | TSInstantiationExpression | JSDocNullableType | JSDocNonNullableType | JSDocUnknownType | ParamPattern;
++//#endregion
++//#region node_modules/.pnpm/rolldown@1.0.0-rc.7_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0/node_modules/rolldown/dist/shared/binding-BohGL_65.d.mts
++interface ParserOptions {
++  /** Treat the source text as `js`, `jsx`, `ts`, `tsx` or `dts`. */
++  lang?: 'js' | 'jsx' | 'ts' | 'tsx' | 'dts';
++  /** Treat the source text as `script` or `module` code. */
++  sourceType?: 'script' | 'module' | 'commonjs' | 'unambiguous' | undefined;
++  /**
++   * Return an AST which includes TypeScript-related properties, or excludes them.
++   *
++   * `'js'` is default for JS / JSX files.
++   * `'ts'` is default for TS / TSX files.
++   * The type of the file is determined from `lang` option, or extension of provided `filename`.
++   */
++  astType?: 'js' | 'ts';
++  /**
++   * Controls whether the `range` property is included on AST nodes.
++   * The `range` property is a `[number, number]` which indicates the start/end offsets
++   * of the node in the file contents.
++   *
++   * @default false
++   */
++  range?: boolean;
++  /**
++   * Emit `ParenthesizedExpression` and `TSParenthesizedType` in AST.
++   *
++   * If this option is true, parenthesized expressions are represented by
++   * (non-standard) `ParenthesizedExpression` and `TSParenthesizedType` nodes that
++   * have a single `expression` property containing the expression inside parentheses.
++   *
++   * @default true
++   */
++  preserveParens?: boolean;
++  /**
++   * Produce semantic errors with an additional AST pass.
++   * Semantic errors depend on symbols and scopes, where the parser does not construct.
++   * This adds a small performance overhead.
++   *
++   * @default false
++   */
++  showSemanticErrors?: boolean;
++}
++interface BindingPluginContextResolveOptions {
++  /**
++   * - `import-statement`: `import { foo } from './lib.js';`
++   * - `dynamic-import`: `import('./lib.js')`
++   * - `require-call`: `require('./lib.js')`
++   * - `import-rule`: `@import 'bg-color.css'`
++   * - `url-token`: `url('./icon.png')`
++   * - `new-url`: `new URL('./worker.js', import.meta.url)`
++   * - `hot-accept`: `import.meta.hot.accept('./lib.js', () => {})`
++   */
++  importKind?: 'import-statement' | 'dynamic-import' | 'require-call' | 'import-rule' | 'url-token' | 'new-url' | 'hot-accept';
++  isEntry?: boolean;
++  skipSelf?: boolean;
++  custom?: number;
++  vitePluginCustom?: BindingVitePluginCustom;
++}
++interface BindingVitePluginCustom {
++  'vite:import-glob'?: ViteImportGlobMeta;
++}
++interface ViteImportGlobMeta {
++  isSubImportsPattern?: boolean;
++} //#endregion
++//#endregion
++//#region node_modules/.pnpm/rolldown@1.0.0-rc.7_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0/node_modules/rolldown/dist/shared/define-config-BqZZMLjO.d.mts
++//#endregion
++//#region src/types/module-info.d.ts
++/** @category Plugin APIs */
++interface ModuleInfo extends ModuleOptions {
++  /**
++  * @hidden Not supported by Rolldown
++  */
++  ast: any;
++  /**
++  * The source code of the module.
++  *
++  * `null` if external or not yet available.
++  */
++  code: string | null;
++  /**
++  * The id of the module for convenience
++  */
++  id: string;
++  /**
++  * The ids of all modules that statically import this module.
++  */
++  importers: string[];
++  /**
++  * The ids of all modules that dynamically import this module.
++  */
++  dynamicImporters: string[];
++  /**
++  * The module ids statically imported by this module.
++  */
++  importedIds: string[];
++  /**
++  * The module ids dynamically imported by this module.
++  */
++  dynamicallyImportedIds: string[];
++  /**
++  * All exported variables
++  */
++  exports: string[];
++  /**
++  * Whether this module is a user- or plugin-defined entry point.
++  */
++  isEntry: boolean;
++  /**
++  * The detected format of the module, based on both its syntax and module definition
++  * metadata (such as `package.json` `type` and file extensions like `.mjs`/`.cjs`/`.mts`/`.cts`).
++  * - "esm" for ES modules (has `import`/`export` statements or is defined as ESM by module metadata)
++  * - "cjs" for CommonJS modules (uses `module.exports`, `exports`, top-level `return`, or is defined as CommonJS by module metadata)
++  * - "unknown" when the format could not be determined from either syntax or module definition metadata
++  *
++  * @experimental
++  */
++  inputFormat: "es" | "cjs" | "unknown";
++} //#endregion
++//#region src/utils/asset-source.d.ts
++/** @inline */
++type AssetSource = string | Uint8Array; //#endregion
++//#region src/types/external-memory-handle.d.ts
++/** @category Plugin APIs */
++interface SourceMap {
++  file: string;
++  mappings: string;
++  names: string[];
++  sources: string[];
++  sourcesContent: string[];
++  version: number;
++  debugId?: string;
++  x_google_ignoreList?: number[];
++  toString(): string;
++  toUrl(): string;
++}
++/** @category Plugin APIs */
++type PartialNull<T> = { [P in keyof T]: T[P] | null };
++//#endregion
++//#region src/log/log-handler.d.ts
++type LoggingFunction = (log: RolldownLog | string | (() => RolldownLog | string)) => void;
++//#endregion
++//#region src/plugin/fs.d.ts
++/** @category Plugin APIs */
++interface RolldownFsModule {
++  appendFile(path: string, data: string | Uint8Array, options?: {
++    encoding?: BufferEncoding | null;
++    mode?: string | number;
++    flag?: string | number;
++  }): Promise<void>;
++  copyFile(source: string, destination: string, mode?: string | number): Promise<void>;
++  mkdir(path: string, options?: {
++    recursive?: boolean;
++    mode?: string | number;
++  }): Promise<void>;
++  mkdtemp(prefix: string): Promise<string>;
++  readdir(path: string, options?: {
++    withFileTypes?: false;
++  }): Promise<string[]>;
++  readdir(path: string, options?: {
++    withFileTypes: true;
++  }): Promise<RolldownDirectoryEntry[]>;
++  readFile(path: string, options?: {
++    encoding?: null;
++    flag?: string | number;
++    signal?: AbortSignal;
++  }): Promise<Uint8Array>;
++  readFile(path: string, options?: {
++    encoding: BufferEncoding;
++    flag?: string | number;
++    signal?: AbortSignal;
++  }): Promise<string>;
++  realpath(path: string): Promise<string>;
++  rename(oldPath: string, newPath: string): Promise<void>;
++  rmdir(path: string, options?: {
++    recursive?: boolean;
++  }): Promise<void>;
++  stat(path: string): Promise<RolldownFileStats>;
++  lstat(path: string): Promise<RolldownFileStats>;
++  unlink(path: string): Promise<void>;
++  writeFile(path: string, data: string | Uint8Array, options?: {
++    encoding?: BufferEncoding | null;
++    mode?: string | number;
++    flag?: string | number;
++  }): Promise<void>;
++}
++/** @category Plugin APIs */
++type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "binary" | "hex";
++/** @category Plugin APIs */
++interface RolldownDirectoryEntry {
++  isFile(): boolean;
++  isDirectory(): boolean;
++  isSymbolicLink(): boolean;
++  name: string;
++}
++/** @category Plugin APIs */
++interface RolldownFileStats {
++  isFile(): boolean;
++  isDirectory(): boolean;
++  isSymbolicLink(): boolean;
++  size: number;
++  mtime: Date;
++  ctime: Date;
++  atime: Date;
++  birthtime: Date;
++} //#endregion
++//#region src/plugin/hook-filter.d.ts
++/** @category Plugin APIs */
++//#endregion
++//#region src/plugin/minimal-plugin-context.d.ts
++/** @category Plugin APIs */
++interface PluginContextMeta {
++  /**
++  * A property for Rollup compatibility. A dummy value is set by Rolldown.
++  * @example `'4.23.0'`
++  */
++  rollupVersion: string;
++  /**
++  * The currently running version of Rolldown.
++  * @example `'1.0.0'`
++  */
++  rolldownVersion: string;
++  /**
++  * Whether Rolldown was started via {@linkcode watch | rolldown.watch()} or
++  * from the command line with `--watch`.
++  */
++  watchMode: boolean;
++}
++/** @category Plugin APIs */
++interface MinimalPluginContext {
++  /** @hidden */
++  readonly pluginName: string;
++  /**
++  * Similar to {@linkcode warn | this.warn}, except that it will also abort
++  * the bundling process with an error.
++  *
++  * If an Error instance is passed, it will be used as-is, otherwise a new Error
++  * instance will be created with the given error message and all additional
++  * provided properties.
++  *
++  * In all hooks except the {@linkcode Plugin.onLog | onLog} hook, the error will
++  * be augmented with {@linkcode RolldownLog.code | code: "PLUGIN_ERROR"} and
++  * {@linkcode RolldownLog.plugin | plugin: plugin.name} properties.
++  * If a `code` property already exists and the code does not start with `PLUGIN_`,
++  * it will be renamed to {@linkcode RolldownLog.pluginCode | pluginCode}.
++  *
++  * @group Logging Methods
++  */
++  error: (e: RolldownError | string) => never;
++  /**
++  * Generate a `"info"` level log.
++  *
++  * {@linkcode RolldownLog.code | code} will be set to `"PLUGIN_LOG"` by Rolldown.
++  * As these logs are displayed by default, use them for information that is not a warning
++  * but makes sense to display to all users on every build.
++  *
++  *
++  *
++  * @inlineType LoggingFunction
++  * @group Logging Methods
++  */
++  info: LoggingFunction;
++  /**
++  * Generate a `"warn"` level log.
++  *
++  * Just like internally generated warnings, these logs will be first passed to and
++  * filtered by plugin {@linkcode Plugin.onLog | onLog} hooks before they are forwarded
++  * to custom {@linkcode InputOptions.onLog | onLog} or
++  * {@linkcode InputOptions.onwarn | onwarn} handlers or printed to the console.
++  *
++  * We encourage you to use objects with a {@linkcode RolldownLog.pluginCode | pluginCode}
++  * property as that will allow users to easily filter for those logs in an `onLog` handler.
++  *
++  *
++  *
++  * @inlineType LoggingFunction
++  * @group Logging Methods
++  */
++  warn: LoggingFunction;
++  /**
++  * Generate a `"debug"` level log.
++  *
++  * {@linkcode RolldownLog.code | code} will be set to `"PLUGIN_LOG"` by Rolldown.
++  * Make sure to add a distinctive {@linkcode RolldownLog.pluginCode | pluginCode} to
++  * those logs for easy filtering.
++  *
++  *
++  *
++  * @inlineType LoggingFunction
++  * @group Logging Methods
++  */
++  debug: LoggingFunction;
++  /** An object containing potentially useful metadata. */
++  meta: PluginContextMeta;
++} //#endregion
++//#region src/plugin/parallel-plugin.d.ts
++//#endregion
++//#region src/plugin/plugin-context.d.ts
++/**
++* Either a {@linkcode name} or a {@linkcode fileName} can be supplied.
++* If a {@linkcode fileName} is provided, it will be used unmodified as the name
++* of the generated file, throwing an error if this causes a conflict.
++* Otherwise, if a {@linkcode name} is supplied, this will be used as substitution
++* for `[name]` in the corresponding
++* {@linkcode OutputOptions.assetFileNames | output.assetFileNames} pattern, possibly
++* adding a unique number to the end of the file name to avoid conflicts.
++* If neither a {@linkcode name} nor {@linkcode fileName} is supplied, a default name will be used.
++*
++* @category Plugin APIs
++*/
++interface EmittedAsset {
++  type: "asset";
++  name?: string;
++  fileName?: string;
++  /**
++  * An absolute path to the original file if this asset corresponds to a file on disk.
++  *
++  * This property will be passed on to subsequent plugin hooks that receive a
++  * {@linkcode PreRenderedAsset} or an {@linkcode OutputAsset} like
++  * {@linkcode Plugin.generateBundle | generateBundle}.
++  * In watch mode, Rolldown will also automatically watch this file for changes and
++  * trigger a rebuild if it changes. Therefore, it is not necessary to call
++  * {@linkcode PluginContext.addWatchFile | this.addWatchFile} for this file.
++  */
++  originalFileName?: string;
++  source: AssetSource;
++}
++/**
++* Either a {@linkcode name} or a {@linkcode fileName} can be supplied.
++* If a {@linkcode fileName} is provided, it will be used unmodified as the name
++* of the generated file, throwing an error if this causes a conflict.
++* Otherwise, if a {@linkcode name} is supplied, this will be used as substitution
++* for `[name]` in the corresponding
++* {@linkcode OutputOptions.chunkFileNames | output.chunkFileNames} pattern, possibly
++* adding a unique number to the end of the file name to avoid conflicts.
++* If neither a {@linkcode name} nor {@linkcode fileName} is supplied, a default name will be used.
++*
++* @category Plugin APIs
++*/
++interface EmittedChunk {
++  type: "chunk";
++  name?: string;
++  fileName?: string;
++  /**
++  * When provided, this will override
++  * {@linkcode InputOptions.preserveEntrySignatures | preserveEntrySignatures} for this particular
++  * chunk.
++  */
++  preserveSignature?: "strict" | "allow-extension" | "exports-only" | false;
++  /**
++  * The module id of the entry point of the chunk.
++  *
++  * It will be passed through build hooks just like regular entry points,
++  * starting with {@linkcode Plugin.resolveId | resolveId}.
++  */
++  id: string;
++  /**
++  * The value to be passed to {@linkcode Plugin.resolveId | resolveId}'s {@linkcode importer} parameter when resolving the entry point.
++  * This is important to properly resolve relative paths. If it is not provided,
++  * paths will be resolved relative to the current working directory.
++  */
++  importer?: string;
++}
++/** @category Plugin APIs */
++interface EmittedPrebuiltChunk {
++  type: "prebuilt-chunk";
++  fileName: string;
++  /**
++  * A semantic name for the chunk. If not provided, `fileName` will be used.
++  */
++  name?: string;
++  /**
++  * The code of this chunk.
++  */
++  code: string;
++  /**
++  * The list of exported variable names from this chunk.
++  *
++  * This should be provided if the chunk exports any variables.
++  */
++  exports?: string[];
++  /**
++  * The corresponding source map for this chunk.
++  */
++  map?: SourceMap;
++  sourcemapFileName?: string;
++  /**
++  * The module id of the facade module for this chunk, if any.
++  */
++  facadeModuleId?: string;
++  /**
++  * Whether this chunk corresponds to an entry point.
++  */
++  isEntry?: boolean;
++  /**
++  * Whether this chunk corresponds to a dynamic entry point.
++  */
++  isDynamicEntry?: boolean;
++}
++/** @inline @category Plugin APIs */
++type EmittedFile = EmittedAsset | EmittedChunk | EmittedPrebuiltChunk;
++/** @category Plugin APIs */
++interface PluginContextResolveOptions {
++  /**
++  * The value for {@linkcode ResolveIdExtraOptions.kind | kind} passed to
++  * {@linkcode Plugin.resolveId | resolveId} hooks.
++  */
++  kind?: BindingPluginContextResolveOptions["importKind"];
++  /**
++  * The value for {@linkcode ResolveIdExtraOptions.isEntry | isEntry} passed to
++  * {@linkcode Plugin.resolveId | resolveId} hooks.
++  *
++  * @default `false` if there's an importer, `true` otherwise.
++  */
++  isEntry?: boolean;
++  /**
++  * Whether the {@linkcode Plugin.resolveId | resolveId} hook of the plugin from
++  * which {@linkcode PluginContext.resolve | this.resolve} is called will be skipped
++  * when resolving.
++  *
++  *
++  *
++  * @default true
++  */
++  skipSelf?: boolean;
++  /**
++  * Plugin-specific options.
++  *
++  * See [Custom resolver options section](https://rolldown.rs/apis/plugin-api/inter-plugin-communication#custom-resolver-options) for more details.
++  */
++  custom?: CustomPluginOptions;
++}
++/** @inline */
++type GetModuleInfo = (moduleId: string) => ModuleInfo | null;
++/** @category Plugin APIs */
++interface PluginContext extends MinimalPluginContext {
++  /**
++  * Provides abstract access to the file system.
++  */
++  fs: RolldownFsModule;
++  /**
++  * Emits a new file that is included in the build output.
++  * You can emit chunks, prebuilt chunks or assets.
++  *
++  *
++  *
++  * @returns A `referenceId` for the emitted file that can be used in various places to reference the emitted file.
++  */
++  emitFile(file: EmittedFile): string;
++  /**
++  * Get the file name of a chunk or asset that has been emitted via
++  * {@linkcode emitFile | this.emitFile}.
++  *
++  * @returns The file name of the emitted file. Relative to {@linkcode OutputOptions.dir | output.dir}.
++  */
++  getFileName(referenceId: string): string;
++  /**
++  * Get all module ids in the current module graph.
++  *
++  * @returns
++  * An iterator of module ids. It can be iterated via
++  * ```js
++  * for (const moduleId of this.getModuleIds()) {
++  *   // ...
++  * }
++  * ```
++  * or converted into an array via `Array.from(this.getModuleIds())`.
++  */
++  getModuleIds(): IterableIterator<string>;
++  /**
++  * Get additional information about the module in question.
++  *
++  *
++  *
++  * @returns Module information for that module. `null` if the module could not be found.
++  * @group Methods
++  */
++  getModuleInfo: GetModuleInfo;
++  /**
++  * Adds additional files to be monitored in watch mode so that changes to these files will trigger rebuilds.
++  *
++  *
++  */
++  addWatchFile(id: string): void;
++  /**
++  * Loads and parses the module corresponding to the given id, attaching additional
++  * meta information to the module if provided. This will trigger the same
++  * {@linkcode Plugin.load | load}, {@linkcode Plugin.transform | transform} and
++  * {@linkcode Plugin.moduleParsed | moduleParsed} hooks as if the module was imported
++  * by another module.
++  *
++  *
++  */
++  load(options: {
++    id: string;
++    resolveDependencies?: boolean;
++  } & Partial<PartialNull<ModuleOptions>>): Promise<ModuleInfo>;
++  /**
++  * Use Rolldown's internal parser to parse code to an [ESTree-compatible](https://github.com/estree/estree) AST.
++  */
++  parse(input: string, options?: ParserOptions | null): Program;
++  /**
++  * Resolve imports to module ids (i.e. file names) using the same plugins that Rolldown uses,
++  * and determine if an import should be external.
++  *
++  * When calling this function from a {@linkcode Plugin.resolveId | resolveId} hook, you should
++  * always check if it makes sense for you to pass along the
++  * {@link PluginContextResolveOptions | options}.
++  *
++  * @returns
++  * If `Promise<null>` is returned, the import could not be resolved by Rolldown or any plugin
++  * but was not explicitly marked as external by the user.
++  * If an absolute external id is returned that should remain absolute in the output either
++  * via the
++  * {@linkcode InputOptions.makeAbsoluteExternalsRelative | makeAbsoluteExternalsRelative}
++  * option or by explicit plugin choice in the {@linkcode Plugin.resolveId | resolveId} hook,
++  * `external` will be `"absolute"` instead of `true`.
++  */
++  resolve(source: string, importer?: string, options?: PluginContextResolveOptions): Promise<ResolvedId | null>;
++} //#endregion
++//#region src/plugin/transform-plugin-context.d.ts
++/** @category Plugin APIs */
++//#endregion
++//#region src/plugin/index.d.ts
++type ModuleSideEffects = boolean | "no-treeshake" | null;
++/** @category Plugin APIs */
++/** @category Plugin APIs */
++interface CustomPluginOptions {
++  [plugin: string]: any;
++}
++/** @category Plugin APIs */
++interface ModuleOptions {
++  moduleSideEffects: ModuleSideEffects;
++  /** See [Custom module meta-data section](https://rolldown.rs/apis/plugin-api/inter-plugin-communication#custom-module-meta-data) for more details. */
++  meta: CustomPluginOptions;
++  invalidate?: boolean;
++  packageJsonPath?: string;
++}
++/** @category Plugin APIs */
++interface ResolvedId extends ModuleOptions {
++  external: boolean | "absolute";
++  id: string;
++}
++//#endregion
+ //#region src/utils/normalizeModuleFederationOptions.d.ts
++interface ExposesItem {
++  import: string;
++}
++interface NormalizedShared {
++  [key: string]: ShareItem;
++}
+ interface RemoteObjectConfig {
+   type?: string;
+   name: string;
+@@ -10,6 +1901,13 @@ interface RemoteObjectConfig {
+   entryGlobalName?: string;
+   shareScope?: string;
+ }
++interface ShareItem {
++  name: string;
++  version: string | undefined;
++  scope: string;
++  from: string;
++  shareConfig: SharedConfig & moduleFederationPlugin.SharedConfig;
++}
+ interface PluginManifestOptions {
+   filePath?: string;
+   disableAssetsAnalyze?: boolean;
+@@ -78,40 +1976,32 @@ type ModuleFederationOptions = {
+    * @default 'web' (or 'node' if build.ssr is enabled)
+    */
+   target?: 'web' | 'node';
+-  /**
+-   * Additional packages to mark as external in the SSR remote entry build.
+-   * Shared packages and MF runtime packages are always external. Use this to
+-   * add any other Node-only packages that should not be bundled into the SSR entry.
+-   */
+-  ssrExternals?: string[];
+ };
++interface NormalizedModuleFederationOptions extends Omit<ModuleFederationOptions, 'exposes' | 'remotes' | 'shared'> {
++  exposes: Record<string, ExposesItem>;
++  filename: string;
++  internalName: string;
++  library: any;
++  remotes: Record<string, RemoteObjectConfig>;
++  runtime: any;
++  shareScope: string;
++  shared: NormalizedShared;
++  runtimePlugins: Array<string | [string, Record<string, unknown>]>;
++  implementation: string;
++  manifest?: PluginManifestOptions | boolean;
++  shareStrategy: ShareStrategy;
++  virtualModuleDir: string;
++  hostInitInjectLocation: HostInitInjectLocationOptions;
++  bundleAllCSS: boolean;
++  moduleParseTimeout: number;
++  moduleParseIdleTimeout?: number;
++}
+ type HostInitInjectLocationOptions = 'entry' | 'html';
+ interface PluginDevOptions {
+   disableLiveReload?: boolean;
+   disableHotTypesReload?: boolean;
+   disableDynamicRemoteTypeHints?: boolean;
+-  /**
+-   * Controls cross-federation HMR for remote modules.
+-   *
+-   * - `false` / `undefined` — HMR disabled (default).
+-   * - `true` — HMR enabled with auto-detected strategy. When a framework
+-   *   plugin with cross-federation HMR support is detected, broadcast/relay
+-   *   is suppressed and the framework's native HMR handles updates:
+-   *     - React (`@vitejs/plugin-react` / `@vitejs/plugin-react-swc`) — the
+-   *       plugin serves a `/@react-refresh` proxy on remotes that delegates
+-   *       to the host's `RefreshRuntime`, unifying the component registry.
+-   *     - Vue (`@vitejs/plugin-vue` / `@vitejs/plugin-vue-jsx`) — the plugin
+-   *       injects a `__VUE_HMR_RUNTIME__` guard into the host page so the
+-   *       first-loaded (host) Vue runtime is pinned and remote-loaded Vue
+-   *       copies cannot overwrite it.
+-   *   For any host, the plugin also injects a script that clears the
+-   *   federation `moduleCache` on `vite:beforeUpdate` so subsequent
+-   *   `loadRemote()` calls return the freshly patched module.
+-   *   Other frameworks fall back to full page reloads.
+-   * - `'full-reload'` — HMR enabled, always use full page reloads even when
+-   *   a framework with native cross-federation HMR is detected.
+-   */
+-  remoteHmr?: boolean | 'full-reload';
++  remoteHmr?: boolean;
+ }
+ interface RemoteTypeUrl {
+   alias?: string;
+@@ -156,12 +2046,98 @@ interface DtsHostOptions {
+   runtimePkgs?: string[];
+   remoteTypeUrls?: (() => Promise<RemoteTypeUrls>) | RemoteTypeUrls;
+   timeout?: number;
+-  family?: 0 | 4 | 6;
++  family?: 4 | 6;
+   typesOnBuild?: boolean;
+ }
+ //#endregion
+ //#region src/index.d.ts
+-declare function federation(mfUserOptions: ModuleFederationOptions): any[];
+-declare function createModuleFederationConfig<T extends ModuleFederationOptions>(options: T): T;
++type OutputNameOption = string | ((...args: unknown[]) => string);
++type ManualChunksOption = Record<string, string[]> | ((id: string, ...args: unknown[]) => string | void);
++type OutputNameOptions = {
++  entryFileNames?: OutputNameOption;
++  chunkFileNames?: OutputNameOption;
++  assetFileNames?: OutputNameOption;
++};
++type CodeSplittingOptions = {
++  groups?: unknown;
++} & Record<string, unknown>;
++type MutableBundlerOutput = OutputNameOptions & {
++  codeSplitting?: false | CodeSplittingOptions;
++  manualChunks?: ManualChunksOption;
++} & Record<string, unknown>;
++type RolldownOptionsLike = {
++  output?: MutableBundlerOutput | MutableBundlerOutput[];
++};
++type EnvironmentWithRolldownOptions = {
++  getRolldownOptions?: () => RolldownOptionsLike | Promise<RolldownOptionsLike>;
++};
++type BuilderLike = {
++  environments: Record<string, EnvironmentWithRolldownOptions>;
++};
++type BundleChunkLike = {
++  type: 'chunk';
++  fileName: string;
++  code: string;
++};
++type BundleAssetLike = {
++  type: 'asset';
++  fileName: string;
++};
++type BundleLike = Record<string, BundleChunkLike | BundleAssetLike>;
++type NormalizedOutputOptionsLike = {
++  dir?: string;
++};
++declare function federation(mfUserOptions: ModuleFederationOptions): (Plugin<any> | {
++  name: string;
++  config: (config: UserConfig) => void;
++} | {
++  name: string;
++  enforce: "post";
++  apply: "build";
++  config(this: vite.ConfigPluginContext, _config: UserConfig, {
++    command
++  }: ConfigEnv): void;
++  generateBundle(this: PluginContext, _outputOptions: NormalizedOutputOptionsLike, bundle: BundleLike, _isWrite: boolean): void;
++} | {
++  name: string;
++  enforce: string;
++  config(_config: UserConfig, env: ConfigEnv): void;
++  configResolved(config: ResolvedConfig): void;
++  apply?: undefined;
++  buildApp?: undefined;
++  load?: undefined;
++  generateBundle?: undefined;
++  _options?: undefined;
++} | {
++  name: string;
++  enforce: string;
++  apply: string;
++  config(config: UserConfig): void;
++  buildApp(builder: BuilderLike): Promise<void>;
++  load(id: string): {
++    code: string;
++    syntheticNamedExports?: undefined;
++  } | {
++    code: string;
++    syntheticNamedExports: string;
++  } | undefined;
++  generateBundle(_outputOptions: NormalizedOutputOptionsLike, bundle: BundleLike, _isWrite: boolean): void;
++  configResolved?: undefined;
++  _options?: undefined;
++} | {
++  name: string;
++  enforce: string;
++  _options: NormalizedModuleFederationOptions;
++  config(config: UserConfig, {
++    command: _command
++  }: {
++    command: string;
++  }): void;
++  configResolved?: undefined;
++  apply?: undefined;
++  buildApp?: undefined;
++  load?: undefined;
++  generateBundle?: undefined;
++})[];
+ //#endregion
+-export { type ModuleFederationOptions, type PluginManifestOptions, createModuleFederationConfig, federation };
+\ No newline at end of file
++export { type ModuleFederationOptions, type PluginManifestOptions, federation };
+\ No newline at end of file
+diff --git a/lib/index.d.mts b/lib/index.d.mts
+index ed5b77c2d4357e74655a8d4442a6ca3cb7e9fe21..b653694ec7ee113b2556ea47c2cbea8fa67e0d91 100644
+--- a/lib/index.d.mts
++++ b/lib/index.d.mts
+@@ -1,7 +1,1898 @@
+ import { moduleFederationPlugin } from "@module-federation/sdk";
+-import { ShareStrategy } from "@module-federation/runtime/types";
++import * as vite from "vite";
++import { ConfigEnv, Plugin, ResolvedConfig, UserConfig } from "vite";
++import { ShareStrategy, SharedConfig } from "@module-federation/runtime/types";
+ 
++//#region node_modules/.pnpm/rolldown@1.0.0-rc.7_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0/node_modules/rolldown/dist/shared/logging-C6h4g8dA.d.mts
++interface RolldownLog {
++  binding?: string;
++  cause?: unknown;
++  /**
++  * The log code for this log object.
++  * @example 'PLUGIN_ERROR'
++  */
++  code?: string;
++  exporter?: string;
++  frame?: string;
++  hook?: string;
++  id?: string;
++  ids?: string[];
++  loc?: {
++    column: number;
++    file?: string;
++    line: number;
++  };
++  /**
++  * The message for this log object.
++  * @example 'The "transform" hook used by the output plugin "rolldown-plugin-foo" is a build time hook and will not be run for that plugin. Either this plugin cannot be used as an output plugin, or it should have an option to configure it as an output plugin.'
++  */
++  message: string;
++  meta?: any;
++  names?: string[];
++  plugin?: string;
++  pluginCode?: unknown;
++  pos?: number;
++  reexporter?: string;
++  stack?: string;
++  url?: string;
++}
++/** @inline */
++/** @category Plugin APIs */
++interface RolldownError extends RolldownLog {
++  name?: string;
++  stack?: string;
++  watchFiles?: string[];
++}
++//#endregion
++//#region node_modules/.pnpm/@oxc-project+types@0.115.0/node_modules/@oxc-project/types/types.d.ts
++// Auto-generated code, DO NOT EDIT DIRECTLY!
++// To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`.
++interface Program extends Span {
++  type: "Program";
++  body: Array<Directive | Statement>;
++  sourceType: ModuleKind;
++  hashbang: Hashbang | null;
++  parent?: null;
++}
++type Expression = BooleanLiteral | NullLiteral | NumericLiteral | BigIntLiteral | RegExpLiteral | StringLiteral | TemplateLiteral | IdentifierReference | MetaProperty | Super | ArrayExpression | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | BinaryExpression | CallExpression | ChainExpression | Class | ConditionalExpression | Function | ImportExpression | LogicalExpression | NewExpression | ObjectExpression | ParenthesizedExpression | SequenceExpression | TaggedTemplateExpression | ThisExpression | UnaryExpression | UpdateExpression | YieldExpression | PrivateInExpression | JSXElement | JSXFragment | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSNonNullExpression | TSInstantiationExpression | V8IntrinsicExpression | MemberExpression;
++interface IdentifierName extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface IdentifierReference extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface BindingIdentifier extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface LabelIdentifier extends Span {
++  type: "Identifier";
++  decorators?: [];
++  name: string;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface ThisExpression extends Span {
++  type: "ThisExpression";
++  parent?: Node;
++}
++interface ArrayExpression extends Span {
++  type: "ArrayExpression";
++  elements: Array<ArrayExpressionElement>;
++  parent?: Node;
++}
++type ArrayExpressionElement = SpreadElement | null | Expression;
++interface ObjectExpression extends Span {
++  type: "ObjectExpression";
++  properties: Array<ObjectPropertyKind>;
++  parent?: Node;
++}
++type ObjectPropertyKind = ObjectProperty | SpreadElement;
++interface ObjectProperty extends Span {
++  type: "Property";
++  kind: PropertyKind;
++  key: PropertyKey;
++  value: Expression;
++  method: boolean;
++  shorthand: boolean;
++  computed: boolean;
++  optional?: false;
++  parent?: Node;
++}
++type PropertyKey = IdentifierName | PrivateIdentifier | Expression;
++type PropertyKind = "init" | "get" | "set";
++interface TemplateLiteral extends Span {
++  type: "TemplateLiteral";
++  quasis: Array<TemplateElement>;
++  expressions: Array<Expression>;
++  parent?: Node;
++}
++interface TaggedTemplateExpression extends Span {
++  type: "TaggedTemplateExpression";
++  tag: Expression;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  quasi: TemplateLiteral;
++  parent?: Node;
++}
++interface TemplateElement extends Span {
++  type: "TemplateElement";
++  value: TemplateElementValue;
++  tail: boolean;
++  parent?: Node;
++}
++interface TemplateElementValue {
++  raw: string;
++  cooked: string | null;
++}
++type MemberExpression = ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;
++interface ComputedMemberExpression extends Span {
++  type: "MemberExpression";
++  object: Expression;
++  property: Expression;
++  optional: boolean;
++  computed: true;
++  parent?: Node;
++}
++interface StaticMemberExpression extends Span {
++  type: "MemberExpression";
++  object: Expression;
++  property: IdentifierName;
++  optional: boolean;
++  computed: false;
++  parent?: Node;
++}
++interface PrivateFieldExpression extends Span {
++  type: "MemberExpression";
++  object: Expression;
++  property: PrivateIdentifier;
++  optional: boolean;
++  computed: false;
++  parent?: Node;
++}
++interface CallExpression extends Span {
++  type: "CallExpression";
++  callee: Expression;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  arguments: Array<Argument>;
++  optional: boolean;
++  parent?: Node;
++}
++interface NewExpression extends Span {
++  type: "NewExpression";
++  callee: Expression;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  arguments: Array<Argument>;
++  parent?: Node;
++}
++interface MetaProperty extends Span {
++  type: "MetaProperty";
++  meta: IdentifierName;
++  property: IdentifierName;
++  parent?: Node;
++}
++interface SpreadElement extends Span {
++  type: "SpreadElement";
++  argument: Expression;
++  parent?: Node;
++}
++type Argument = SpreadElement | Expression;
++interface UpdateExpression extends Span {
++  type: "UpdateExpression";
++  operator: UpdateOperator;
++  prefix: boolean;
++  argument: SimpleAssignmentTarget;
++  parent?: Node;
++}
++interface UnaryExpression extends Span {
++  type: "UnaryExpression";
++  operator: UnaryOperator;
++  argument: Expression;
++  prefix: true;
++  parent?: Node;
++}
++interface BinaryExpression extends Span {
++  type: "BinaryExpression";
++  left: Expression;
++  operator: BinaryOperator;
++  right: Expression;
++  parent?: Node;
++}
++interface PrivateInExpression extends Span {
++  type: "BinaryExpression";
++  left: PrivateIdentifier;
++  operator: "in";
++  right: Expression;
++  parent?: Node;
++}
++interface LogicalExpression extends Span {
++  type: "LogicalExpression";
++  left: Expression;
++  operator: LogicalOperator;
++  right: Expression;
++  parent?: Node;
++}
++interface ConditionalExpression extends Span {
++  type: "ConditionalExpression";
++  test: Expression;
++  consequent: Expression;
++  alternate: Expression;
++  parent?: Node;
++}
++interface AssignmentExpression extends Span {
++  type: "AssignmentExpression";
++  operator: AssignmentOperator;
++  left: AssignmentTarget;
++  right: Expression;
++  parent?: Node;
++}
++type AssignmentTarget = SimpleAssignmentTarget | AssignmentTargetPattern;
++type SimpleAssignmentTarget = IdentifierReference | TSAsExpression | TSSatisfiesExpression | TSNonNullExpression | TSTypeAssertion | MemberExpression;
++type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTarget;
++interface ArrayAssignmentTarget extends Span {
++  type: "ArrayPattern";
++  decorators?: [];
++  elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface ObjectAssignmentTarget extends Span {
++  type: "ObjectPattern";
++  decorators?: [];
++  properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface AssignmentTargetRest extends Span {
++  type: "RestElement";
++  decorators?: [];
++  argument: AssignmentTarget;
++  optional?: false;
++  typeAnnotation?: null;
++  value?: null;
++  parent?: Node;
++}
++type AssignmentTargetMaybeDefault = AssignmentTargetWithDefault | AssignmentTarget;
++interface AssignmentTargetWithDefault extends Span {
++  type: "AssignmentPattern";
++  decorators?: [];
++  left: AssignmentTarget;
++  right: Expression;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty;
++interface AssignmentTargetPropertyIdentifier extends Span {
++  type: "Property";
++  kind: "init";
++  key: IdentifierReference;
++  value: IdentifierReference | AssignmentTargetWithDefault;
++  method: false;
++  shorthand: true;
++  computed: false;
++  optional?: false;
++  parent?: Node;
++}
++interface AssignmentTargetPropertyProperty extends Span {
++  type: "Property";
++  kind: "init";
++  key: PropertyKey;
++  value: AssignmentTargetMaybeDefault;
++  method: false;
++  shorthand: false;
++  computed: boolean;
++  optional?: false;
++  parent?: Node;
++}
++interface SequenceExpression extends Span {
++  type: "SequenceExpression";
++  expressions: Array<Expression>;
++  parent?: Node;
++}
++interface Super extends Span {
++  type: "Super";
++  parent?: Node;
++}
++interface AwaitExpression extends Span {
++  type: "AwaitExpression";
++  argument: Expression;
++  parent?: Node;
++}
++interface ChainExpression extends Span {
++  type: "ChainExpression";
++  expression: ChainElement;
++  parent?: Node;
++}
++type ChainElement = CallExpression | TSNonNullExpression | MemberExpression;
++interface ParenthesizedExpression extends Span {
++  type: "ParenthesizedExpression";
++  expression: Expression;
++  parent?: Node;
++}
++type Statement = BlockStatement | BreakStatement | ContinueStatement | DebuggerStatement | DoWhileStatement | EmptyStatement | ExpressionStatement | ForInStatement | ForOfStatement | ForStatement | IfStatement | LabeledStatement | ReturnStatement | SwitchStatement | ThrowStatement | TryStatement | WhileStatement | WithStatement | Declaration | ModuleDeclaration;
++interface Directive extends Span {
++  type: "ExpressionStatement";
++  expression: StringLiteral;
++  directive: string;
++  parent?: Node;
++}
++interface Hashbang extends Span {
++  type: "Hashbang";
++  value: string;
++  parent?: Node;
++}
++interface BlockStatement extends Span {
++  type: "BlockStatement";
++  body: Array<Statement>;
++  parent?: Node;
++}
++type Declaration = VariableDeclaration | Function | Class | TSTypeAliasDeclaration | TSInterfaceDeclaration | TSEnumDeclaration | TSModuleDeclaration | TSGlobalDeclaration | TSImportEqualsDeclaration;
++interface VariableDeclaration extends Span {
++  type: "VariableDeclaration";
++  kind: VariableDeclarationKind;
++  declarations: Array<VariableDeclarator>;
++  declare?: boolean;
++  parent?: Node;
++}
++type VariableDeclarationKind = "var" | "let" | "const" | "using" | "await using";
++interface VariableDeclarator extends Span {
++  type: "VariableDeclarator";
++  id: BindingPattern;
++  init: Expression | null;
++  definite?: boolean;
++  parent?: Node;
++}
++interface EmptyStatement extends Span {
++  type: "EmptyStatement";
++  parent?: Node;
++}
++interface ExpressionStatement extends Span {
++  type: "ExpressionStatement";
++  expression: Expression;
++  directive?: string | null;
++  parent?: Node;
++}
++interface IfStatement extends Span {
++  type: "IfStatement";
++  test: Expression;
++  consequent: Statement;
++  alternate: Statement | null;
++  parent?: Node;
++}
++interface DoWhileStatement extends Span {
++  type: "DoWhileStatement";
++  body: Statement;
++  test: Expression;
++  parent?: Node;
++}
++interface WhileStatement extends Span {
++  type: "WhileStatement";
++  test: Expression;
++  body: Statement;
++  parent?: Node;
++}
++interface ForStatement extends Span {
++  type: "ForStatement";
++  init: ForStatementInit | null;
++  test: Expression | null;
++  update: Expression | null;
++  body: Statement;
++  parent?: Node;
++}
++type ForStatementInit = VariableDeclaration | Expression;
++interface ForInStatement extends Span {
++  type: "ForInStatement";
++  left: ForStatementLeft;
++  right: Expression;
++  body: Statement;
++  parent?: Node;
++}
++type ForStatementLeft = VariableDeclaration | AssignmentTarget;
++interface ForOfStatement extends Span {
++  type: "ForOfStatement";
++  await: boolean;
++  left: ForStatementLeft;
++  right: Expression;
++  body: Statement;
++  parent?: Node;
++}
++interface ContinueStatement extends Span {
++  type: "ContinueStatement";
++  label: LabelIdentifier | null;
++  parent?: Node;
++}
++interface BreakStatement extends Span {
++  type: "BreakStatement";
++  label: LabelIdentifier | null;
++  parent?: Node;
++}
++interface ReturnStatement extends Span {
++  type: "ReturnStatement";
++  argument: Expression | null;
++  parent?: Node;
++}
++interface WithStatement extends Span {
++  type: "WithStatement";
++  object: Expression;
++  body: Statement;
++  parent?: Node;
++}
++interface SwitchStatement extends Span {
++  type: "SwitchStatement";
++  discriminant: Expression;
++  cases: Array<SwitchCase>;
++  parent?: Node;
++}
++interface SwitchCase extends Span {
++  type: "SwitchCase";
++  test: Expression | null;
++  consequent: Array<Statement>;
++  parent?: Node;
++}
++interface LabeledStatement extends Span {
++  type: "LabeledStatement";
++  label: LabelIdentifier;
++  body: Statement;
++  parent?: Node;
++}
++interface ThrowStatement extends Span {
++  type: "ThrowStatement";
++  argument: Expression;
++  parent?: Node;
++}
++interface TryStatement extends Span {
++  type: "TryStatement";
++  block: BlockStatement;
++  handler: CatchClause | null;
++  finalizer: BlockStatement | null;
++  parent?: Node;
++}
++interface CatchClause extends Span {
++  type: "CatchClause";
++  param: BindingPattern | null;
++  body: BlockStatement;
++  parent?: Node;
++}
++interface DebuggerStatement extends Span {
++  type: "DebuggerStatement";
++  parent?: Node;
++}
++type BindingPattern = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
++interface AssignmentPattern extends Span {
++  type: "AssignmentPattern";
++  decorators?: [];
++  left: BindingPattern;
++  right: Expression;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface ObjectPattern extends Span {
++  type: "ObjectPattern";
++  decorators?: [];
++  properties: Array<BindingProperty | BindingRestElement>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface BindingProperty extends Span {
++  type: "Property";
++  kind: "init";
++  key: PropertyKey;
++  value: BindingPattern;
++  method: false;
++  shorthand: boolean;
++  computed: boolean;
++  optional?: false;
++  parent?: Node;
++}
++interface ArrayPattern extends Span {
++  type: "ArrayPattern";
++  decorators?: [];
++  elements: Array<BindingPattern | BindingRestElement | null>;
++  optional?: false;
++  typeAnnotation?: null;
++  parent?: Node;
++}
++interface BindingRestElement extends Span {
++  type: "RestElement";
++  decorators?: [];
++  argument: BindingPattern;
++  optional?: false;
++  typeAnnotation?: null;
++  value?: null;
++  parent?: Node;
++}
++interface Function extends Span {
++  type: FunctionType;
++  id: BindingIdentifier | null;
++  generator: boolean;
++  async: boolean;
++  declare?: boolean;
++  typeParameters?: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType?: TSTypeAnnotation | null;
++  body: FunctionBody | null;
++  expression: false;
++  parent?: Node;
++}
++type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest;
++type FunctionType = "FunctionDeclaration" | "FunctionExpression" | "TSDeclareFunction" | "TSEmptyBodyFunctionExpression";
++interface FormalParameterRest extends Span {
++  type: "RestElement";
++  argument: BindingPattern;
++  decorators?: [];
++  optional?: boolean;
++  typeAnnotation?: TSTypeAnnotation | null;
++  value?: null;
++  parent?: Node;
++}
++type FormalParameter = {
++  decorators?: Array<Decorator>;
++} & BindingPattern;
++interface TSParameterProperty extends Span {
++  type: "TSParameterProperty";
++  accessibility: TSAccessibility | null;
++  decorators: Array<Decorator>;
++  override: boolean;
++  parameter: FormalParameter;
++  readonly: boolean;
++  static: boolean;
++  parent?: Node;
++}
++interface FunctionBody extends Span {
++  type: "BlockStatement";
++  body: Array<Directive | Statement>;
++  parent?: Node;
++}
++interface ArrowFunctionExpression extends Span {
++  type: "ArrowFunctionExpression";
++  expression: boolean;
++  async: boolean;
++  typeParameters?: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType?: TSTypeAnnotation | null;
++  body: FunctionBody | Expression;
++  id: null;
++  generator: false;
++  parent?: Node;
++}
++interface YieldExpression extends Span {
++  type: "YieldExpression";
++  delegate: boolean;
++  argument: Expression | null;
++  parent?: Node;
++}
++interface Class extends Span {
++  type: ClassType;
++  decorators: Array<Decorator>;
++  id: BindingIdentifier | null;
++  typeParameters?: TSTypeParameterDeclaration | null;
++  superClass: Expression | null;
++  superTypeArguments?: TSTypeParameterInstantiation | null;
++  implements?: Array<TSClassImplements>;
++  body: ClassBody;
++  abstract?: boolean;
++  declare?: boolean;
++  parent?: Node;
++}
++type ClassType = "ClassDeclaration" | "ClassExpression";
++interface ClassBody extends Span {
++  type: "ClassBody";
++  body: Array<ClassElement>;
++  parent?: Node;
++}
++type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition | AccessorProperty | TSIndexSignature;
++interface MethodDefinition extends Span {
++  type: MethodDefinitionType;
++  decorators: Array<Decorator>;
++  key: PropertyKey;
++  value: Function;
++  kind: MethodDefinitionKind;
++  computed: boolean;
++  static: boolean;
++  override?: boolean;
++  optional?: boolean;
++  accessibility?: TSAccessibility | null;
++  parent?: Node;
++}
++type MethodDefinitionType = "MethodDefinition" | "TSAbstractMethodDefinition";
++interface PropertyDefinition extends Span {
++  type: PropertyDefinitionType;
++  decorators: Array<Decorator>;
++  key: PropertyKey;
++  typeAnnotation?: TSTypeAnnotation | null;
++  value: Expression | null;
++  computed: boolean;
++  static: boolean;
++  declare?: boolean;
++  override?: boolean;
++  optional?: boolean;
++  definite?: boolean;
++  readonly?: boolean;
++  accessibility?: TSAccessibility | null;
++  parent?: Node;
++}
++type PropertyDefinitionType = "PropertyDefinition" | "TSAbstractPropertyDefinition";
++type MethodDefinitionKind = "constructor" | "method" | "get" | "set";
++interface PrivateIdentifier extends Span {
++  type: "PrivateIdentifier";
++  name: string;
++  parent?: Node;
++}
++interface StaticBlock extends Span {
++  type: "StaticBlock";
++  body: Array<Statement>;
++  parent?: Node;
++}
++type ModuleDeclaration = ImportDeclaration | ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration | TSExportAssignment | TSNamespaceExportDeclaration;
++type AccessorPropertyType = "AccessorProperty" | "TSAbstractAccessorProperty";
++interface AccessorProperty extends Span {
++  type: AccessorPropertyType;
++  decorators: Array<Decorator>;
++  key: PropertyKey;
++  typeAnnotation?: TSTypeAnnotation | null;
++  value: Expression | null;
++  computed: boolean;
++  static: boolean;
++  override?: boolean;
++  definite?: boolean;
++  accessibility?: TSAccessibility | null;
++  declare?: false;
++  optional?: false;
++  readonly?: false;
++  parent?: Node;
++}
++interface ImportExpression extends Span {
++  type: "ImportExpression";
++  source: Expression;
++  options: Expression | null;
++  phase: ImportPhase | null;
++  parent?: Node;
++}
++interface ImportDeclaration extends Span {
++  type: "ImportDeclaration";
++  specifiers: Array<ImportDeclarationSpecifier>;
++  source: StringLiteral;
++  phase: ImportPhase | null;
++  attributes: Array<ImportAttribute>;
++  importKind?: ImportOrExportKind;
++  parent?: Node;
++}
++type ImportPhase = "source" | "defer";
++type ImportDeclarationSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier;
++interface ImportSpecifier extends Span {
++  type: "ImportSpecifier";
++  imported: ModuleExportName;
++  local: BindingIdentifier;
++  importKind?: ImportOrExportKind;
++  parent?: Node;
++}
++interface ImportDefaultSpecifier extends Span {
++  type: "ImportDefaultSpecifier";
++  local: BindingIdentifier;
++  parent?: Node;
++}
++interface ImportNamespaceSpecifier extends Span {
++  type: "ImportNamespaceSpecifier";
++  local: BindingIdentifier;
++  parent?: Node;
++}
++interface ImportAttribute extends Span {
++  type: "ImportAttribute";
++  key: ImportAttributeKey;
++  value: StringLiteral;
++  parent?: Node;
++}
++type ImportAttributeKey = IdentifierName | StringLiteral;
++interface ExportNamedDeclaration extends Span {
++  type: "ExportNamedDeclaration";
++  declaration: Declaration | null;
++  specifiers: Array<ExportSpecifier>;
++  source: StringLiteral | null;
++  exportKind?: ImportOrExportKind;
++  attributes: Array<ImportAttribute>;
++  parent?: Node;
++}
++interface ExportDefaultDeclaration extends Span {
++  type: "ExportDefaultDeclaration";
++  declaration: ExportDefaultDeclarationKind;
++  exportKind?: "value";
++  parent?: Node;
++}
++interface ExportAllDeclaration extends Span {
++  type: "ExportAllDeclaration";
++  exported: ModuleExportName | null;
++  source: StringLiteral;
++  attributes: Array<ImportAttribute>;
++  exportKind?: ImportOrExportKind;
++  parent?: Node;
++}
++interface ExportSpecifier extends Span {
++  type: "ExportSpecifier";
++  local: ModuleExportName;
++  exported: ModuleExportName;
++  exportKind?: ImportOrExportKind;
++  parent?: Node;
++}
++type ExportDefaultDeclarationKind = Function | Class | TSInterfaceDeclaration | Expression;
++type ModuleExportName = IdentifierName | IdentifierReference | StringLiteral;
++interface V8IntrinsicExpression extends Span {
++  type: "V8IntrinsicExpression";
++  name: IdentifierName;
++  arguments: Array<Argument>;
++  parent?: Node;
++}
++interface BooleanLiteral extends Span {
++  type: "Literal";
++  value: boolean;
++  raw: string | null;
++  parent?: Node;
++}
++interface NullLiteral extends Span {
++  type: "Literal";
++  value: null;
++  raw: "null" | null;
++  parent?: Node;
++}
++interface NumericLiteral extends Span {
++  type: "Literal";
++  value: number;
++  raw: string | null;
++  parent?: Node;
++}
++interface StringLiteral extends Span {
++  type: "Literal";
++  value: string;
++  raw: string | null;
++  parent?: Node;
++}
++interface BigIntLiteral extends Span {
++  type: "Literal";
++  value: bigint;
++  raw: string | null;
++  bigint: string;
++  parent?: Node;
++}
++interface RegExpLiteral extends Span {
++  type: "Literal";
++  value: RegExp | null;
++  raw: string | null;
++  regex: {
++    pattern: string;
++    flags: string;
++  };
++  parent?: Node;
++}
++interface JSXElement extends Span {
++  type: "JSXElement";
++  openingElement: JSXOpeningElement;
++  children: Array<JSXChild>;
++  closingElement: JSXClosingElement | null;
++  parent?: Node;
++}
++interface JSXOpeningElement extends Span {
++  type: "JSXOpeningElement";
++  name: JSXElementName;
++  typeArguments?: TSTypeParameterInstantiation | null;
++  attributes: Array<JSXAttributeItem>;
++  selfClosing: boolean;
++  parent?: Node;
++}
++interface JSXClosingElement extends Span {
++  type: "JSXClosingElement";
++  name: JSXElementName;
++  parent?: Node;
++}
++interface JSXFragment extends Span {
++  type: "JSXFragment";
++  openingFragment: JSXOpeningFragment;
++  children: Array<JSXChild>;
++  closingFragment: JSXClosingFragment;
++  parent?: Node;
++}
++interface JSXOpeningFragment extends Span {
++  type: "JSXOpeningFragment";
++  attributes?: [];
++  selfClosing?: false;
++  parent?: Node;
++}
++interface JSXClosingFragment extends Span {
++  type: "JSXClosingFragment";
++  parent?: Node;
++}
++type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression;
++interface JSXNamespacedName extends Span {
++  type: "JSXNamespacedName";
++  namespace: JSXIdentifier;
++  name: JSXIdentifier;
++  parent?: Node;
++}
++interface JSXMemberExpression extends Span {
++  type: "JSXMemberExpression";
++  object: JSXMemberExpressionObject;
++  property: JSXIdentifier;
++  parent?: Node;
++}
++type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression;
++interface JSXExpressionContainer extends Span {
++  type: "JSXExpressionContainer";
++  expression: JSXExpression;
++  parent?: Node;
++}
++type JSXExpression = JSXEmptyExpression | Expression;
++interface JSXEmptyExpression extends Span {
++  type: "JSXEmptyExpression";
++  parent?: Node;
++}
++type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;
++interface JSXAttribute extends Span {
++  type: "JSXAttribute";
++  name: JSXAttributeName;
++  value: JSXAttributeValue | null;
++  parent?: Node;
++}
++interface JSXSpreadAttribute extends Span {
++  type: "JSXSpreadAttribute";
++  argument: Expression;
++  parent?: Node;
++}
++type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
++type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;
++interface JSXIdentifier extends Span {
++  type: "JSXIdentifier";
++  name: string;
++  parent?: Node;
++}
++type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
++interface JSXSpreadChild extends Span {
++  type: "JSXSpreadChild";
++  expression: Expression;
++  parent?: Node;
++}
++interface JSXText extends Span {
++  type: "JSXText";
++  value: string;
++  raw: string | null;
++  parent?: Node;
++}
++interface TSThisParameter extends Span {
++  type: "Identifier";
++  decorators: [];
++  name: "this";
++  optional: false;
++  typeAnnotation: TSTypeAnnotation | null;
++  parent?: Node;
++}
++interface TSEnumDeclaration extends Span {
++  type: "TSEnumDeclaration";
++  id: BindingIdentifier;
++  body: TSEnumBody;
++  const: boolean;
++  declare: boolean;
++  parent?: Node;
++}
++interface TSEnumBody extends Span {
++  type: "TSEnumBody";
++  members: Array<TSEnumMember>;
++  parent?: Node;
++}
++interface TSEnumMember extends Span {
++  type: "TSEnumMember";
++  id: TSEnumMemberName;
++  initializer: Expression | null;
++  computed: boolean;
++  parent?: Node;
++}
++type TSEnumMemberName = IdentifierName | StringLiteral | TemplateLiteral;
++interface TSTypeAnnotation extends Span {
++  type: "TSTypeAnnotation";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSLiteralType extends Span {
++  type: "TSLiteralType";
++  literal: TSLiteral;
++  parent?: Node;
++}
++type TSLiteral = BooleanLiteral | NumericLiteral | BigIntLiteral | StringLiteral | TemplateLiteral | UnaryExpression;
++type TSType = TSAnyKeyword | TSBigIntKeyword | TSBooleanKeyword | TSIntrinsicKeyword | TSNeverKeyword | TSNullKeyword | TSNumberKeyword | TSObjectKeyword | TSStringKeyword | TSSymbolKeyword | TSUndefinedKeyword | TSUnknownKeyword | TSVoidKeyword | TSArrayType | TSConditionalType | TSConstructorType | TSFunctionType | TSImportType | TSIndexedAccessType | TSInferType | TSIntersectionType | TSLiteralType | TSMappedType | TSNamedTupleMember | TSTemplateLiteralType | TSThisType | TSTupleType | TSTypeLiteral | TSTypeOperator | TSTypePredicate | TSTypeQuery | TSTypeReference | TSUnionType | TSParenthesizedType | JSDocNullableType | JSDocNonNullableType | JSDocUnknownType;
++interface TSConditionalType extends Span {
++  type: "TSConditionalType";
++  checkType: TSType;
++  extendsType: TSType;
++  trueType: TSType;
++  falseType: TSType;
++  parent?: Node;
++}
++interface TSUnionType extends Span {
++  type: "TSUnionType";
++  types: Array<TSType>;
++  parent?: Node;
++}
++interface TSIntersectionType extends Span {
++  type: "TSIntersectionType";
++  types: Array<TSType>;
++  parent?: Node;
++}
++interface TSParenthesizedType extends Span {
++  type: "TSParenthesizedType";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSTypeOperator extends Span {
++  type: "TSTypeOperator";
++  operator: TSTypeOperatorOperator;
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++type TSTypeOperatorOperator = "keyof" | "unique" | "readonly";
++interface TSArrayType extends Span {
++  type: "TSArrayType";
++  elementType: TSType;
++  parent?: Node;
++}
++interface TSIndexedAccessType extends Span {
++  type: "TSIndexedAccessType";
++  objectType: TSType;
++  indexType: TSType;
++  parent?: Node;
++}
++interface TSTupleType extends Span {
++  type: "TSTupleType";
++  elementTypes: Array<TSTupleElement>;
++  parent?: Node;
++}
++interface TSNamedTupleMember extends Span {
++  type: "TSNamedTupleMember";
++  label: IdentifierName;
++  elementType: TSTupleElement;
++  optional: boolean;
++  parent?: Node;
++}
++interface TSOptionalType extends Span {
++  type: "TSOptionalType";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSRestType extends Span {
++  type: "TSRestType";
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++type TSTupleElement = TSOptionalType | TSRestType | TSType;
++interface TSAnyKeyword extends Span {
++  type: "TSAnyKeyword";
++  parent?: Node;
++}
++interface TSStringKeyword extends Span {
++  type: "TSStringKeyword";
++  parent?: Node;
++}
++interface TSBooleanKeyword extends Span {
++  type: "TSBooleanKeyword";
++  parent?: Node;
++}
++interface TSNumberKeyword extends Span {
++  type: "TSNumberKeyword";
++  parent?: Node;
++}
++interface TSNeverKeyword extends Span {
++  type: "TSNeverKeyword";
++  parent?: Node;
++}
++interface TSIntrinsicKeyword extends Span {
++  type: "TSIntrinsicKeyword";
++  parent?: Node;
++}
++interface TSUnknownKeyword extends Span {
++  type: "TSUnknownKeyword";
++  parent?: Node;
++}
++interface TSNullKeyword extends Span {
++  type: "TSNullKeyword";
++  parent?: Node;
++}
++interface TSUndefinedKeyword extends Span {
++  type: "TSUndefinedKeyword";
++  parent?: Node;
++}
++interface TSVoidKeyword extends Span {
++  type: "TSVoidKeyword";
++  parent?: Node;
++}
++interface TSSymbolKeyword extends Span {
++  type: "TSSymbolKeyword";
++  parent?: Node;
++}
++interface TSThisType extends Span {
++  type: "TSThisType";
++  parent?: Node;
++}
++interface TSObjectKeyword extends Span {
++  type: "TSObjectKeyword";
++  parent?: Node;
++}
++interface TSBigIntKeyword extends Span {
++  type: "TSBigIntKeyword";
++  parent?: Node;
++}
++interface TSTypeReference extends Span {
++  type: "TSTypeReference";
++  typeName: TSTypeName;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++type TSTypeName = IdentifierReference | TSQualifiedName | ThisExpression;
++interface TSQualifiedName extends Span {
++  type: "TSQualifiedName";
++  left: TSTypeName;
++  right: IdentifierName;
++  parent?: Node;
++}
++interface TSTypeParameterInstantiation extends Span {
++  type: "TSTypeParameterInstantiation";
++  params: Array<TSType>;
++  parent?: Node;
++}
++interface TSTypeParameter extends Span {
++  type: "TSTypeParameter";
++  name: BindingIdentifier;
++  constraint: TSType | null;
++  default: TSType | null;
++  in: boolean;
++  out: boolean;
++  const: boolean;
++  parent?: Node;
++}
++interface TSTypeParameterDeclaration extends Span {
++  type: "TSTypeParameterDeclaration";
++  params: Array<TSTypeParameter>;
++  parent?: Node;
++}
++interface TSTypeAliasDeclaration extends Span {
++  type: "TSTypeAliasDeclaration";
++  id: BindingIdentifier;
++  typeParameters: TSTypeParameterDeclaration | null;
++  typeAnnotation: TSType;
++  declare: boolean;
++  parent?: Node;
++}
++type TSAccessibility = "private" | "protected" | "public";
++interface TSClassImplements extends Span {
++  type: "TSClassImplements";
++  expression: IdentifierReference | ThisExpression | MemberExpression;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++interface TSInterfaceDeclaration extends Span {
++  type: "TSInterfaceDeclaration";
++  id: BindingIdentifier;
++  typeParameters: TSTypeParameterDeclaration | null;
++  extends: Array<TSInterfaceHeritage>;
++  body: TSInterfaceBody;
++  declare: boolean;
++  parent?: Node;
++}
++interface TSInterfaceBody extends Span {
++  type: "TSInterfaceBody";
++  body: Array<TSSignature>;
++  parent?: Node;
++}
++interface TSPropertySignature extends Span {
++  type: "TSPropertySignature";
++  computed: boolean;
++  optional: boolean;
++  readonly: boolean;
++  key: PropertyKey;
++  typeAnnotation: TSTypeAnnotation | null;
++  accessibility: null;
++  static: false;
++  parent?: Node;
++}
++type TSSignature = TSIndexSignature | TSPropertySignature | TSCallSignatureDeclaration | TSConstructSignatureDeclaration | TSMethodSignature;
++interface TSIndexSignature extends Span {
++  type: "TSIndexSignature";
++  parameters: Array<TSIndexSignatureName>;
++  typeAnnotation: TSTypeAnnotation;
++  readonly: boolean;
++  static: boolean;
++  accessibility: null;
++  parent?: Node;
++}
++interface TSCallSignatureDeclaration extends Span {
++  type: "TSCallSignatureDeclaration";
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation | null;
++  parent?: Node;
++}
++type TSMethodSignatureKind = "method" | "get" | "set";
++interface TSMethodSignature extends Span {
++  type: "TSMethodSignature";
++  key: PropertyKey;
++  computed: boolean;
++  optional: boolean;
++  kind: TSMethodSignatureKind;
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation | null;
++  accessibility: null;
++  readonly: false;
++  static: false;
++  parent?: Node;
++}
++interface TSConstructSignatureDeclaration extends Span {
++  type: "TSConstructSignatureDeclaration";
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation | null;
++  parent?: Node;
++}
++interface TSIndexSignatureName extends Span {
++  type: "Identifier";
++  decorators: [];
++  name: string;
++  optional: false;
++  typeAnnotation: TSTypeAnnotation;
++  parent?: Node;
++}
++interface TSInterfaceHeritage extends Span {
++  type: "TSInterfaceHeritage";
++  expression: Expression;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++interface TSTypePredicate extends Span {
++  type: "TSTypePredicate";
++  parameterName: TSTypePredicateName;
++  asserts: boolean;
++  typeAnnotation: TSTypeAnnotation | null;
++  parent?: Node;
++}
++type TSTypePredicateName = IdentifierName | TSThisType;
++interface TSModuleDeclaration extends Span {
++  type: "TSModuleDeclaration";
++  id: BindingIdentifier | StringLiteral | TSQualifiedName;
++  body: TSModuleBlock | null;
++  kind: TSModuleDeclarationKind;
++  declare: boolean;
++  global: false;
++  parent?: Node;
++}
++type TSModuleDeclarationKind = "module" | "namespace";
++interface TSGlobalDeclaration extends Span {
++  type: "TSModuleDeclaration";
++  id: IdentifierName;
++  body: TSModuleBlock;
++  kind: "global";
++  declare: boolean;
++  global: true;
++  parent?: Node;
++}
++interface TSModuleBlock extends Span {
++  type: "TSModuleBlock";
++  body: Array<Directive | Statement>;
++  parent?: Node;
++}
++interface TSTypeLiteral extends Span {
++  type: "TSTypeLiteral";
++  members: Array<TSSignature>;
++  parent?: Node;
++}
++interface TSInferType extends Span {
++  type: "TSInferType";
++  typeParameter: TSTypeParameter;
++  parent?: Node;
++}
++interface TSTypeQuery extends Span {
++  type: "TSTypeQuery";
++  exprName: TSTypeQueryExprName;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++type TSTypeQueryExprName = TSImportType | TSTypeName;
++interface TSImportType extends Span {
++  type: "TSImportType";
++  source: StringLiteral;
++  options: ObjectExpression | null;
++  qualifier: TSImportTypeQualifier | null;
++  typeArguments: TSTypeParameterInstantiation | null;
++  parent?: Node;
++}
++type TSImportTypeQualifier = IdentifierName | TSImportTypeQualifiedName;
++interface TSImportTypeQualifiedName extends Span {
++  type: "TSQualifiedName";
++  left: TSImportTypeQualifier;
++  right: IdentifierName;
++  parent?: Node;
++}
++interface TSFunctionType extends Span {
++  type: "TSFunctionType";
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation;
++  parent?: Node;
++}
++interface TSConstructorType extends Span {
++  type: "TSConstructorType";
++  abstract: boolean;
++  typeParameters: TSTypeParameterDeclaration | null;
++  params: ParamPattern[];
++  returnType: TSTypeAnnotation;
++  parent?: Node;
++}
++interface TSMappedType extends Span {
++  type: "TSMappedType";
++  key: BindingIdentifier;
++  constraint: TSType;
++  nameType: TSType | null;
++  typeAnnotation: TSType | null;
++  optional: TSMappedTypeModifierOperator | false;
++  readonly: TSMappedTypeModifierOperator | null;
++  parent?: Node;
++}
++type TSMappedTypeModifierOperator = true | "+" | "-";
++interface TSTemplateLiteralType extends Span {
++  type: "TSTemplateLiteralType";
++  quasis: Array<TemplateElement>;
++  types: Array<TSType>;
++  parent?: Node;
++}
++interface TSAsExpression extends Span {
++  type: "TSAsExpression";
++  expression: Expression;
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSSatisfiesExpression extends Span {
++  type: "TSSatisfiesExpression";
++  expression: Expression;
++  typeAnnotation: TSType;
++  parent?: Node;
++}
++interface TSTypeAssertion extends Span {
++  type: "TSTypeAssertion";
++  typeAnnotation: TSType;
++  expression: Expression;
++  parent?: Node;
++}
++interface TSImportEqualsDeclaration extends Span {
++  type: "TSImportEqualsDeclaration";
++  id: BindingIdentifier;
++  moduleReference: TSModuleReference;
++  importKind: ImportOrExportKind;
++  parent?: Node;
++}
++type TSModuleReference = TSExternalModuleReference | IdentifierReference | TSQualifiedName;
++interface TSExternalModuleReference extends Span {
++  type: "TSExternalModuleReference";
++  expression: StringLiteral;
++  parent?: Node;
++}
++interface TSNonNullExpression extends Span {
++  type: "TSNonNullExpression";
++  expression: Expression;
++  parent?: Node;
++}
++interface Decorator extends Span {
++  type: "Decorator";
++  expression: Expression;
++  parent?: Node;
++}
++interface TSExportAssignment extends Span {
++  type: "TSExportAssignment";
++  expression: Expression;
++  parent?: Node;
++}
++interface TSNamespaceExportDeclaration extends Span {
++  type: "TSNamespaceExportDeclaration";
++  id: IdentifierName;
++  parent?: Node;
++}
++interface TSInstantiationExpression extends Span {
++  type: "TSInstantiationExpression";
++  expression: Expression;
++  typeArguments: TSTypeParameterInstantiation;
++  parent?: Node;
++}
++type ImportOrExportKind = "value" | "type";
++interface JSDocNullableType extends Span {
++  type: "TSJSDocNullableType";
++  typeAnnotation: TSType;
++  postfix: boolean;
++  parent?: Node;
++}
++interface JSDocNonNullableType extends Span {
++  type: "TSJSDocNonNullableType";
++  typeAnnotation: TSType;
++  postfix: boolean;
++  parent?: Node;
++}
++interface JSDocUnknownType extends Span {
++  type: "TSJSDocUnknownType";
++  parent?: Node;
++}
++type AssignmentOperator = "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" | "<<=" | ">>=" | ">>>=" | "|=" | "^=" | "&=" | "||=" | "&&=" | "??=";
++type BinaryOperator = "==" | "!=" | "===" | "!==" | "<" | "<=" | ">" | ">=" | "+" | "-" | "*" | "/" | "%" | "**" | "<<" | ">>" | ">>>" | "|" | "^" | "&" | "in" | "instanceof";
++type LogicalOperator = "||" | "&&" | "??";
++type UnaryOperator = "+" | "-" | "!" | "~" | "typeof" | "void" | "delete";
++type UpdateOperator = "++" | "--";
++interface Span {
++  start: number;
++  end: number;
++  range?: [number, number];
++}
++type ModuleKind = "script" | "module" | "commonjs";
++type Node = Program | IdentifierName | IdentifierReference | BindingIdentifier | LabelIdentifier | ThisExpression | ArrayExpression | ObjectExpression | ObjectProperty | TemplateLiteral | TaggedTemplateExpression | TemplateElement | ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression | CallExpression | NewExpression | MetaProperty | SpreadElement | UpdateExpression | UnaryExpression | BinaryExpression | PrivateInExpression | LogicalExpression | ConditionalExpression | AssignmentExpression | ArrayAssignmentTarget | ObjectAssignmentTarget | AssignmentTargetRest | AssignmentTargetWithDefault | AssignmentTargetPropertyIdentifier | AssignmentTargetPropertyProperty | SequenceExpression | Super | AwaitExpression | ChainExpression | ParenthesizedExpression | Directive | Hashbang | BlockStatement | VariableDeclaration | VariableDeclarator | EmptyStatement | ExpressionStatement | IfStatement | DoWhileStatement | WhileStatement | ForStatement | ForInStatement | ForOfStatement | ContinueStatement | BreakStatement | ReturnStatement | WithStatement | SwitchStatement | SwitchCase | LabeledStatement | ThrowStatement | TryStatement | CatchClause | DebuggerStatement | AssignmentPattern | ObjectPattern | BindingProperty | ArrayPattern | BindingRestElement | Function | FunctionBody | ArrowFunctionExpression | YieldExpression | Class | ClassBody | MethodDefinition | PropertyDefinition | PrivateIdentifier | StaticBlock | AccessorProperty | ImportExpression | ImportDeclaration | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ImportAttribute | ExportNamedDeclaration | ExportDefaultDeclaration | ExportAllDeclaration | ExportSpecifier | V8IntrinsicExpression | BooleanLiteral | NullLiteral | NumericLiteral | StringLiteral | BigIntLiteral | RegExpLiteral | JSXElement | JSXOpeningElement | JSXClosingElement | JSXFragment | JSXOpeningFragment | JSXClosingFragment | JSXNamespacedName | JSXMemberExpression | JSXExpressionContainer | JSXEmptyExpression | JSXAttribute | JSXSpreadAttribute | JSXIdentifier | JSXSpreadChild | JSXText | TSThisParameter | TSEnumDeclaration | TSEnumBody | TSEnumMember | TSTypeAnnotation | TSLiteralType | TSConditionalType | TSUnionType | TSIntersectionType | TSParenthesizedType | TSTypeOperator | TSArrayType | TSIndexedAccessType | TSTupleType | TSNamedTupleMember | TSOptionalType | TSRestType | TSAnyKeyword | TSStringKeyword | TSBooleanKeyword | TSNumberKeyword | TSNeverKeyword | TSIntrinsicKeyword | TSUnknownKeyword | TSNullKeyword | TSUndefinedKeyword | TSVoidKeyword | TSSymbolKeyword | TSThisType | TSObjectKeyword | TSBigIntKeyword | TSTypeReference | TSQualifiedName | TSTypeParameterInstantiation | TSTypeParameter | TSTypeParameterDeclaration | TSTypeAliasDeclaration | TSClassImplements | TSInterfaceDeclaration | TSInterfaceBody | TSPropertySignature | TSIndexSignature | TSCallSignatureDeclaration | TSMethodSignature | TSConstructSignatureDeclaration | TSIndexSignatureName | TSInterfaceHeritage | TSTypePredicate | TSModuleDeclaration | TSGlobalDeclaration | TSModuleBlock | TSTypeLiteral | TSInferType | TSTypeQuery | TSImportType | TSImportTypeQualifiedName | TSFunctionType | TSConstructorType | TSMappedType | TSTemplateLiteralType | TSAsExpression | TSSatisfiesExpression | TSTypeAssertion | TSImportEqualsDeclaration | TSExternalModuleReference | TSNonNullExpression | Decorator | TSExportAssignment | TSNamespaceExportDeclaration | TSInstantiationExpression | JSDocNullableType | JSDocNonNullableType | JSDocUnknownType | ParamPattern;
++//#endregion
++//#region node_modules/.pnpm/rolldown@1.0.0-rc.7_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0/node_modules/rolldown/dist/shared/binding-BohGL_65.d.mts
++interface ParserOptions {
++  /** Treat the source text as `js`, `jsx`, `ts`, `tsx` or `dts`. */
++  lang?: 'js' | 'jsx' | 'ts' | 'tsx' | 'dts';
++  /** Treat the source text as `script` or `module` code. */
++  sourceType?: 'script' | 'module' | 'commonjs' | 'unambiguous' | undefined;
++  /**
++   * Return an AST which includes TypeScript-related properties, or excludes them.
++   *
++   * `'js'` is default for JS / JSX files.
++   * `'ts'` is default for TS / TSX files.
++   * The type of the file is determined from `lang` option, or extension of provided `filename`.
++   */
++  astType?: 'js' | 'ts';
++  /**
++   * Controls whether the `range` property is included on AST nodes.
++   * The `range` property is a `[number, number]` which indicates the start/end offsets
++   * of the node in the file contents.
++   *
++   * @default false
++   */
++  range?: boolean;
++  /**
++   * Emit `ParenthesizedExpression` and `TSParenthesizedType` in AST.
++   *
++   * If this option is true, parenthesized expressions are represented by
++   * (non-standard) `ParenthesizedExpression` and `TSParenthesizedType` nodes that
++   * have a single `expression` property containing the expression inside parentheses.
++   *
++   * @default true
++   */
++  preserveParens?: boolean;
++  /**
++   * Produce semantic errors with an additional AST pass.
++   * Semantic errors depend on symbols and scopes, where the parser does not construct.
++   * This adds a small performance overhead.
++   *
++   * @default false
++   */
++  showSemanticErrors?: boolean;
++}
++interface BindingPluginContextResolveOptions {
++  /**
++   * - `import-statement`: `import { foo } from './lib.js';`
++   * - `dynamic-import`: `import('./lib.js')`
++   * - `require-call`: `require('./lib.js')`
++   * - `import-rule`: `@import 'bg-color.css'`
++   * - `url-token`: `url('./icon.png')`
++   * - `new-url`: `new URL('./worker.js', import.meta.url)`
++   * - `hot-accept`: `import.meta.hot.accept('./lib.js', () => {})`
++   */
++  importKind?: 'import-statement' | 'dynamic-import' | 'require-call' | 'import-rule' | 'url-token' | 'new-url' | 'hot-accept';
++  isEntry?: boolean;
++  skipSelf?: boolean;
++  custom?: number;
++  vitePluginCustom?: BindingVitePluginCustom;
++}
++interface BindingVitePluginCustom {
++  'vite:import-glob'?: ViteImportGlobMeta;
++}
++interface ViteImportGlobMeta {
++  isSubImportsPattern?: boolean;
++} //#endregion
++//#endregion
++//#region node_modules/.pnpm/rolldown@1.0.0-rc.7_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0/node_modules/rolldown/dist/shared/define-config-BqZZMLjO.d.mts
++//#endregion
++//#region src/types/module-info.d.ts
++/** @category Plugin APIs */
++interface ModuleInfo extends ModuleOptions {
++  /**
++  * @hidden Not supported by Rolldown
++  */
++  ast: any;
++  /**
++  * The source code of the module.
++  *
++  * `null` if external or not yet available.
++  */
++  code: string | null;
++  /**
++  * The id of the module for convenience
++  */
++  id: string;
++  /**
++  * The ids of all modules that statically import this module.
++  */
++  importers: string[];
++  /**
++  * The ids of all modules that dynamically import this module.
++  */
++  dynamicImporters: string[];
++  /**
++  * The module ids statically imported by this module.
++  */
++  importedIds: string[];
++  /**
++  * The module ids dynamically imported by this module.
++  */
++  dynamicallyImportedIds: string[];
++  /**
++  * All exported variables
++  */
++  exports: string[];
++  /**
++  * Whether this module is a user- or plugin-defined entry point.
++  */
++  isEntry: boolean;
++  /**
++  * The detected format of the module, based on both its syntax and module definition
++  * metadata (such as `package.json` `type` and file extensions like `.mjs`/`.cjs`/`.mts`/`.cts`).
++  * - "esm" for ES modules (has `import`/`export` statements or is defined as ESM by module metadata)
++  * - "cjs" for CommonJS modules (uses `module.exports`, `exports`, top-level `return`, or is defined as CommonJS by module metadata)
++  * - "unknown" when the format could not be determined from either syntax or module definition metadata
++  *
++  * @experimental
++  */
++  inputFormat: "es" | "cjs" | "unknown";
++} //#endregion
++//#region src/utils/asset-source.d.ts
++/** @inline */
++type AssetSource = string | Uint8Array; //#endregion
++//#region src/types/external-memory-handle.d.ts
++/** @category Plugin APIs */
++interface SourceMap {
++  file: string;
++  mappings: string;
++  names: string[];
++  sources: string[];
++  sourcesContent: string[];
++  version: number;
++  debugId?: string;
++  x_google_ignoreList?: number[];
++  toString(): string;
++  toUrl(): string;
++}
++/** @category Plugin APIs */
++type PartialNull<T> = { [P in keyof T]: T[P] | null };
++//#endregion
++//#region src/log/log-handler.d.ts
++type LoggingFunction = (log: RolldownLog | string | (() => RolldownLog | string)) => void;
++//#endregion
++//#region src/plugin/fs.d.ts
++/** @category Plugin APIs */
++interface RolldownFsModule {
++  appendFile(path: string, data: string | Uint8Array, options?: {
++    encoding?: BufferEncoding | null;
++    mode?: string | number;
++    flag?: string | number;
++  }): Promise<void>;
++  copyFile(source: string, destination: string, mode?: string | number): Promise<void>;
++  mkdir(path: string, options?: {
++    recursive?: boolean;
++    mode?: string | number;
++  }): Promise<void>;
++  mkdtemp(prefix: string): Promise<string>;
++  readdir(path: string, options?: {
++    withFileTypes?: false;
++  }): Promise<string[]>;
++  readdir(path: string, options?: {
++    withFileTypes: true;
++  }): Promise<RolldownDirectoryEntry[]>;
++  readFile(path: string, options?: {
++    encoding?: null;
++    flag?: string | number;
++    signal?: AbortSignal;
++  }): Promise<Uint8Array>;
++  readFile(path: string, options?: {
++    encoding: BufferEncoding;
++    flag?: string | number;
++    signal?: AbortSignal;
++  }): Promise<string>;
++  realpath(path: string): Promise<string>;
++  rename(oldPath: string, newPath: string): Promise<void>;
++  rmdir(path: string, options?: {
++    recursive?: boolean;
++  }): Promise<void>;
++  stat(path: string): Promise<RolldownFileStats>;
++  lstat(path: string): Promise<RolldownFileStats>;
++  unlink(path: string): Promise<void>;
++  writeFile(path: string, data: string | Uint8Array, options?: {
++    encoding?: BufferEncoding | null;
++    mode?: string | number;
++    flag?: string | number;
++  }): Promise<void>;
++}
++/** @category Plugin APIs */
++type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "binary" | "hex";
++/** @category Plugin APIs */
++interface RolldownDirectoryEntry {
++  isFile(): boolean;
++  isDirectory(): boolean;
++  isSymbolicLink(): boolean;
++  name: string;
++}
++/** @category Plugin APIs */
++interface RolldownFileStats {
++  isFile(): boolean;
++  isDirectory(): boolean;
++  isSymbolicLink(): boolean;
++  size: number;
++  mtime: Date;
++  ctime: Date;
++  atime: Date;
++  birthtime: Date;
++} //#endregion
++//#region src/plugin/hook-filter.d.ts
++/** @category Plugin APIs */
++//#endregion
++//#region src/plugin/minimal-plugin-context.d.ts
++/** @category Plugin APIs */
++interface PluginContextMeta {
++  /**
++  * A property for Rollup compatibility. A dummy value is set by Rolldown.
++  * @example `'4.23.0'`
++  */
++  rollupVersion: string;
++  /**
++  * The currently running version of Rolldown.
++  * @example `'1.0.0'`
++  */
++  rolldownVersion: string;
++  /**
++  * Whether Rolldown was started via {@linkcode watch | rolldown.watch()} or
++  * from the command line with `--watch`.
++  */
++  watchMode: boolean;
++}
++/** @category Plugin APIs */
++interface MinimalPluginContext {
++  /** @hidden */
++  readonly pluginName: string;
++  /**
++  * Similar to {@linkcode warn | this.warn}, except that it will also abort
++  * the bundling process with an error.
++  *
++  * If an Error instance is passed, it will be used as-is, otherwise a new Error
++  * instance will be created with the given error message and all additional
++  * provided properties.
++  *
++  * In all hooks except the {@linkcode Plugin.onLog | onLog} hook, the error will
++  * be augmented with {@linkcode RolldownLog.code | code: "PLUGIN_ERROR"} and
++  * {@linkcode RolldownLog.plugin | plugin: plugin.name} properties.
++  * If a `code` property already exists and the code does not start with `PLUGIN_`,
++  * it will be renamed to {@linkcode RolldownLog.pluginCode | pluginCode}.
++  *
++  * @group Logging Methods
++  */
++  error: (e: RolldownError | string) => never;
++  /**
++  * Generate a `"info"` level log.
++  *
++  * {@linkcode RolldownLog.code | code} will be set to `"PLUGIN_LOG"` by Rolldown.
++  * As these logs are displayed by default, use them for information that is not a warning
++  * but makes sense to display to all users on every build.
++  *
++  *
++  *
++  * @inlineType LoggingFunction
++  * @group Logging Methods
++  */
++  info: LoggingFunction;
++  /**
++  * Generate a `"warn"` level log.
++  *
++  * Just like internally generated warnings, these logs will be first passed to and
++  * filtered by plugin {@linkcode Plugin.onLog | onLog} hooks before they are forwarded
++  * to custom {@linkcode InputOptions.onLog | onLog} or
++  * {@linkcode InputOptions.onwarn | onwarn} handlers or printed to the console.
++  *
++  * We encourage you to use objects with a {@linkcode RolldownLog.pluginCode | pluginCode}
++  * property as that will allow users to easily filter for those logs in an `onLog` handler.
++  *
++  *
++  *
++  * @inlineType LoggingFunction
++  * @group Logging Methods
++  */
++  warn: LoggingFunction;
++  /**
++  * Generate a `"debug"` level log.
++  *
++  * {@linkcode RolldownLog.code | code} will be set to `"PLUGIN_LOG"` by Rolldown.
++  * Make sure to add a distinctive {@linkcode RolldownLog.pluginCode | pluginCode} to
++  * those logs for easy filtering.
++  *
++  *
++  *
++  * @inlineType LoggingFunction
++  * @group Logging Methods
++  */
++  debug: LoggingFunction;
++  /** An object containing potentially useful metadata. */
++  meta: PluginContextMeta;
++} //#endregion
++//#region src/plugin/parallel-plugin.d.ts
++//#endregion
++//#region src/plugin/plugin-context.d.ts
++/**
++* Either a {@linkcode name} or a {@linkcode fileName} can be supplied.
++* If a {@linkcode fileName} is provided, it will be used unmodified as the name
++* of the generated file, throwing an error if this causes a conflict.
++* Otherwise, if a {@linkcode name} is supplied, this will be used as substitution
++* for `[name]` in the corresponding
++* {@linkcode OutputOptions.assetFileNames | output.assetFileNames} pattern, possibly
++* adding a unique number to the end of the file name to avoid conflicts.
++* If neither a {@linkcode name} nor {@linkcode fileName} is supplied, a default name will be used.
++*
++* @category Plugin APIs
++*/
++interface EmittedAsset {
++  type: "asset";
++  name?: string;
++  fileName?: string;
++  /**
++  * An absolute path to the original file if this asset corresponds to a file on disk.
++  *
++  * This property will be passed on to subsequent plugin hooks that receive a
++  * {@linkcode PreRenderedAsset} or an {@linkcode OutputAsset} like
++  * {@linkcode Plugin.generateBundle | generateBundle}.
++  * In watch mode, Rolldown will also automatically watch this file for changes and
++  * trigger a rebuild if it changes. Therefore, it is not necessary to call
++  * {@linkcode PluginContext.addWatchFile | this.addWatchFile} for this file.
++  */
++  originalFileName?: string;
++  source: AssetSource;
++}
++/**
++* Either a {@linkcode name} or a {@linkcode fileName} can be supplied.
++* If a {@linkcode fileName} is provided, it will be used unmodified as the name
++* of the generated file, throwing an error if this causes a conflict.
++* Otherwise, if a {@linkcode name} is supplied, this will be used as substitution
++* for `[name]` in the corresponding
++* {@linkcode OutputOptions.chunkFileNames | output.chunkFileNames} pattern, possibly
++* adding a unique number to the end of the file name to avoid conflicts.
++* If neither a {@linkcode name} nor {@linkcode fileName} is supplied, a default name will be used.
++*
++* @category Plugin APIs
++*/
++interface EmittedChunk {
++  type: "chunk";
++  name?: string;
++  fileName?: string;
++  /**
++  * When provided, this will override
++  * {@linkcode InputOptions.preserveEntrySignatures | preserveEntrySignatures} for this particular
++  * chunk.
++  */
++  preserveSignature?: "strict" | "allow-extension" | "exports-only" | false;
++  /**
++  * The module id of the entry point of the chunk.
++  *
++  * It will be passed through build hooks just like regular entry points,
++  * starting with {@linkcode Plugin.resolveId | resolveId}.
++  */
++  id: string;
++  /**
++  * The value to be passed to {@linkcode Plugin.resolveId | resolveId}'s {@linkcode importer} parameter when resolving the entry point.
++  * This is important to properly resolve relative paths. If it is not provided,
++  * paths will be resolved relative to the current working directory.
++  */
++  importer?: string;
++}
++/** @category Plugin APIs */
++interface EmittedPrebuiltChunk {
++  type: "prebuilt-chunk";
++  fileName: string;
++  /**
++  * A semantic name for the chunk. If not provided, `fileName` will be used.
++  */
++  name?: string;
++  /**
++  * The code of this chunk.
++  */
++  code: string;
++  /**
++  * The list of exported variable names from this chunk.
++  *
++  * This should be provided if the chunk exports any variables.
++  */
++  exports?: string[];
++  /**
++  * The corresponding source map for this chunk.
++  */
++  map?: SourceMap;
++  sourcemapFileName?: string;
++  /**
++  * The module id of the facade module for this chunk, if any.
++  */
++  facadeModuleId?: string;
++  /**
++  * Whether this chunk corresponds to an entry point.
++  */
++  isEntry?: boolean;
++  /**
++  * Whether this chunk corresponds to a dynamic entry point.
++  */
++  isDynamicEntry?: boolean;
++}
++/** @inline @category Plugin APIs */
++type EmittedFile = EmittedAsset | EmittedChunk | EmittedPrebuiltChunk;
++/** @category Plugin APIs */
++interface PluginContextResolveOptions {
++  /**
++  * The value for {@linkcode ResolveIdExtraOptions.kind | kind} passed to
++  * {@linkcode Plugin.resolveId | resolveId} hooks.
++  */
++  kind?: BindingPluginContextResolveOptions["importKind"];
++  /**
++  * The value for {@linkcode ResolveIdExtraOptions.isEntry | isEntry} passed to
++  * {@linkcode Plugin.resolveId | resolveId} hooks.
++  *
++  * @default `false` if there's an importer, `true` otherwise.
++  */
++  isEntry?: boolean;
++  /**
++  * Whether the {@linkcode Plugin.resolveId | resolveId} hook of the plugin from
++  * which {@linkcode PluginContext.resolve | this.resolve} is called will be skipped
++  * when resolving.
++  *
++  *
++  *
++  * @default true
++  */
++  skipSelf?: boolean;
++  /**
++  * Plugin-specific options.
++  *
++  * See [Custom resolver options section](https://rolldown.rs/apis/plugin-api/inter-plugin-communication#custom-resolver-options) for more details.
++  */
++  custom?: CustomPluginOptions;
++}
++/** @inline */
++type GetModuleInfo = (moduleId: string) => ModuleInfo | null;
++/** @category Plugin APIs */
++interface PluginContext extends MinimalPluginContext {
++  /**
++  * Provides abstract access to the file system.
++  */
++  fs: RolldownFsModule;
++  /**
++  * Emits a new file that is included in the build output.
++  * You can emit chunks, prebuilt chunks or assets.
++  *
++  *
++  *
++  * @returns A `referenceId` for the emitted file that can be used in various places to reference the emitted file.
++  */
++  emitFile(file: EmittedFile): string;
++  /**
++  * Get the file name of a chunk or asset that has been emitted via
++  * {@linkcode emitFile | this.emitFile}.
++  *
++  * @returns The file name of the emitted file. Relative to {@linkcode OutputOptions.dir | output.dir}.
++  */
++  getFileName(referenceId: string): string;
++  /**
++  * Get all module ids in the current module graph.
++  *
++  * @returns
++  * An iterator of module ids. It can be iterated via
++  * ```js
++  * for (const moduleId of this.getModuleIds()) {
++  *   // ...
++  * }
++  * ```
++  * or converted into an array via `Array.from(this.getModuleIds())`.
++  */
++  getModuleIds(): IterableIterator<string>;
++  /**
++  * Get additional information about the module in question.
++  *
++  *
++  *
++  * @returns Module information for that module. `null` if the module could not be found.
++  * @group Methods
++  */
++  getModuleInfo: GetModuleInfo;
++  /**
++  * Adds additional files to be monitored in watch mode so that changes to these files will trigger rebuilds.
++  *
++  *
++  */
++  addWatchFile(id: string): void;
++  /**
++  * Loads and parses the module corresponding to the given id, attaching additional
++  * meta information to the module if provided. This will trigger the same
++  * {@linkcode Plugin.load | load}, {@linkcode Plugin.transform | transform} and
++  * {@linkcode Plugin.moduleParsed | moduleParsed} hooks as if the module was imported
++  * by another module.
++  *
++  *
++  */
++  load(options: {
++    id: string;
++    resolveDependencies?: boolean;
++  } & Partial<PartialNull<ModuleOptions>>): Promise<ModuleInfo>;
++  /**
++  * Use Rolldown's internal parser to parse code to an [ESTree-compatible](https://github.com/estree/estree) AST.
++  */
++  parse(input: string, options?: ParserOptions | null): Program;
++  /**
++  * Resolve imports to module ids (i.e. file names) using the same plugins that Rolldown uses,
++  * and determine if an import should be external.
++  *
++  * When calling this function from a {@linkcode Plugin.resolveId | resolveId} hook, you should
++  * always check if it makes sense for you to pass along the
++  * {@link PluginContextResolveOptions | options}.
++  *
++  * @returns
++  * If `Promise<null>` is returned, the import could not be resolved by Rolldown or any plugin
++  * but was not explicitly marked as external by the user.
++  * If an absolute external id is returned that should remain absolute in the output either
++  * via the
++  * {@linkcode InputOptions.makeAbsoluteExternalsRelative | makeAbsoluteExternalsRelative}
++  * option or by explicit plugin choice in the {@linkcode Plugin.resolveId | resolveId} hook,
++  * `external` will be `"absolute"` instead of `true`.
++  */
++  resolve(source: string, importer?: string, options?: PluginContextResolveOptions): Promise<ResolvedId | null>;
++} //#endregion
++//#region src/plugin/transform-plugin-context.d.ts
++/** @category Plugin APIs */
++//#endregion
++//#region src/plugin/index.d.ts
++type ModuleSideEffects = boolean | "no-treeshake" | null;
++/** @category Plugin APIs */
++/** @category Plugin APIs */
++interface CustomPluginOptions {
++  [plugin: string]: any;
++}
++/** @category Plugin APIs */
++interface ModuleOptions {
++  moduleSideEffects: ModuleSideEffects;
++  /** See [Custom module meta-data section](https://rolldown.rs/apis/plugin-api/inter-plugin-communication#custom-module-meta-data) for more details. */
++  meta: CustomPluginOptions;
++  invalidate?: boolean;
++  packageJsonPath?: string;
++}
++/** @category Plugin APIs */
++interface ResolvedId extends ModuleOptions {
++  external: boolean | "absolute";
++  id: string;
++}
++//#endregion
+ //#region src/utils/normalizeModuleFederationOptions.d.ts
++interface ExposesItem {
++  import: string;
++}
++interface NormalizedShared {
++  [key: string]: ShareItem;
++}
+ interface RemoteObjectConfig {
+   type?: string;
+   name: string;
+@@ -10,6 +1901,13 @@ interface RemoteObjectConfig {
+   entryGlobalName?: string;
+   shareScope?: string;
+ }
++interface ShareItem {
++  name: string;
++  version: string | undefined;
++  scope: string;
++  from: string;
++  shareConfig: SharedConfig & moduleFederationPlugin.SharedConfig;
++}
+ interface PluginManifestOptions {
+   filePath?: string;
+   disableAssetsAnalyze?: boolean;
+@@ -78,40 +1976,32 @@ type ModuleFederationOptions = {
+    * @default 'web' (or 'node' if build.ssr is enabled)
+    */
+   target?: 'web' | 'node';
+-  /**
+-   * Additional packages to mark as external in the SSR remote entry build.
+-   * Shared packages and MF runtime packages are always external. Use this to
+-   * add any other Node-only packages that should not be bundled into the SSR entry.
+-   */
+-  ssrExternals?: string[];
+ };
++interface NormalizedModuleFederationOptions extends Omit<ModuleFederationOptions, 'exposes' | 'remotes' | 'shared'> {
++  exposes: Record<string, ExposesItem>;
++  filename: string;
++  internalName: string;
++  library: any;
++  remotes: Record<string, RemoteObjectConfig>;
++  runtime: any;
++  shareScope: string;
++  shared: NormalizedShared;
++  runtimePlugins: Array<string | [string, Record<string, unknown>]>;
++  implementation: string;
++  manifest?: PluginManifestOptions | boolean;
++  shareStrategy: ShareStrategy;
++  virtualModuleDir: string;
++  hostInitInjectLocation: HostInitInjectLocationOptions;
++  bundleAllCSS: boolean;
++  moduleParseTimeout: number;
++  moduleParseIdleTimeout?: number;
++}
+ type HostInitInjectLocationOptions = 'entry' | 'html';
+ interface PluginDevOptions {
+   disableLiveReload?: boolean;
+   disableHotTypesReload?: boolean;
+   disableDynamicRemoteTypeHints?: boolean;
+-  /**
+-   * Controls cross-federation HMR for remote modules.
+-   *
+-   * - `false` / `undefined` — HMR disabled (default).
+-   * - `true` — HMR enabled with auto-detected strategy. When a framework
+-   *   plugin with cross-federation HMR support is detected, broadcast/relay
+-   *   is suppressed and the framework's native HMR handles updates:
+-   *     - React (`@vitejs/plugin-react` / `@vitejs/plugin-react-swc`) — the
+-   *       plugin serves a `/@react-refresh` proxy on remotes that delegates
+-   *       to the host's `RefreshRuntime`, unifying the component registry.
+-   *     - Vue (`@vitejs/plugin-vue` / `@vitejs/plugin-vue-jsx`) — the plugin
+-   *       injects a `__VUE_HMR_RUNTIME__` guard into the host page so the
+-   *       first-loaded (host) Vue runtime is pinned and remote-loaded Vue
+-   *       copies cannot overwrite it.
+-   *   For any host, the plugin also injects a script that clears the
+-   *   federation `moduleCache` on `vite:beforeUpdate` so subsequent
+-   *   `loadRemote()` calls return the freshly patched module.
+-   *   Other frameworks fall back to full page reloads.
+-   * - `'full-reload'` — HMR enabled, always use full page reloads even when
+-   *   a framework with native cross-federation HMR is detected.
+-   */
+-  remoteHmr?: boolean | 'full-reload';
++  remoteHmr?: boolean;
+ }
+ interface RemoteTypeUrl {
+   alias?: string;
+@@ -156,12 +2046,98 @@ interface DtsHostOptions {
+   runtimePkgs?: string[];
+   remoteTypeUrls?: (() => Promise<RemoteTypeUrls>) | RemoteTypeUrls;
+   timeout?: number;
+-  family?: 0 | 4 | 6;
++  family?: 4 | 6;
+   typesOnBuild?: boolean;
+ }
+ //#endregion
+ //#region src/index.d.ts
+-declare function federation(mfUserOptions: ModuleFederationOptions): any[];
+-declare function createModuleFederationConfig<T extends ModuleFederationOptions>(options: T): T;
++type OutputNameOption = string | ((...args: unknown[]) => string);
++type ManualChunksOption = Record<string, string[]> | ((id: string, ...args: unknown[]) => string | void);
++type OutputNameOptions = {
++  entryFileNames?: OutputNameOption;
++  chunkFileNames?: OutputNameOption;
++  assetFileNames?: OutputNameOption;
++};
++type CodeSplittingOptions = {
++  groups?: unknown;
++} & Record<string, unknown>;
++type MutableBundlerOutput = OutputNameOptions & {
++  codeSplitting?: false | CodeSplittingOptions;
++  manualChunks?: ManualChunksOption;
++} & Record<string, unknown>;
++type RolldownOptionsLike = {
++  output?: MutableBundlerOutput | MutableBundlerOutput[];
++};
++type EnvironmentWithRolldownOptions = {
++  getRolldownOptions?: () => RolldownOptionsLike | Promise<RolldownOptionsLike>;
++};
++type BuilderLike = {
++  environments: Record<string, EnvironmentWithRolldownOptions>;
++};
++type BundleChunkLike = {
++  type: 'chunk';
++  fileName: string;
++  code: string;
++};
++type BundleAssetLike = {
++  type: 'asset';
++  fileName: string;
++};
++type BundleLike = Record<string, BundleChunkLike | BundleAssetLike>;
++type NormalizedOutputOptionsLike = {
++  dir?: string;
++};
++declare function federation(mfUserOptions: ModuleFederationOptions): (Plugin<any> | {
++  name: string;
++  config: (config: UserConfig) => void;
++} | {
++  name: string;
++  enforce: "post";
++  apply: "build";
++  config(this: vite.ConfigPluginContext, _config: UserConfig, {
++    command
++  }: ConfigEnv): void;
++  generateBundle(this: PluginContext, _outputOptions: NormalizedOutputOptionsLike, bundle: BundleLike, _isWrite: boolean): void;
++} | {
++  name: string;
++  enforce: string;
++  config(_config: UserConfig, env: ConfigEnv): void;
++  configResolved(config: ResolvedConfig): void;
++  apply?: undefined;
++  buildApp?: undefined;
++  load?: undefined;
++  generateBundle?: undefined;
++  _options?: undefined;
++} | {
++  name: string;
++  enforce: string;
++  apply: string;
++  config(config: UserConfig): void;
++  buildApp(builder: BuilderLike): Promise<void>;
++  load(id: string): {
++    code: string;
++    syntheticNamedExports?: undefined;
++  } | {
++    code: string;
++    syntheticNamedExports: string;
++  } | undefined;
++  generateBundle(_outputOptions: NormalizedOutputOptionsLike, bundle: BundleLike, _isWrite: boolean): void;
++  configResolved?: undefined;
++  _options?: undefined;
++} | {
++  name: string;
++  enforce: string;
++  _options: NormalizedModuleFederationOptions;
++  config(config: UserConfig, {
++    command: _command
++  }: {
++    command: string;
++  }): void;
++  configResolved?: undefined;
++  apply?: undefined;
++  buildApp?: undefined;
++  load?: undefined;
++  generateBundle?: undefined;
++})[];
+ //#endregion
+-export { type ModuleFederationOptions, type PluginManifestOptions, createModuleFederationConfig, federation };
+\ No newline at end of file
++export { type ModuleFederationOptions, type PluginManifestOptions, federation };
+\ No newline at end of file
+diff --git a/lib/index.mjs b/lib/index.mjs
+index dd80177c938763613658169528c165e9cae9ad5d..7fe309bf1f1e1da5f26c9f46452e4d74086478c6 100644
+--- a/lib/index.mjs
++++ b/lib/index.mjs
+@@ -1,147 +1,47 @@
+-import { a as getPackageName, c as hasPackageDependency, d as packageNameEncode, f as setPackageDetectionCwd, g as __require, h as mfWarn, i as getPackageDetectionCwd, l as isNuxtProjectRoot, n as getInstalledPackageJson, o as getPackageNameFromNodeModulePath, p as createModuleFederationError, r as getIsRolldown, s as getSharedCacheKey, t as getInstalledPackageEntry, u as packageNameDecode } from "./packageUtils-Bbc6r6__.mjs";
++import { createRequire } from "node:module";
++import defu from "defu";
+ import * as fs$1 from "fs";
+-import { existsSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
+-import { createRequire } from "module";
++import fs, { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFile, writeFileSync } from "fs";
++import { createRequire as createRequire$1 } from "module";
+ import * as path$1 from "pathe";
+-import path, { basename } from "pathe";
+-import { version } from "vite";
+-import { createHash } from "node:crypto";
++import path, { basename, dirname, join, parse, resolve } from "pathe";
++import MagicString from "magic-string";
++import { normalizeOptions } from "@module-federation/sdk";
++import { consumeTypesAPI, generateTypesAPI, isTSProject, normalizeConsumeTypesOptions, normalizeDtsOptions, normalizeGenerateTypesOptions } from "@module-federation/dts-plugin";
++import { rpc } from "@module-federation/dts-plugin/core";
++import { createFilter } from "@rollup/pluginutils";
+ import { fileURLToPath } from "url";
+-import { init, parse } from "es-module-lexer";
+-//#region src/utils/codeRewriter.ts
+-const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+-var CodeRewriter = class {
+-	replacements = [];
+-	constructor(original) {
+-		this.original = original;
+-	}
+-	overwrite(start, end, content) {
+-		if (start < 0 || end < start || end > this.original.length) throw new Error(`Invalid overwrite range: ${start}-${end}`);
+-		this.replacements.push({
+-			start,
+-			end,
+-			content
+-		});
+-	}
+-	toString() {
+-		return applyReplacements(this.original, this.getSortedReplacements()).code;
+-	}
+-	generateMap(source = "") {
+-		const { code, replacements } = applyReplacements(this.original, this.getSortedReplacements());
+-		return {
+-			version: 3,
+-			sources: [source],
+-			sourcesContent: [this.original],
+-			names: [],
+-			mappings: generateLineMappings(code, this.original, replacements)
+-		};
+-	}
+-	getSortedReplacements() {
+-		return [...this.replacements].sort((a, b) => a.start - b.start || a.end - b.end);
+-	}
+-};
+-function createSourceMap(code, source = "") {
+-	return {
+-		version: 3,
+-		sources: [source],
+-		sourcesContent: [code],
+-		names: [],
+-		mappings: generateLineMappings(code, code, [])
+-	};
+-}
+-function applyReplacements(original, replacements) {
+-	let code = "";
+-	let cursor = 0;
+-	let delta = 0;
+-	const applied = [];
+-	for (const replacement of replacements) {
+-		if (replacement.start < cursor) throw new Error("Overlapping overwrite ranges are not supported");
+-		code += original.slice(cursor, replacement.start);
+-		const generatedStart = replacement.start + delta;
+-		code += replacement.content;
+-		const generatedEnd = generatedStart + replacement.content.length;
+-		applied.push({
+-			...replacement,
+-			generatedStart,
+-			generatedEnd
+-		});
+-		cursor = replacement.end;
+-		delta += replacement.content.length - (replacement.end - replacement.start);
+-	}
+-	code += original.slice(cursor);
+-	return {
+-		code,
+-		replacements: applied
+-	};
+-}
+-function generateLineMappings(generated, original, replacements) {
+-	const generatedLineStarts = getLineStarts(generated);
+-	const originalLineStarts = getLineStarts(original);
+-	let previousOriginalLine = 0;
+-	let previousOriginalColumn = 0;
+-	let mappings = "";
+-	generatedLineStarts.forEach((generatedOffset, lineIndex) => {
+-		if (lineIndex > 0) mappings += ";";
+-		const originalOffset = generatedOffsetToOriginalOffset(generatedOffset, replacements);
+-		const originalLine = findLine(originalLineStarts, originalOffset);
+-		const originalColumn = originalOffset - originalLineStarts[originalLine];
+-		mappings += encodeSegment([
+-			0,
+-			0,
+-			originalLine - previousOriginalLine,
+-			originalColumn - previousOriginalColumn
+-		]);
+-		previousOriginalLine = originalLine;
+-		previousOriginalColumn = originalColumn;
+-	});
+-	return mappings;
+-}
+-function generatedOffsetToOriginalOffset(offset, replacements) {
+-	let delta = 0;
+-	for (const replacement of replacements) {
+-		if (offset < replacement.generatedStart) break;
+-		if (offset < replacement.generatedEnd) return replacement.start;
+-		delta += replacement.content.length - (replacement.end - replacement.start);
+-	}
+-	return offset - delta;
+-}
+-function getLineStarts(code) {
+-	const starts = [0];
+-	for (let i = 0; i < code.length; i++) if (code.charCodeAt(i) === 10) starts.push(i + 1);
+-	return starts;
+-}
+-function findLine(lineStarts, offset) {
+-	let low = 0;
+-	let high = lineStarts.length - 1;
+-	while (low <= high) {
+-		const mid = low + high >> 1;
+-		if (lineStarts[mid] <= offset) low = mid + 1;
+-		else high = mid - 1;
+-	}
+-	return Math.max(0, high);
+-}
+-function encodeSegment(values) {
+-	return values.map(encodeVlq).join("");
+-}
+-function encodeVlq(value) {
+-	let vlq = value < 0 ? (-value << 1) + 1 : value << 1;
+-	let encoded = "";
+-	do {
+-		let digit = vlq & 31;
+-		vlq >>>= 5;
+-		if (vlq > 0) digit |= 32;
+-		encoded += BASE64_CHARS[digit];
+-	} while (vlq > 0);
+-	return encoded;
++import { init, parse as parse$1 } from "es-module-lexer";
++//#region \0rolldown/runtime.js
++var __require = /* @__PURE__ */ createRequire(import.meta.url);
++//#endregion
++//#region src/utils/buildPaths.ts
++function getEntryFileNamesDir(rollupOutput) {
++	const outOpts = Array.isArray(rollupOutput) ? rollupOutput[0] : rollupOutput;
++	const entryPattern = typeof outOpts?.entryFileNames === "string" ? outOpts.entryFileNames : void 0;
++	if (!entryPattern) return "";
++	const nameIdx = entryPattern.indexOf("[name]");
++	if (nameIdx === -1) return "";
++	return entryPattern.slice(0, nameIdx);
++}
++function rebaseImport(importSrc, dir) {
++	if (!dir) return importSrc;
++	const prefix = "./" + dir;
++	if (importSrc.startsWith(prefix)) return "./" + importSrc.slice(prefix.length);
++	const absPrefix = "/" + dir;
++	if (importSrc.startsWith(absPrefix)) return "/" + importSrc.slice(absPrefix.length);
++	if (importSrc.startsWith(dir)) return "./" + importSrc.slice(dir.length);
++	return importSrc;
+ }
+ //#endregion
+ //#region src/utils/mapCodeToCodeWithSourcemap.ts
+ async function mapCodeToCodeWithSourcemap(code) {
+ 	const resolvedCode = await code;
+ 	if (resolvedCode === void 0) return;
++	const s = new MagicString(resolvedCode);
+ 	return {
+-		code: resolvedCode,
+-		map: createSourceMap(resolvedCode)
++		code: s.toString(),
++		map: s.generateMap({ hires: true })
+ 	};
+ }
+ //#endregion
+@@ -169,6 +69,228 @@ function injectEntryScript(html, initSrc) {
+ 	return html.replace("<head>", `<head><script type="module" src=${JSON.stringify(src)}><\/script>`);
+ }
+ //#endregion
++//#region src/utils/logger.ts
++const MODULE_FEDERATION_LOG_PREFIX = "[Module Federation]";
++function formatModuleFederationMessage(message) {
++	return `${MODULE_FEDERATION_LOG_PREFIX} ${message}`;
++}
++function createModuleFederationError(message) {
++	return new Error(formatModuleFederationMessage(message));
++}
++function toConsoleArgs(message, rest = []) {
++	if (typeof message === "string") return [formatModuleFederationMessage(message), ...rest];
++	if (message === void 0) return [MODULE_FEDERATION_LOG_PREFIX, ...rest];
++	return [
++		MODULE_FEDERATION_LOG_PREFIX,
++		message,
++		...rest
++	];
++}
++const moduleFederationConsole = {
++	log(message, ...rest) {
++		console.log(...toConsoleArgs(message, rest));
++	},
++	warn(message, ...rest) {
++		console.warn(...toConsoleArgs(message, rest));
++	},
++	error(message, ...rest) {
++		console.error(...toConsoleArgs(message, rest));
++	}
++};
++moduleFederationConsole.log;
++const mfWarn = moduleFederationConsole.warn;
++const mfError = moduleFederationConsole.error;
++//#endregion
++//#region src/utils/packageUtils.ts
++const dependencyPresenceCache = /* @__PURE__ */ new Map();
++let packageDetectionCwd;
++function getDependencyCacheKey(cwd, dependencyName) {
++	return `${cwd}:${dependencyName}`;
++}
++function setPackageDetectionCwd(cwd) {
++	packageDetectionCwd = cwd;
++}
++function getPackageDetectionCwd() {
++	return packageDetectionCwd || process.cwd();
++}
++const DEFAULT_EXPORT_CONDITIONS = [
++	"browser",
++	"import",
++	"module",
++	"default",
++	"require"
++];
++function resolveExportsEntry(exportsField, conditions = DEFAULT_EXPORT_CONDITIONS) {
++	if (typeof exportsField === "string") return exportsField;
++	if (!exportsField || typeof exportsField !== "object") return void 0;
++	const record = exportsField;
++	const rootExport = record["."];
++	if (rootExport) return resolveExportsEntry(rootExport);
++	for (const condition of conditions) {
++		const target = resolveExportsEntry(record[condition], conditions);
++		if (target) return target;
++	}
++	for (const target of Object.values(record)) {
++		const resolved = resolveExportsEntry(target, conditions);
++		if (resolved) return resolved;
++	}
++}
++function getPackageExportsTarget(pkg, packageName, exportsField) {
++	if (typeof exportsField === "string") return pkg === packageName ? exportsField : void 0;
++	if (!exportsField || typeof exportsField !== "object") return void 0;
++	const record = exportsField;
++	const subpath = pkg === packageName ? "." : `.${pkg.slice(packageName.length)}`;
++	if (subpath !== ".") return record[subpath];
++	return record["."] ?? (!Object.keys(record).some((key) => key.startsWith(".")) ? record : void 0);
++}
++/**
++* Escaping rules:
++* Convert using the format __${mapping}__, where _ and $ are not allowed in npm package names but can be used in variable names.
++*  @ => 1
++*  / => 2
++*  - => 3
++*  . => 4
++*/
++/**
++* Encodes a package name into a valid file name.
++* @param {string} name - The package name, e.g., "@scope/xx-xx.xx".
++* @returns {string} - The encoded file name.
++*/
++function packageNameEncode(name) {
++	if (typeof name !== "string") throw createModuleFederationError("A string package name is required");
++	return name.replace(/@/g, "_mf_0_").replace(/\//g, "_mf_1_").replace(/-/g, "_mf_2_").replace(/\./g, "_mf_3_");
++}
++/**
++* Decodes an encoded file name back to the original package name.
++* @param {string} encoded - The encoded file name, e.g., "_mf_0_scope_mf_1_xx_mf_2_xx_mf_3_xx".
++* @returns {string} - The decoded package name.
++*/
++function packageNameDecode(encoded) {
++	if (typeof encoded !== "string") throw createModuleFederationError("A string encoded file name is required");
++	return encoded.replace(/_mf_0_/g, "@").replace(/_mf_1_/g, "/").replace(/_mf_2_/g, "-").replace(/_mf_3_/g, ".");
++}
++/**
++* Removes any subpath from an npm package specifier and returns the package name only.
++* @param {string} packageString - The package specifier, e.g., "@scope/pkg/runtime" or "react/jsx-runtime".
++* @returns {string} - The base npm package name.
++*/
++function getPackageName(packageString) {
++	const match = packageString.match(/^(?:@[^/]+\/)?[^/]+/);
++	return match ? match[0] : packageString;
++}
++function getInstalledPackageJson(pkg, opts) {
++	const cwd = opts?.cwd || getPackageDetectionCwd();
++	const packageName = opts?.packageName || getPackageName(pkg);
++	const tryReadPackageJson = (packageJsonPath) => {
++		if (!existsSync(packageJsonPath)) return void 0;
++		try {
++			return {
++				path: packageJsonPath,
++				dir: path.dirname(packageJsonPath),
++				packageJson: JSON.parse(readFileSync(packageJsonPath, "utf-8"))
++			};
++		} catch {
++			return;
++		}
++	};
++	const findPackageInPnpmStore = (startDir) => {
++		let currentDir = startDir;
++		const rootDir = path.parse(currentDir).root;
++		while (true) {
++			const pnpmStoreDir = path.join(currentDir, "node_modules", ".pnpm");
++			if (existsSync(pnpmStoreDir)) try {
++				for (const entry of readdirSync(pnpmStoreDir, { withFileTypes: true })) {
++					if (!entry.isDirectory()) continue;
++					const candidate = tryReadPackageJson(path.join(pnpmStoreDir, entry.name, "node_modules", packageName, "package.json"));
++					if (candidate?.packageJson.name === packageName) return candidate;
++				}
++			} catch {}
++			if (currentDir === rootDir) break;
++			currentDir = path.dirname(currentDir);
++		}
++	};
++	try {
++		const projectRequire = createRequire$1(new URL(`file://${path.join(cwd, "package.json")}`));
++		let resolvedPath;
++		if (opts?.fromResolvedEntry) resolvedPath = opts.fromResolvedEntry;
++		else try {
++			resolvedPath = projectRequire.resolve(pkg);
++		} catch {
++			resolvedPath = projectRequire.resolve(packageName);
++		}
++		let currentDir = path.dirname(resolvedPath);
++		const rootDir = path.parse(currentDir).root;
++		while (true) {
++			const packageJsonPath = path.join(currentDir, "package.json");
++			if (existsSync(packageJsonPath)) {
++				const packageJsonContent = readFileSync(packageJsonPath, "utf-8");
++				try {
++					const packageJson = JSON.parse(packageJsonContent);
++					if (packageJson.name === packageName) return {
++						path: packageJsonPath,
++						dir: currentDir,
++						packageJson
++					};
++				} catch (error) {
++					if (!(error instanceof SyntaxError)) throw error;
++				}
++			}
++			if (currentDir === rootDir) break;
++			currentDir = path.dirname(currentDir);
++		}
++	} catch {
++		let currentDir = cwd;
++		const rootDir = path.parse(currentDir).root;
++		while (true) {
++			const directCandidate = tryReadPackageJson(path.join(currentDir, "node_modules", packageName, "package.json"));
++			if (directCandidate?.packageJson.name === packageName) return directCandidate;
++			if (currentDir === rootDir) break;
++			currentDir = path.dirname(currentDir);
++		}
++		return findPackageInPnpmStore(cwd);
++	}
++}
++function getInstalledPackageEntry(pkg, opts) {
++	const installed = getInstalledPackageJson(pkg, opts);
++	if (!installed) return void 0;
++	const cwd = opts?.cwd || getPackageDetectionCwd();
++	const packageName = opts?.packageName || getPackageName(pkg);
++	if (pkg !== packageName && opts?.resolveSubpathWithRequire !== false) try {
++		return createRequire$1(new URL(`file://${path.join(cwd, "package.json")}`)).resolve(pkg);
++	} catch {}
++	const packageJson = installed.packageJson;
++	const explicitEntry = resolveExportsEntry(getPackageExportsTarget(pkg, packageName, packageJson.exports), opts?.conditions) || (typeof packageJson.module === "string" ? packageJson.module : void 0) || (typeof packageJson.main === "string" ? packageJson.main : void 0) || "index.js";
++	return path.join(installed.dir, explicitEntry);
++}
++/**
++* Detect whether the current runtime is Vite 8+ by checking for a Vite version flag
++* on the plugin hook context, with Rolldown metadata kept as a compatibility fallback.
++*/
++function getIsRolldown(ctx) {
++	const viteVersion = ctx?.meta?.viteVersion;
++	const viteMajor = Number(String(viteVersion ?? "").split(".")[0]);
++	return Number.isFinite(viteMajor) && viteMajor >= 8 || !!ctx?.meta?.rolldownVersion;
++}
++function hasPackageDependency(dependencyName, cwd = packageDetectionCwd || process.cwd()) {
++	const cacheKey = getDependencyCacheKey(cwd, dependencyName);
++	const cached = dependencyPresenceCache.get(cacheKey);
++	if (cached !== void 0) return cached;
++	try {
++		const packageJson = JSON.parse(readFileSync(path.join(cwd, "package.json"), "utf8"));
++		const hasDependency = [
++			packageJson.dependencies,
++			packageJson.devDependencies,
++			packageJson.peerDependencies,
++			packageJson.optionalDependencies
++		].some((deps) => !!deps?.[dependencyName]);
++		dependencyPresenceCache.set(cacheKey, hasDependency);
++		return hasDependency;
++	} catch {
++		dependencyPresenceCache.set(cacheKey, false);
++		return false;
++	}
++}
++//#endregion
+ //#region src/utils/normalizeModuleFederationOptions.ts
+ const INTERNAL_NAME_PREFIX = "__mfe_internal__";
+ function toInternalModuleFederationName(name) {
+@@ -240,7 +362,7 @@ function normalizeRemoteItem(key, remote) {
+ * @returns {string | undefined}
+ */
+ function searchPackageVersion(sharedName) {
+-	const version = getInstalledPackageJson(sharedName)?.packageJson.version;
++	const version = getInstalledPackageJson(sharedName, { packageName: sharedName })?.packageJson.version;
+ 	return typeof version === "string" ? version : void 0;
+ }
+ function inferVersionFromRequiredVersion(requiredVersion) {
+@@ -254,8 +376,21 @@ function getLitExportSubpathShares(sharedName) {
+ 	return Object.keys(exportsField).filter((key) => key.startsWith("./") && key !== "." && !key.includes("*")).map((key) => `${sharedName}/${key.slice(2)}`);
+ }
+ function normalizeShareItem(key, shareItem) {
+-	const isImportFalse = typeof shareItem === "object" && shareItem.import === false;
+-	const version = (typeof shareItem === "object" ? shareItem.version || inferVersionFromRequiredVersion(shareItem.requiredVersion) : void 0) || searchPackageVersion(key);
++	let version;
++	if (!(typeof shareItem === "object" && shareItem.import === false)) try {
++		try {
++			version = __require(path$1.join(getPackageName(key), "package.json")).version;
++		} catch (e1) {
++			try {
++				version = __require(path$1.join(process.cwd(), "node_modules", getPackageName(key), "package.json")).version;
++			} catch (e2) {
++				version = searchPackageVersion(key);
++				if (!version) mfError(e1);
++			}
++		}
++	} catch (e) {
++		mfError(`Unexpected error resolving version for ${key}:`, e);
++	}
+ 	if (typeof shareItem === "string") return {
+ 		name: shareItem,
+ 		version,
+@@ -270,18 +405,17 @@ function normalizeShareItem(key, shareItem) {
+ 	return {
+ 		name: key,
+ 		from: "",
+-		version,
++		version: shareItem.version || inferVersionFromRequiredVersion(shareItem.requiredVersion) || version,
+ 		scope: shareItem.shareScope || "default",
+ 		shareConfig: {
+ 			import: shareItem.import,
+ 			singleton: shareItem.singleton || false,
+-			requiredVersion: shareItem.requiredVersion || (isImportFalse || shareItem.version ? "*" : version ? `^${version}` : "*"),
++			requiredVersion: shareItem.requiredVersion || (version ? `^${version}` : "*"),
+ 			strictVersion: !!shareItem.strictVersion
+ 		}
+ 	};
+ }
+ function normalizeShared(shared) {
+-	explicitSharedKeys = /* @__PURE__ */ new Set();
+ 	if (!shared) {
+ 		const result = {};
+ 		const packageJsonPath = path$1.join(getPackageDetectionCwd(), "package.json");
+@@ -303,16 +437,12 @@ function normalizeShared(shared) {
+ 	const result = {};
+ 	const sourceEntries = [];
+ 	if (Array.isArray(shared)) shared.forEach((key) => {
+-		if (isModuleFederationRuntimePackage(key)) return;
+ 		result[key] = normalizeShareItem(key, key);
+-		explicitSharedKeys.add(key);
+ 		sourceEntries.push([key, key]);
+ 	});
+ 	else if (typeof shared === "object") Object.keys(shared).forEach((key) => {
+-		if (isModuleFederationRuntimePackage(key)) return;
+ 		const value = shared[key];
+ 		result[key] = normalizeShareItem(key, value);
+-		explicitSharedKeys.add(key);
+ 		sourceEntries.push([key, value]);
+ 	});
+ 	sourceEntries.forEach(([key, value]) => {
+@@ -323,14 +453,11 @@ function normalizeShared(shared) {
+ 	});
+ 	return result;
+ }
+-function isModuleFederationRuntimePackage(key) {
+-	return key === "@module-federation/runtime" || key === "@module-federation/runtime-core";
+-}
+ function shouldAutoShareDependency(key) {
+ 	const pkg = getInstalledPackageJson(key)?.packageJson;
+ 	if (!pkg) return false;
+ 	if (!pkg.browser && !pkg.exports && typeof pkg.module !== "string") return false;
+-	if (key === "@module-federation/vite" || isModuleFederationRuntimePackage(key)) return false;
++	if (key === "@module-federation/vite") return false;
+ 	const entry = [
+ 		pkg.module,
+ 		pkg.main,
+@@ -353,25 +480,9 @@ function normalizeManifest(manifest) {
+ 	};
+ }
+ let config;
+-let explicitSharedKeys = /* @__PURE__ */ new Set();
+-function resolveRuntimeImplementation() {
+-	const fallback = __require.resolve("@module-federation/runtime");
+-	try {
+-		const packageJsonPath = __require.resolve("@module-federation/runtime/package.json");
+-		const packageJson = JSON.parse(fs$1.readFileSync(packageJsonPath, "utf-8"));
+-		const importExport = packageJson.exports?.["."];
+-		const exportImport = typeof importExport === "object" ? typeof importExport.import === "string" ? importExport.import : importExport.import?.default : void 0;
+-		const esmEntry = packageJson.module || exportImport;
+-		if (esmEntry) return path$1.join(path$1.dirname(packageJsonPath), esmEntry);
+-	} catch {}
+-	return fallback;
+-}
+ function getNormalizeModuleFederationOptions() {
+ 	return config;
+ }
+-function isExplicitSharedKey(key) {
+-	return explicitSharedKeys.has(key);
+-}
+ function getNormalizeShareItem(key) {
+ 	const options = getNormalizeModuleFederationOptions();
+ 	return options.shared[key] || options.shared[getPackageName(key)] || options.shared[getPackageName(key) + "/"];
+@@ -390,7 +501,7 @@ function normalizeModuleFederationOptions(options) {
+ 		shareScope: options.shareScope || "default",
+ 		shared: normalizeShared(options.shared),
+ 		runtimePlugins: options.runtimePlugins || [],
+-		implementation: options.implementation || resolveRuntimeImplementation(),
++		implementation: options.implementation || __require.resolve("@module-federation/runtime"),
+ 		manifest: normalizeManifest(options.manifest),
+ 		dev: options.dev,
+ 		dts: options.dts,
+@@ -409,6 +520,35 @@ function normalizeModuleFederationOptions(options) {
+ }
+ //#endregion
+ //#region src/utils/VirtualModule.ts
++/**
++* Initialize virtual module infrastructure BEFORE VirtualModule class is used.
++* This must be called in the config hook to ensure the directory exists
++* before Vite's optimization phase.
++*/
++function initVirtualModuleInfrastructure(root, virtualModuleDir = "__mf__virtual") {
++	const virtualPackagePath = join(join(root, "node_modules"), virtualModuleDir);
++	mkdirSync(virtualPackagePath, { recursive: true });
++	writeFileSync(join(virtualPackagePath, "empty.js"), "");
++	writeFileSync(join(virtualPackagePath, "package.json"), JSON.stringify({
++		name: virtualModuleDir,
++		main: "empty.js"
++	}));
++}
++let rootDir;
++function findNodeModulesDir(root = process.cwd()) {
++	let currentDir = root;
++	while (currentDir !== parse(currentDir).root) {
++		const nodeModulesPath = join(currentDir, "node_modules");
++		if (existsSync(nodeModulesPath)) return nodeModulesPath;
++		currentDir = dirname(currentDir);
++	}
++	return "";
++}
++let cachedNodeModulesDir;
++function getNodeModulesDir() {
++	if (!cachedNodeModulesDir) cachedNodeModulesDir = findNodeModulesDir(rootDir);
++	return cachedNodeModulesDir;
++}
+ function getSuffix(name) {
+ 	const base = basename(name);
+ 	const dotIndex = base.lastIndexOf(".");
+@@ -417,52 +557,45 @@ function getSuffix(name) {
+ }
+ const patternMap = {};
+ const cacheMap = {};
+-const VITE_ID_PREFIX = "/@id/";
+-const VITE_ENCODED_NULL_BYTE_PREFIX = `${VITE_ID_PREFIX}__x00__`;
+-function escapeRegExp$1(value) {
+-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+-}
+-function createViteEncodedIdPrefixRegExp(sourcePrefix = "") {
+-	return new RegExp(`^(?:${escapeRegExp$1(VITE_ENCODED_NULL_BYTE_PREFIX)})?${sourcePrefix}`);
+-}
+-function toViteEncodedId(id) {
+-	return `${VITE_ENCODED_NULL_BYTE_PREFIX}${id}`;
+-}
+-function decodeViteId(id) {
+-	if (!id.startsWith("/@id/")) return id;
+-	const viteId = id.slice(5);
+-	return viteId.startsWith("__x00__") ? `\0${viteId.slice(7)}` : viteId;
+-}
++/**
++* Physically generate files as virtual modules under node_modules/__mf__virtual/*
++*/
+ function assertModuleFound(tag, str = "") {
+ 	const module = VirtualModule.findModule(tag, str);
+ 	if (!module) throw createModuleFederationError(`Module Federation shared module '${str}' not found. Please ensure it's installed as a dependency in your package.json.`);
+ 	return module;
+ }
+-function normalizeVirtualModuleId(id) {
+-	const decoded = decodeViteId(id).replace(/^\0+/, "");
+-	const queryIndex = decoded.indexOf("?");
+-	const hashIndex = decoded.indexOf("#");
+-	const endIndex = queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
+-	return endIndex === -1 ? decoded : decoded.slice(0, endIndex);
+-}
+-var VirtualModule = class VirtualModule {
++var VirtualModule = class {
+ 	name;
+ 	tag;
+ 	suffix;
+ 	inited = false;
+-	code;
+-	static findName(tag, str = "") {
+-		if (!patternMap[tag]) patternMap[tag] = new RegExp(`(.*${packageNameEncode(tag)}(.+?)${packageNameEncode(tag)}.*)`);
+-		const moduleName = (normalizeVirtualModuleId(str).match(patternMap[tag]) || [])[2];
+-		return moduleName ? packageNameDecode(moduleName) : void 0;
++	/**
++	* Set the root path for finding node_modules
++	* @param root - Root path
++	*/
++	static setRoot(root) {
++		rootDir = root;
++		cachedNodeModulesDir = void 0;
+ 	}
+-	static findModule(tag, str = "") {
+-		const moduleName = VirtualModule.findName(tag, str);
+-		return moduleName ? cacheMap[tag][moduleName] : void 0;
++	/**
++	* Ensure virtual package directory exists
++	*/
++	static ensureVirtualPackageExists() {
++		const nodeModulesDir = getNodeModulesDir();
++		const { virtualModuleDir } = getNormalizeModuleFederationOptions();
++		const virtualPackagePath = resolve(nodeModulesDir, virtualModuleDir);
++		mkdirSync(virtualPackagePath, { recursive: true });
++		writeFileSync(resolve(virtualPackagePath, "empty.js"), "");
++		writeFileSync(resolve(virtualPackagePath, "package.json"), JSON.stringify({
++			name: virtualModuleDir,
++			main: "empty.js"
++		}));
+ 	}
+-	static findById(id) {
+-		const normalized = normalizeVirtualModuleId(id);
+-		for (const modules of Object.values(cacheMap)) for (const module of Object.values(modules)) if (module.getImportId() === normalized) return module;
++	static findModule(tag, str = "") {
++		if (!patternMap[tag]) patternMap[tag] = new RegExp(`(.*${packageNameEncode(tag)}(.+?)${packageNameEncode(tag)}.*)`);
++		const moduleName = (str.match(patternMap[tag]) || [])[2];
++		if (moduleName) return cacheMap[tag][packageNameDecode(moduleName)];
+ 	}
+ 	constructor(name, tag = "__mf_v__", suffix = "") {
+ 		this.name = name;
+@@ -471,23 +604,128 @@ var VirtualModule = class VirtualModule {
+ 		if (!cacheMap[this.tag]) cacheMap[this.tag] = {};
+ 		cacheMap[this.tag][this.name] = this;
+ 	}
+-	getImportId() {
+-		const { internalName: mfName } = getNormalizeModuleFederationOptions();
+-		return `virtual:mf:${packageNameEncode(`${mfName}${this.tag}${this.name}${this.tag}`)}${this.suffix}`;
++	getPath() {
++		return resolve(getNodeModulesDir(), this.getImportId());
+ 	}
+-	getResolvedId() {
+-		return `\0${this.getImportId()}`;
++	getImportId() {
++		const { internalName: mfName, virtualModuleDir } = getNormalizeModuleFederationOptions();
++		return `${virtualModuleDir}/${packageNameEncode(`${mfName}${this.tag}${this.name}${this.tag}`)}${this.suffix}`;
+ 	}
+ 	writeSync(code, force) {
+ 		if (!force && this.inited) return;
+ 		if (!this.inited) this.inited = true;
+-		this.code = code;
++		const path = this.getPath();
++		mkdirSync(dirname(path), { recursive: true });
++		writeFileSync(path, code);
+ 	}
+ 	write(code) {
+-		this.writeSync(code, true);
++		const path = this.getPath();
++		mkdirSync(dirname(path), { recursive: true });
++		writeFile(path, code, function() {});
+ 	}
+ };
+ //#endregion
++//#region src/virtualModules/virtualRuntimeInitStatus.ts
++const virtualRuntimeInitStatus = new VirtualModule("runtimeInit");
++const MODULE_CACHE_GLOBAL_KEY = "__mf_module_cache__";
++function getRuntimeInitGlobalKey() {
++	return `__mf_init__${virtualRuntimeInitStatus.getImportId()}__`;
++}
++function getDeferredInitPromiseCode() {
++	return `let initResolve, initReject;
++  const initPromise = new Promise((re, rj) => {
++    initResolve = re;
++    initReject = rj;
++  });`;
++}
++function getSsrNoopResolveCode() {
++	return `if (typeof window === 'undefined') {
++    initResolve({
++      loadRemote: function() { return Promise.resolve(undefined); },
++      loadShare: function() { return Promise.resolve(undefined); },
++    });
++  }`;
++}
++function getRuntimeInitStateBootstrapCode(options) {
++	return `
++const ${options.globalKeyVar} = ${JSON.stringify(getRuntimeInitGlobalKey())};
++let ${options.stateVar} = globalThis[${options.globalKeyVar}];
++if (!${options.stateVar}) {
++  ${getDeferredInitPromiseCode()}
++  ${options.stateVar} = globalThis[${options.globalKeyVar}] = {
++    initPromise,
++    initResolve,
++    initReject,
++  };
++  ${getSsrNoopResolveCode()}
++}
++const ${options.exposedConst} = ${options.stateVar}.${options.exposedProperty};
++`;
++}
++function getRuntimeInitBootstrapCode() {
++	return `
++const globalKey = ${JSON.stringify(getRuntimeInitGlobalKey())};
++const moduleCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
++globalThis[moduleCacheGlobalKey] ||= { share: {}, remote: {} };
++globalThis[moduleCacheGlobalKey].share ||= {};
++globalThis[moduleCacheGlobalKey].remote ||= {};
++if (!globalThis[globalKey]) {
++  ${getDeferredInitPromiseCode()}
++  globalThis[globalKey] = {
++    initPromise,
++    initResolve,
++    initReject,
++    moduleCache: globalThis[moduleCacheGlobalKey],
++  };
++  ${getSsrNoopResolveCode()}
++}
++globalThis[globalKey].moduleCache ||= globalThis[moduleCacheGlobalKey];
++globalThis[globalKey].moduleCache.share ||= {};
++globalThis[globalKey].moduleCache.remote ||= {};
++`;
++}
++function getRuntimeModuleCacheBootstrapCode() {
++	return `
++const __mfCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
++globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
++globalThis[__mfCacheGlobalKey].share ||= {};
++globalThis[__mfCacheGlobalKey].remote ||= {};
++const __mfModuleCache = globalThis[__mfCacheGlobalKey];
++`;
++}
++function getRuntimeInitResolveBootstrapCode() {
++	return getRuntimeInitStateBootstrapCode({
++		globalKeyVar: "__mfResolveGlobalKey",
++		stateVar: "__mfResolveState",
++		exposedConst: "initResolve",
++		exposedProperty: "initResolve"
++	});
++}
++function writeRuntimeInitStatus(command) {
++	const exportStatement = command === "build" ? `const { initPromise, initResolve, initReject, moduleCache } = globalThis[globalKey];
++export { initPromise, initResolve, initReject, moduleCache };` : `module.exports = globalThis[globalKey];`;
++	virtualRuntimeInitStatus.writeSync(`
++${getRuntimeInitBootstrapCode()}
++${exportStatement}
++`);
++}
++//#endregion
++//#region src/utils/localSharedImportMap_temp.ts
++/**
++* https://github.com/module-federation/vite/issues/68
++*/
++function getLocalSharedImportMapPath_temp() {
++	const { name } = getNormalizeModuleFederationOptions();
++	return path.resolve(".__mf__temp", packageNameEncode(name), "localSharedImportMap");
++}
++function writeLocalSharedImportMap_temp(content) {
++	createFile(getLocalSharedImportMapPath_temp() + ".js", "\n// Windows temporarily needs this file, https://github.com/module-federation/vite/issues/68\n" + content);
++}
++function createFile(filePath, content) {
++	mkdirSync(path.dirname(filePath), { recursive: true });
++	writeFileSync(filePath, content);
++}
++//#endregion
+ //#region src/utils/serializeRuntimeOptions.ts
+ /**
+ * Serializes a JavaScript object into a string of source code that can be evaluated.
+@@ -618,151 +856,43 @@ function generateExposes(options) {
+   `;
+ }
+ //#endregion
+-//#region src/virtualModules/virtualRuntimeInitStatus.ts
+-const virtualRuntimeInitStatus = new VirtualModule("runtimeInit");
+-const MODULE_CACHE_GLOBAL_KEY = "__mf_module_cache__";
+-function getRuntimeInitGlobalKey() {
+-	return `__mf_init__${virtualRuntimeInitStatus.getImportId()}__`;
+-}
+-function getDeferredInitPromiseCode() {
+-	return `let initResolve, initReject;
+-  const initPromise = new Promise((re, rj) => {
+-    initResolve = re;
+-    initReject = rj;
+-  });`;
++//#region src/virtualModules/virtualShared_preBuild.ts
++/**
++* Even the resolveId hook cannot interfere with vite pre-build,
++* and adding query parameter virtual modules will also fail.
++* You can only proxy to the real file through alias
++*/
++/**
++* shared will be proxied:
++* 1. __prebuild__: export shareModule (pre-built source code of modules such as vue, react, etc.)
++* 2. __loadShare__: load shareModule (mfRuntime.loadShare('vue'))
++*/
++const JS_IDENTIFIER_REGEX = /* @__PURE__ */ new RegExp("^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$", "u");
++function escapeGeneratedStringLiteral(value) {
++	return JSON.stringify(value).replace(/[<>\u2028\u2029]/g, (char) => {
++		switch (char) {
++			case "<": return "\\u003C";
++			case ">": return "\\u003E";
++			case "\u2028": return "\\u2028";
++			case "\u2029": return "\\u2029";
++			default: return char;
++		}
++	});
+ }
+-let _ssrRemotes = [];
+-function setSsrRemotes(remotes) {
+-	_ssrRemotes = remotes;
++function isValidJsIdentifier(name) {
++	return JS_IDENTIFIER_REGEX.test(name);
+ }
+-function getSsrNoopResolveCode(enableSsrInit) {
+-	if (!enableSsrInit) return "";
+-	return `if (typeof window === 'undefined') {
+-    var _noop = { loadRemote: function() { return Promise.resolve(undefined); }, loadShare: function() { return Promise.resolve(undefined); } };
+-    import(/* @vite-ignore */ '@module-federation/runtime').then(function(runtimeMod) {
+-      return import(/* @vite-ignore */ '@module-federation/vite/ssrEntryLoader').then(
+-        function(loaderMod) { return [runtimeMod, [loaderMod.default()]]; },
+-        function() { return [runtimeMod, []]; }
+-      );
+-    }).then(function(pair) {
+-      var runtime = pair[0].init({ name: '__mf_ssr_host__', remotes: ${JSON.stringify(_ssrRemotes)}, shared: {}, plugins: pair[1] });
+-      initResolve(runtime);
+-    }, function() {
+-      initResolve(_noop);
+-    });
+-  }`;
++function isValidEsmExportName(name) {
++	return !!name && name !== "default" && name !== "__esModule" && isValidJsIdentifier(name);
+ }
+-function getRuntimeInitStateBootstrapCode(options) {
+-	return `
+-const ${options.globalKeyVar} = ${JSON.stringify(getRuntimeInitGlobalKey())};
+-let ${options.stateVar} = globalThis[${options.globalKeyVar}];
+-if (!${options.stateVar}) {
+-  ${getDeferredInitPromiseCode()}
+-  ${options.stateVar} = globalThis[${options.globalKeyVar}] = {
+-    initPromise,
+-    initResolve,
+-    initReject,
+-  };
+-  ${getSsrNoopResolveCode(options.enableSsrInit)}
+-}
+-const ${options.exposedConst} = ${options.stateVar}.${options.exposedProperty};
+-`;
+-}
+-function getRuntimeInitBootstrapCode(enableSsrInit = false) {
+-	return `
+-const globalKey = ${JSON.stringify(getRuntimeInitGlobalKey())};
+-const moduleCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
+-globalThis[moduleCacheGlobalKey] ||= { share: {}, remote: {} };
+-globalThis[moduleCacheGlobalKey].share ||= {};
+-globalThis[moduleCacheGlobalKey].remote ||= {};
+-if (!globalThis[globalKey]) {
+-  ${getDeferredInitPromiseCode()}
+-  globalThis[globalKey] = {
+-    initPromise,
+-    initResolve,
+-    initReject,
+-    moduleCache: globalThis[moduleCacheGlobalKey],
+-  };
+-  ${getSsrNoopResolveCode(enableSsrInit)}
+-}
+-globalThis[globalKey].moduleCache ||= globalThis[moduleCacheGlobalKey];
+-globalThis[globalKey].moduleCache.share ||= {};
+-globalThis[globalKey].moduleCache.remote ||= {};
+-`;
+-}
+-function getRuntimeModuleCacheBootstrapCode() {
+-	return `
+-const __mfCacheGlobalKey = ${JSON.stringify(MODULE_CACHE_GLOBAL_KEY)};
+-globalThis[__mfCacheGlobalKey] ||= { share: {}, remote: {} };
+-globalThis[__mfCacheGlobalKey].share ||= {};
+-globalThis[__mfCacheGlobalKey].remote ||= {};
+-const __mfModuleCache = globalThis[__mfCacheGlobalKey];
+-`;
+-}
+-function getRuntimeInitPromiseBootstrapCode(enableSsrInit = false) {
+-	return getRuntimeInitStateBootstrapCode({
+-		globalKeyVar: "__mfPromiseGlobalKey",
+-		stateVar: "__mfPromiseState",
+-		exposedConst: "initPromise",
+-		exposedProperty: "initPromise",
+-		enableSsrInit
+-	});
+-}
+-function getRuntimeInitResolveBootstrapCode(enableSsrInit = false) {
+-	return getRuntimeInitStateBootstrapCode({
+-		globalKeyVar: "__mfResolveGlobalKey",
+-		stateVar: "__mfResolveState",
+-		exposedConst: "initResolve",
+-		exposedProperty: "initResolve",
+-		enableSsrInit
+-	});
+-}
+-function writeRuntimeInitStatus(command, enableSsrInit = false) {
+-	const exportStatement = command === "build" ? `const { initPromise, initResolve, initReject, moduleCache } = globalThis[globalKey];
+-export { initPromise, initResolve, initReject, moduleCache };` : `module.exports = globalThis[globalKey];`;
+-	virtualRuntimeInitStatus.writeSync(`
+-${getRuntimeInitBootstrapCode(enableSsrInit)}
+-${exportStatement}
+-`);
+-}
+-//#endregion
+-//#region src/virtualModules/virtualShared_preBuild.ts
+-/**
+-* Even the resolveId hook cannot interfere with vite pre-build,
+-* and adding query parameter virtual modules will also fail.
+-* You can only proxy to the real file through alias
+-*/
+-/**
+-* shared will be proxied:
+-* 1. __prebuild__: export shareModule (pre-built source code of modules such as vue, react, etc.)
+-* 2. __loadShare__: load shareModule (mfRuntime.loadShare('vue'))
+-*/
+-const JS_IDENTIFIER_REGEX = /* @__PURE__ */ new RegExp("^[$_\\p{ID_Start}][$_\\u200C\\u200D\\p{ID_Continue}]*$", "u");
+-function escapeGeneratedStringLiteral(value) {
+-	return JSON.stringify(value).replace(/[<>\u2028\u2029]/g, (char) => {
+-		switch (char) {
+-			case "<": return "\\u003C";
+-			case ">": return "\\u003E";
+-			case "\u2028": return "\\u2028";
+-			case "\u2029": return "\\u2029";
+-			default: return char;
+-		}
+-	});
+-}
+-function isValidJsIdentifier(name) {
+-	return JS_IDENTIFIER_REGEX.test(name);
+-}
+-function isValidEsmExportName(name) {
+-	return !!name && name !== "default" && name !== "__esModule" && isValidJsIdentifier(name);
+-}
+-const JS_IDENTIFIER_PATTERN = `[\$_\\p{ID_Start}][\$_\\u200C\\u200D\\p{ID_Continue}]*`;
+-const localRequire = createRequire(import.meta.url);
+-function resolvePackageEntryFromProjectRoot(pkg) {
+-	try {
+-		return createRequire(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
+-	} catch {
+-		return;
+-	}
++const JS_IDENTIFIER_PATTERN = `[\$_\\p{ID_Start}][\$_\\u200C\\u200D\\p{ID_Continue}]*`;
++const localRequire = createRequire$1(import.meta.url);
++function resolvePackageEntryFromProjectRoot(pkg) {
++	try {
++		return createRequire$1(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
++	} catch {
++		return;
++	}
+ }
+ function getPackageEsmEntryPath(pkg) {
+ 	return getInstalledPackageEntry(pkg, {
+@@ -775,9 +905,11 @@ function getPackageEsmEntryPath(pkg) {
+ 		resolveSubpathWithRequire: false
+ 	}) || resolvePackageEntryFromProjectRoot(pkg);
+ }
+-function getEsmNamedExportsFromFile(entryPath) {
++function getEsmNamedExports(pkg) {
+ 	let source = "";
++	let entryPath;
+ 	try {
++		entryPath = getPackageEsmEntryPath(pkg);
+ 		if (!entryPath) return [];
+ 		const { initSync, parse } = localRequire("es-module-lexer");
+ 		initSync();
+@@ -792,48 +924,6 @@ function getEsmNamedExportsFromFile(entryPath) {
+ 		return source ? getNamedExportsViaRegex(source, entryPath) : [];
+ 	}
+ }
+-function getEsmNamedExports(pkg) {
+-	return getEsmNamedExportsFromFile(getPackageEsmEntryPath(pkg));
+-}
+-function resolveConfiguredImportPath(importSource) {
+-	if (path.isAbsolute(importSource)) return resolveFileLikeModule(importSource);
+-	const projectRoot = getPackageDetectionCwd();
+-	if (importSource.startsWith(".")) return resolveFileLikeModule(path.resolve(projectRoot, importSource));
+-	const esmEntry = getInstalledPackageEntry(importSource, {
+-		conditions: [
+-			"browser",
+-			"import",
+-			"module",
+-			"default"
+-		],
+-		resolveSubpathWithRequire: false
+-	});
+-	if (esmEntry) return esmEntry;
+-	try {
+-		return createRequire(new URL(`file://${path.join(projectRoot, "package.json")}`)).resolve(importSource);
+-	} catch {
+-		return;
+-	}
+-}
+-function resolveFileLikeModule(filePath) {
+-	if (existsSync(filePath) && !statSync(filePath).isDirectory()) return filePath;
+-	const extensions = [
+-		".ts",
+-		".tsx",
+-		".js",
+-		".jsx",
+-		".mjs",
+-		".mts"
+-	];
+-	for (const ext of extensions) {
+-		const candidate = filePath + ext;
+-		if (existsSync(candidate) && !statSync(candidate).isDirectory()) return candidate;
+-	}
+-	for (const ext of extensions) {
+-		const candidate = path.join(filePath, "index" + ext);
+-		if (existsSync(candidate) && !statSync(candidate).isDirectory()) return candidate;
+-	}
+-}
+ function resolveRelativeModule(filePath, specifier) {
+ 	const dir = path.dirname(filePath);
+ 	const exact = path.resolve(dir, specifier);
+@@ -860,25 +950,12 @@ function getNamedExportsViaRegex(source, filePath, visited) {
+ 	const names = /* @__PURE__ */ new Set();
+ 	visited = visited || /* @__PURE__ */ new Set();
+ 	if (filePath) visited.add(filePath);
+-	const declRegex = new RegExp(`export\\s+(?:async\\s+)?(?:function(?:\\*\\s*|\\s+\\*?\\s*)|const\\s+|let\\s+|var\\s+|class\\s+|enum\\s+|namespace\\s+)(${JS_IDENTIFIER_PATTERN})`, "gu");
++	const declRegex = new RegExp(`export\\s+(?:async\\s+)?(?:function(?:\\*\\s*|\\s+\\*?\\s*)|const\\s+|let\\s+|var\\s+|class\\s+)(${JS_IDENTIFIER_PATTERN})`, "gu");
+ 	let match;
+ 	while ((match = declRegex.exec(source)) !== null) {
+ 		const name = match[1];
+ 		if (isValidEsmExportName(name)) names.add(name);
+ 	}
+-	const destructureRegex = /export\s+(?:const|let|var)\s+(\{[^}]*\}|\[[^\]]*\])\s*=/g;
+-	const bindingNameRegex = new RegExp(`^(${JS_IDENTIFIER_PATTERN})`, "u");
+-	while ((match = destructureRegex.exec(source)) !== null) {
+-		const inner = match[1].slice(1, -1);
+-		for (const part of inner.split(",")) {
+-			let token = part.split("=")[0].trim();
+-			if (token.startsWith("...")) token = token.slice(3).trim();
+-			if (!token) continue;
+-			if (token.includes(":")) token = token.slice(token.indexOf(":") + 1).trim();
+-			const bindingMatch = token.match(bindingNameRegex);
+-			if (bindingMatch && isValidEsmExportName(bindingMatch[1])) names.add(bindingMatch[1]);
+-		}
+-	}
+ 	const listRegex = /export\s*\{([^}]+)\}/g;
+ 	const typeOnlySpecifierRegex = new RegExp(`^type\\s+${JS_IDENTIFIER_PATTERN}(?:\\s+as\\s+${JS_IDENTIFIER_PATTERN})?$`, "u");
+ 	const exportSpecifierRegex = new RegExp(`(?:\\S+\\s+as\\s+)?(${JS_IDENTIFIER_PATTERN})$`, "u");
+@@ -910,55 +987,31 @@ function getNamedExportsViaRegex(source, filePath, visited) {
+ }
+ function getPackageNamedExports(pkg) {
+ 	try {
+-		const mod = createRequire(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`))(pkg);
++		const mod = createRequire$1(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`))(pkg);
+ 		return Object.keys(mod).filter((k) => isValidEsmExportName(k));
+ 	} catch {
+ 		return getEsmNamedExports(pkg);
+ 	}
+ }
+-function getSharedNamedExports(pkg, shareItem) {
+-	const configuredImport = shareItem?.shareConfig.import;
+-	if (typeof configuredImport === "string") {
+-		const configuredNamedExports = getEsmNamedExportsFromFile(resolveConfiguredImportPath(configuredImport));
+-		if (configuredNamedExports.length > 0) return configuredNamedExports;
+-	}
+-	return getPackageNamedExports(pkg);
+-}
+ function getLocalProviderImportPath(pkg) {
+ 	try {
+-		const resolved = createRequire(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
++		const resolved = createRequire$1(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
+ 		return isWorkspaceFilePath(resolved) ? resolved : void 0;
+ 	} catch {
+-		const resolved = getInstalledPackageEntry(pkg, {
+-			conditions: [
+-				"browser",
+-				"import",
+-				"module",
+-				"default"
+-			],
+-			resolveSubpathWithRequire: false
+-		});
+-		return isWorkspaceFilePath(resolved) ? resolved : void 0;
++		return;
+ 	}
+ }
+ function getProjectResolvedImportPath(pkg) {
+-	if (pkg === getPackageName(pkg)) {
+-		const esmEntry = getPackageEsmEntryPath(pkg);
+-		if (esmEntry) return esmEntry;
+-	}
++	const esmEntry = getPackageEsmEntryPath(pkg);
++	if (esmEntry) return esmEntry;
+ 	try {
+-		return createRequire(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
++		return createRequire$1(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(pkg);
+ 	} catch {
+ 		return;
+ 	}
+ }
+ function isWorkspaceFilePath(resolved) {
+-	if (!resolved) return false;
+-	let realResolved = resolved;
+-	try {
+-		realResolved = realpathSync.native(resolved);
+-	} catch {}
+-	return !realResolved.includes("/node_modules/") && !realResolved.includes("\\node_modules\\");
++	return !!resolved && !resolved.includes("/node_modules/") && !resolved.includes("\\node_modules\\");
+ }
+ function isWorkspacePackageEntry(pkg, resolved) {
+ 	if (!resolved || !path.isAbsolute(resolved) || !isWorkspaceFilePath(resolved)) return false;
+@@ -969,7 +1022,7 @@ function isWorkspacePackageEntry(pkg, resolved) {
+ }
+ function tryResolveImportFromPackageRoot(pkg, root) {
+ 	try {
+-		return createRequire(new URL(`file://${path.join(root, "package.json")}`)).resolve(pkg);
++		return createRequire$1(new URL(`file://${path.join(root, "package.json")}`)).resolve(pkg);
+ 	} catch {
+ 		return;
+ 	}
+@@ -991,23 +1044,9 @@ const preBuildCacheMap = {};
+ const preBuildShareItemMap = {};
+ const PREBUILD_TAG = "__prebuild__";
+ function writePreBuildLibPath(pkg, shareItem) {
+-	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG, ".js");
++	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG);
+ 	preBuildShareItemMap[pkg] = shareItem;
+ 	const importSource = getConcreteSharedImportSource(pkg, shareItem) || pkg;
+-	if (pkg === "react/compiler-runtime") {
+-		preBuildCacheMap[pkg].writeSync(`
+-    const __mfCacheGlobalKey = "__mf_module_cache__";
+-    export const c = function(size) {
+-      const cache = globalThis[__mfCacheGlobalKey]?.share;
+-      const sharedReact = cache?.['react'];
+-      const reactExports = sharedReact?.default ?? sharedReact;
+-      const internals = reactExports?.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+-      return internals?.H?.useMemoCache(size);
+-    };
+-    export default { c };
+-  `, true);
+-		return;
+-	}
+ 	if (pkg === "react/jsx-dev-runtime") {
+ 		preBuildCacheMap[pkg].writeSync(`
+     import __mfPrebuildDefault from ${escapeGeneratedStringLiteral(importSource)};
+@@ -1028,20 +1067,6 @@ function writePreBuildLibPath(pkg, shareItem) {
+     export const jsx = __mfPrebuildExports.jsx;
+     export const jsxs = __mfPrebuildExports.jsxs;
+     export default __mfPrebuildExports;
+-  `, true);
+-		return;
+-	}
+-	const namedExports = getSharedNamedExports(pkg, shareItem);
+-	if (namedExports.length > 0) {
+-		const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+-		const declarations = namedExports.map((name, i) => `const ${namedExportVars[i]} = __mfPrebuildExports[${escapeGeneratedStringLiteral(name)}];`).join("\n    ");
+-		const namedExportLine = `export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(", ")} };`;
+-		preBuildCacheMap[pkg].writeSync(`
+-    import * as __mfPrebuildNamespace from ${escapeGeneratedStringLiteral(importSource)};
+-    const __mfPrebuildExports = __mfPrebuildNamespace;
+-    ${declarations}
+-    ${namedExportLine}
+-    export default __mfPrebuildExports;
+   `, true);
+ 		return;
+ 	}
+@@ -1052,7 +1077,7 @@ function writePreBuildLibPath(pkg, shareItem) {
+   `, true);
+ }
+ function getPreBuildLibImportId(pkg) {
+-	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG, ".js");
++	if (!preBuildCacheMap[pkg]) preBuildCacheMap[pkg] = new VirtualModule(pkg, PREBUILD_TAG);
+ 	return preBuildCacheMap[pkg].getImportId();
+ }
+ function getPreBuildShareItem(pkg) {
+@@ -1069,84 +1094,25 @@ function getLoadShareImportId(pkg, _isRolldown) {
+ }
+ function getLoadShareModulePath(pkg, isRolldown) {
+ 	if (!loadShareCacheMap[pkg]) getLoadShareImportId(pkg, isRolldown);
+-	return loadShareCacheMap[pkg].getImportId();
++	return loadShareCacheMap[pkg].getPath();
+ }
+-function toViteOptimizedDepVirtualId(id) {
+-	return toViteEncodedId(id);
+-}
+-function getCachedLoadSharePkg(id) {
+-	const normalized = normalizeVirtualModuleId(id);
+-	if (!normalized.startsWith("virtual:mf:")) return;
+-	const pkg = VirtualModule.findName(LOAD_SHARE_TAG, normalized);
+-	if (!pkg) return;
+-	return pkg;
+-}
+-function materializeCachedLoadShareModule(options) {
+-	const pkg = getCachedLoadSharePkg(options.id);
+-	if (!pkg) return;
+-	const key = options.findSharedKey(pkg, options.shared);
+-	if (!key) return;
+-	const shareItem = options.shared[key];
+-	writeLoadShareModule(pkg, shareItem, options.command, options.isRolldown);
+-	if (shareItem.shareConfig?.import !== false) writePreBuildLibPath(pkg, shareItem);
+-	options.addUsedShares(pkg);
+-	options.writeLocalSharedImportMap();
+-}
+-function generateDeferredHostProvidedExports(namedExports, pkg, cacheKey) {
+-	const namedExportVars = namedExports.map((_name, i) => `__mf_${i}`);
+-	const declarations = ["let __mf_default;", ...namedExportVars.map((name) => `let ${name};`)].join("\n    ");
+-	const assignments = [...namedExports.map((name, i) => `${namedExportVars[i]} = exportModule[${escapeGeneratedStringLiteral(name)}];`), "__mf_default = exportModule.default ?? exportModule;"].join("\n      ");
+-	const namedExportLine = namedExports.length > 0 ? `\n    export { ${namedExports.map((name, i) => `${namedExportVars[i]} as ${name}`).join(", ")} };` : "";
+-	return `${declarations}
+-    const __mfApplyHostProvidedExports = (exportModule) => {
+-      ${assignments}
+-    };
+-    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}];
+-    if (exportModule === undefined) {
+-      initPromise.then(() => {
+-        exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}];
+-        if (exportModule === undefined) {
+-          throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.");
+-        }
+-        __mfApplyHostProvidedExports(exportModule);
+-      });
+-    } else {
+-      __mfApplyHostProvidedExports(exportModule);
+-    }
+-    export { __mf_default as default };${namedExportLine}`;
+-}
+-function generateShareModuleUnwrapCode({ source, preserveNamedExports, stopWithReturn }) {
+-	return `let current = ${source};
+-      for (let i = 0; i < 5; i++) {
+-        const defaultExport = current?.default;
+-        ${stopWithReturn ? `if (!defaultExport || typeof defaultExport !== "object") return ${stopWithReturn};` : `if (!defaultExport || typeof defaultExport !== "object") break;`}${preserveNamedExports ? `
+-        const namedValues = Object.keys(current).filter((key) => key !== "default").map((key) => current[key]);
+-        if (namedValues.length > 0 && namedValues.some((value) => value !== undefined)) break;` : ""}
+-        current = defaultExport;
+-      }
+-      return current;`;
+-}
+-const normalizeLocalShareModuleCode = `const __mfNormalizeShareModule = (mod) => {
+-      ${generateShareModuleUnwrapCode({
+-	source: "mod",
+-	preserveNamedExports: true
+-})}
+-    };`;
+ function writeLoadShareModule(pkg, shareItem, command, _isRolldown) {
+ 	if (!loadShareCacheMap[pkg]) loadShareCacheMap[pkg] = new VirtualModule(pkg, LOAD_SHARE_TAG, ".mjs");
+ 	const importLine = getRuntimeModuleCacheBootstrapCode();
+-	const cacheKey = getSharedCacheKey(pkg, shareItem);
+ 	if (shareItem.shareConfig.import === false) {
+ 		const namedExports = getPackageNamedExports(pkg);
+ 		let exportLine;
+-		if (namedExports.length > 0) exportLine = generateDeferredHostProvidedExports(namedExports, pkg, cacheKey);
++		if (namedExports.length > 0) exportLine = `export default exportModule.default ?? exportModule;\n    ${`const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(", ")} } = exportModule;`}\n    ${`export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(", ")} };`}`;
+ 		else {
+ 			mfWarn(`Shared dependency "${pkg}" has import: false but is not installed locally.\n  Named imports (e.g. import { ... } from '${pkg}') will not work in production builds.\n  Install it as a devDependency to enable named export detection.`);
+-			exportLine = generateDeferredHostProvidedExports([], pkg, cacheKey);
++			exportLine = "export default exportModule.default ?? exportModule";
+ 		}
+ 		loadShareCacheMap[pkg].writeSync(`
+-    ${getRuntimeInitPromiseBootstrapCode()}
+     ${importLine}
++    const exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
++    if (exportModule === undefined) {
++      throw new Error("[Module Federation] Shared module ${pkg} was imported before federation bootstrap finished.")
++    }
+     ${exportLine}
+   `, true);
+ 		return;
+@@ -1158,36 +1124,22 @@ function writeLoadShareModule(pkg, shareItem, command, _isRolldown) {
+ 	const isWorkspacePackage = isWorkspacePackageEntry(pkg, localProviderPath) || isWorkspacePackageEntry(pkg, concreteSharedImportSource);
+ 	const lazyLocalFallbackSource = concreteSharedImportSource || localProviderPath || sharedImportSource;
+ 	const skipServePrebuildWarmup = command !== "build" && (pkg === "lit" || pkg.startsWith("lit/"));
+-	const usesLazyLocalFallback = isWorkspacePackage && shareItem.shareConfig.singleton === true;
+-	const namedExports = getSharedNamedExports(pkg, shareItem);
++	const namedExports = getPackageNamedExports(pkg);
+ 	let exportLine;
+-	if (namedExports.length > 0) {
+-		const destructure = `const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(", ")} } = exportModule;`;
+-		const namedExportLine = `export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(", ")} };`;
+-		exportLine = `const __mfDefaultExport = (() => {
+-      ${generateShareModuleUnwrapCode({
+-			source: "exportModule",
+-			preserveNamedExports: false,
+-			stopWithReturn: "defaultExport ?? current"
+-		})}
+-    })();
+-    export default __mfDefaultExport;
+-    ${destructure}
+-    ${namedExportLine}`;
+-	} else if (usesLazyLocalFallback) exportLine = `export default exportModule.default ?? exportModule`;
++	if (namedExports.length > 0) exportLine = `export default exportModule.default ?? exportModule;\n    ${`const { ${namedExports.map((name, i) => `${name}: __mf_${i}`).join(", ")} } = exportModule;`}\n    ${`export { ${namedExports.map((name, i) => `__mf_${i} as ${name}`).join(", ")} };`}`;
+ 	else exportLine = `export default exportModule.default ?? exportModule\n    export * from ${escapeGeneratedStringLiteral(sharedImportSource)}`;
+-	const prebuildImportLine = usesLazyLocalFallback || isWorkspacePackage && command !== "build" ? "" : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(skipServePrebuildWarmup ? devImportSource : sharedImportSource)};`;
++	const usesLazyLocalFallback = isWorkspacePackage && shareItem.shareConfig.singleton === true;
++	const prebuildImportLine = usesLazyLocalFallback || isWorkspacePackage && command !== "build" || skipServePrebuildWarmup ? "" : `import * as __mfLocalShare from ${escapeGeneratedStringLiteral(sharedImportSource)};`;
+ 	const devDynamicImportLine = isWorkspacePackage ? "" : command !== "build" && !skipServePrebuildWarmup ? `;() => import(${escapeGeneratedStringLiteral(devImportSource)}).catch(() => {});` : "";
+ 	loadShareCacheMap[pkg].writeSync(`
+     ${prebuildImportLine}
+     ${devDynamicImportLine}
+     ${importLine}
+-    ${normalizeLocalShareModuleCode}
+-    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}]
++    let exportModule = __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}]
+     if (exportModule === undefined) {
+-      ${usesLazyLocalFallback ? `exportModule = __mfNormalizeShareModule(await import(${escapeGeneratedStringLiteral(lazyLocalFallbackSource)}));
+-      __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;` : `exportModule = __mfNormalizeShareModule(__mfLocalShare);
+-      __mfModuleCache.share[${escapeGeneratedStringLiteral(cacheKey)}] = exportModule;`}
++      ${usesLazyLocalFallback ? `exportModule = await import(${escapeGeneratedStringLiteral(lazyLocalFallbackSource)});
++      __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}] = exportModule;` : `exportModule = __mfLocalShare;
++      __mfModuleCache.share[${escapeGeneratedStringLiteral(pkg)}] = exportModule;`}
+     }
+     ${exportLine}
+   `, true);
+@@ -1201,24 +1153,15 @@ function getUsedShares() {
+ function addUsedShares(pkg) {
+ 	usedShares.add(pkg);
+ }
+-const LOCAL_SHARED_IMPORT_MAP_ID = "virtual:mf-localSharedImportMap";
+ function getLocalSharedImportMapPath() {
+-	const { internalName, name } = getNormalizeModuleFederationOptions();
+-	return `${LOCAL_SHARED_IMPORT_MAP_ID}:${packageNameEncode(internalName || name)}`;
+-}
+-function getResolvedLocalSharedImportMapId() {
+-	return `\0${getLocalSharedImportMapPath()}`;
+-}
+-let invalidateLocalSharedImportMap;
+-function setLocalSharedImportMapInvalidator(invalidator) {
+-	invalidateLocalSharedImportMap = invalidator;
++	return getLocalSharedImportMapPath_temp();
+ }
+ let prevLocalSharedImportMapContent;
+ function writeLocalSharedImportMap() {
+ 	const nextContent = generateLocalSharedImportMap();
+ 	if (prevLocalSharedImportMapContent !== nextContent) {
+ 		prevLocalSharedImportMapContent = nextContent;
+-		invalidateLocalSharedImportMap?.();
++		writeLocalSharedImportMap_temp(nextContent);
+ 	}
+ }
+ function shouldUseDirectReactImport() {
+@@ -1259,7 +1202,7 @@ function generateLocalSharedImportMap() {
+             version: ${JSON.stringify(shareItem.version)},
+             scope: [${JSON.stringify(shareItem.scope)}],
+             loaded: false,
+-            from: ${JSON.stringify(options.name)},
++            from: ${JSON.stringify(options.internalName)},
+             async get () {
+               if (${shareItem.shareConfig.import === false}) {
+                 throw new Error(\`[Module Federation] Shared module '\${${JSON.stringify(key)}}' must be provided by host\`);
+@@ -1327,7 +1270,7 @@ function getOrderedUsedShares() {
+ 	const shares = new Set(getUsedShares());
+ 	try {
+ 		Object.keys(getNormalizeModuleFederationOptions().shared).forEach((pkg) => {
+-			if (!pkg.endsWith("/")) shares.add(pkg);
++			shares.add(pkg.endsWith("/") ? pkg.slice(0, -1) : pkg);
+ 		});
+ 	} catch {}
+ 	return Array.from(shares).sort((a, b) => {
+@@ -1336,72 +1279,30 @@ function getOrderedUsedShares() {
+ 	});
+ }
+ function getShareItemForPreload(pkg) {
+-	const shared = getNormalizeModuleFederationOptions().shared;
+-	const wildcardKey = `${pkg.startsWith("@") ? pkg.split("/").slice(0, 2).join("/") : pkg.split("/")[0]}/`;
+-	if (isExplicitSharedKey(pkg)) return shared[pkg];
+-	if (isExplicitSharedKey(wildcardKey)) return shared[wildcardKey];
+-}
+-function generateSharedCacheSeedItem(pkg, shareItem, importPath) {
+-	const cacheKey = getSharedCacheKey(pkg, shareItem);
+-	return `if (__mfModuleCache.share[${JSON.stringify(cacheKey)}] === undefined) {
++	return getNormalizeShareItem(pkg) || getNormalizeShareItem(`${pkg}/`);
++}
++function generateDirectSharedCacheSeedCode(command = "build") {
++	return getOrderedUsedShares().map((pkg) => {
++		const shareItem = getShareItemForPreload(pkg);
++		if (!shareItem || shareItem.shareConfig.import === false) return null;
++		const importPath = command === "serve" ? getLocalSharedPackagePath(pkg, shareItem) : getDirectSharedCacheSeedImportPath(pkg, shareItem);
++		return `if (__mfModuleCache.share[${JSON.stringify(pkg)}] === undefined) {
+         const mod = await import(${JSON.stringify(importPath)});
+-        ${normalizeRuntimeShareCode}
+-        const normalizedModule = __mfNormalizeRuntimeShare(mod);
+-        const exportModule = normalizedModule === mod ? {...mod} : normalizedModule;
++        const exportModule = ${JSON.stringify(shouldUseDirectReactImport())} && ${JSON.stringify(pkg)} === "react"
++          ? (mod?.default ?? mod)
++          : {...mod};
+         Object.defineProperty(exportModule, "__esModule", {
+           value: true,
+           enumerable: false
+         });
+-        __mfModuleCache.share[${JSON.stringify(cacheKey)}] = exportModule;
++        __mfModuleCache.share[${JSON.stringify(pkg)}] = exportModule;
+       }`;
+-}
+-const normalizeRuntimeShareCode = `const __mfNormalizeRuntimeShare = (mod) => {
+-            let current = mod;
+-            for (let i = 0; i < 5; i++) {
+-              const defaultExport = current?.default;
+-              if (!defaultExport || typeof defaultExport !== "object" || Object.keys(defaultExport).length === 0) break;
+-              const namedValues = Object.keys(current).filter((key) => key !== "default").map((key) => current[key]);
+-              if (namedValues.length > 0 && namedValues.some((value) => value !== undefined)) break;
+-              current = defaultExport;
+-            }
+-            return current;
+-          };`;
+-function generateDirectSharedCacheSeedCode(command = "build") {
+-	return getOrderedUsedShares().map((pkg) => {
+-		const shareItem = getShareItemForPreload(pkg);
+-		if (!shareItem || shareItem.shareConfig.import === false) return null;
+-		return generateSharedCacheSeedItem(pkg, shareItem, command === "serve" ? getLocalSharedPackagePath(pkg, shareItem) : getDirectSharedCacheSeedImportPath(pkg, shareItem));
+-	}).filter((item) => item !== null).join("\n");
+-}
+-function getBrowserImportPath(importPath) {
+-	if (/^(?:[a-zA-Z]:[\\/]|\/)/.test(importPath) && !importPath.startsWith("/@")) return `/@fs/${importPath}`;
+-	return importPath;
+-}
+-function getHostAutoInitSharedSeedItems() {
+-	return getOrderedUsedShares().map((pkg) => ({
+-		pkg,
+-		shareItem: getShareItemForPreload(pkg)
+-	})).filter(({ shareItem }) => shareItem?.shareConfig.import === false).sort((a, b) => {
+-		const priority = (pkg) => pkg === "vue" ? 0 : pkg === "pinia" ? 1 : 2;
+-		const aIsLocal = !!getLocalProviderImportPath(a.pkg);
+-		const bIsLocal = !!getLocalProviderImportPath(b.pkg);
+-		return priority(a.pkg) - priority(b.pkg) || Number(aIsLocal) - Number(bIsLocal) || a.pkg.localeCompare(b.pkg);
+-	});
+-}
+-function generateHostAutoInitSharedCacheSeedCode(command = "build") {
+-	if (command === "build") return "";
+-	return getHostAutoInitSharedSeedItems().map(({ pkg, shareItem }) => {
+-		if (!shareItem) return null;
+-		return generateSharedCacheSeedItem(pkg, shareItem, getBrowserImportPath(getDirectSharedCacheSeedImportPath(pkg, shareItem)));
+ 	}).filter((item) => item !== null).join("\n");
+ }
+ const REMOTE_ENTRY_ID = "virtual:mf-REMOTE_ENTRY_ID";
+ function getRemoteEntryId(options) {
+ 	return `${REMOTE_ENTRY_ID}:${`${options.internalName}__${options.filename}`.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+ }
+-const SSR_ONLY_PLUGIN_SPECIFIERS = new Set(["@module-federation/vite/ssrEntryLoader"]);
+-const isSsrOnlyPlugin = (importStatement) => [...SSR_ONLY_PLUGIN_SPECIFIERS].some((s) => importStatement.includes(s));
+-const getSsrOnlyPluginSpecifier = (importStatement) => [...SSR_ONLY_PLUGIN_SPECIFIERS].find((s) => importStatement.includes(s));
+ function generateRemoteEntry(options, virtualExposesId = getVirtualExposesId(options), command = "build") {
+ 	const pluginImportNames = options.runtimePlugins.map((p, i) => {
+ 		if (typeof p === "string") return [
+@@ -1425,89 +1326,33 @@ function generateRemoteEntry(options, virtualExposesId = getVirtualExposesId(opt
+     globalThis.__VUE_HMR_RUNTIME__ = { createRecord() {}, rerender() {}, reload() {} };
+   }
+   import {init as runtimeInit, loadRemote} from "@module-federation/runtime";
+-  ${pluginImportNames.filter((item) => !isSsrOnlyPlugin(item[1])).map((item) => item[1]).join("\n")}
++  ${pluginImportNames.map((item) => item[1]).join("\n")}
+   ${command === "build" ? getRuntimeInitResolveBootstrapCode() : getRuntimeInitBootstrapCode() + "\n  const { initResolve } = globalThis[globalKey];"}
+   ${getRuntimeModuleCacheBootstrapCode()}
+   const initTokens = {}
+   const shareScopeName = ${JSON.stringify(options.shareScope)}
+-  const mfName = ${JSON.stringify(options.name)}
++  const mfName = ${JSON.stringify(options.internalName)}
+   let localSharedImportMapPromise
+   let exposesMapPromise
+-  const shouldRetrySharedInitError = ${command !== "build"} && ((error) => {
+-    const message = String((error && error.message) || error || '');
+-    return message.includes('Importing a module script failed') ||
+-      message.includes('Failed to fetch') ||
+-      message.includes('Load failed') ||
+-      message.includes('Outdated Optimize Dep');
+-  });
+-  const waitSharedInitRetry = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+-  async function retrySharedInit(fn) {
+-    for (let attempt = 0; ; attempt++) {
+-      try {
+-        return await fn();
+-      } catch (e) {
+-        const canRetry = typeof shouldRetrySharedInitError === 'function' && shouldRetrySharedInitError(e);
+-        if (!canRetry || attempt >= 19) throw e;
+-        await waitSharedInitRetry(250);
+-      }
+-    }
+-  }
+ 
+   async function getLocalSharedImportMap() {
+-    if (!localSharedImportMapPromise) {
+-      localSharedImportMapPromise = retrySharedInit(() => import("${getLocalSharedImportMapPath()}"))
+-        .catch((e) => { localSharedImportMapPromise = undefined; throw e; });
+-    }
++    localSharedImportMapPromise ??= import("${getLocalSharedImportMapPath()}")
+     return localSharedImportMapPromise
+   }
+ 
+   async function getExposesMap() {
+-    if (!exposesMapPromise) {
+-      exposesMapPromise = retrySharedInit(() => import("${virtualExposesId}"))
+-        .then((mod) => mod.default ?? mod)
+-        .catch((e) => { exposesMapPromise = undefined; throw e; });
+-    }
++    exposesMapPromise ??= import("${virtualExposesId}").then((mod) => mod.default ?? mod)
+     return exposesMapPromise
+   }
+ 
+   async function init(shared = {}, initScope = []) {
+     const {usedShared, usedRemotes} = await getLocalSharedImportMap()
+-    try {
+-      const allInstances = globalThis.__FEDERATION__?.__SHARE__;
+-      if (allInstances) {
+-        ${normalizeRuntimeShareCode}
+-        for (const [, scopes] of Object.entries(allInstances)) {
+-          const scopeShare = scopes?.['${options.shareScope}'];
+-          if (!scopeShare) continue;
+-          for (const [pkg, versionMap] of Object.entries(scopeShare)) {
+-            for (const [version, provider] of Object.entries(versionMap)) {
+-              if (!provider.lib) continue;
+-              const cacheKey = provider.shareConfig?.singleton ? pkg : \`\${pkg}@\${version}\`;
+-              if (__mfModuleCache.share[cacheKey] !== undefined) continue;
+-              const mod = typeof provider.lib === "function" ? provider.lib() : provider.lib;
+-              const resolved = await Promise.resolve(mod);
+-              __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
+-            }
+-          }
+-        }
+-      }
+-    } catch (e) {
+-      console.error('[Module Federation] Failed to bridge external shared modules', e)
+-    }
+     ${generateDirectSharedCacheSeedCode(command)}
+-    const __browserPlugins = [${pluginImportNames.filter((item) => !isSsrOnlyPlugin(item[1])).map((item) => `${item[0]}(${item[2]})`).join(", ")}];
+-    const __ssrPlugins = typeof globalThis.window === 'undefined'
+-      ? await Promise.all([${pluginImportNames.filter((item) => isSsrOnlyPlugin(item[1])).map((item) => {
+-		const specifier = getSsrOnlyPluginSpecifier(item[1]);
+-		const opts = item[2];
+-		return `import(${JSON.stringify(specifier)}).then(m => (m.default ?? m)(${opts}))`;
+-	}).join(", ")}])
+-      : [];
+     const initRes = runtimeInit({
+       name: mfName,
+-      remotes: ${options.shareStrategy === "loaded-first" ? "[]" : "usedRemotes"},
++      remotes: usedRemotes,
+       shared: usedShared,
+-      plugins: [...__browserPlugins, ...__ssrPlugins],
++      plugins: [${pluginImportNames.map((item) => `${item[0]}(${item[2]})`).join(", ")}],
+       ${options.shareStrategy ? `shareStrategy: '${options.shareStrategy}'` : ""}
+     });
+     // handling circular init calls
+@@ -1519,28 +1364,14 @@ function generateRemoteEntry(options, virtualExposesId = getVirtualExposesId(opt
+     initRes.initShareScopeMap('${options.shareScope}', shared);
+     initResolve(initRes)
+     try {
+-      await retrySharedInit(async () => {
+-        await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
+-          strategy: '${options.shareStrategy}',
+-          from: "build",
+-          initScope
+-        }));
+-      });
++      await Promise.all(await initRes.initializeSharing('${options.shareScope}', {
++        strategy: '${options.shareStrategy}',
++        from: "build",
++        initScope
++      }));
+     } catch (e) {
+       console.error('[Module Federation]', e)
+     }
+-    for (const [pkg, share] of Object.entries(usedShared)) {
+-      const cacheKey = share.shareConfig?.singleton || !share.version ? pkg : \`\${pkg}@\${share.version}\`;
+-      if (share.shareConfig?.import !== false || __mfModuleCache.share[cacheKey] !== undefined) continue;
+-      ${normalizeRuntimeShareCode}
+-      const versions = shared?.[pkg];
+-      const provider = versions && versions[Object.keys(versions)[0]];
+-      if (!provider) continue;
+-      const factory = provider.lib || (provider.loading ? await provider.loading : await provider.get?.());
+-      const mod = typeof factory === "function" ? factory() : factory;
+-      const resolved = await Promise.resolve(mod);
+-      __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
+-    }
+     return initRes
+   }
+ 
+@@ -1559,22 +1390,17 @@ const hostAutoInitModule = new VirtualModule("hostAutoInit", "__H_A_I__");
+ let currentHostAutoInitRemoteEntryId = REMOTE_ENTRY_ID;
+ let currentHostAutoInitCommand = "build";
+ function generateHostAutoInitCode(remoteEntryImport, _command = "build") {
+-	const shouldPreloadShares = getNormalizeModuleFederationOptions().shareStrategy !== "loaded-first";
+ 	return `
+     ${getRuntimeModuleCacheBootstrapCode()}
+     let hostInitPromise;
+     async function initHost() {
+       if (!hostInitPromise) {
+         hostInitPromise = (async () => {
+-          ${generateHostAutoInitSharedCacheSeedCode(_command)}
+           const remoteEntry = await import(${remoteEntryImport});
+           const runtime = await remoteEntry.init();
+           const usedShared = ${generateUsedSharedPreloadConfig()};
+-          ${normalizeRuntimeShareCode}
+-          ${shouldPreloadShares ? `
+           for (const [pkg, share] of Object.entries(usedShared)) {
+-            const cacheKey = share.shareConfig?.singleton || !share.version ? pkg : \`\${pkg}@\${share.version}\`;
+-            if (__mfModuleCache.share[cacheKey] !== undefined) {
++            if (__mfModuleCache.share[pkg] !== undefined) {
+               continue;
+             }
+             await runtime.loadShare(pkg, {
+@@ -1582,11 +1408,10 @@ function generateHostAutoInitCode(remoteEntryImport, _command = "build") {
+             }).then((factory) => {
+               const mod = typeof factory === "function" ? factory() : factory;
+               return Promise.resolve(mod).then((resolved) => {
+-                __mfModuleCache.share[cacheKey] = __mfNormalizeRuntimeShare(resolved);
++                __mfModuleCache.share[pkg] = resolved;
+               });
+             });
+           }
+-          ` : ""}
+           const __mfRemotePreloads = [];
+           await Promise.all(__mfRemotePreloads);
+           return runtime;
+@@ -1612,19 +1437,18 @@ function getHostAutoInitImportId() {
+ 	return hostAutoInitModule.getImportId();
+ }
+ function getHostAutoInitPath() {
+-	return hostAutoInitModule.getImportId();
++	return hostAutoInitModule.getPath();
+ }
+ //#endregion
+ //#region src/virtualModules/virtualRemotes.ts
+ const cacheRemoteMap = {};
+ const LOAD_REMOTE_TAG = "__loadRemote__";
+-function getRemoteVirtualModule(remote, command, enableSsrInit = false) {
+-	const cacheKey = `${remote}__${command}__${enableSsrInit ? "ssr" : "no-ssr"}`;
+-	if (!cacheRemoteMap[cacheKey]) {
+-		cacheRemoteMap[cacheKey] = new VirtualModule(remote, LOAD_REMOTE_TAG, ".mjs");
+-		cacheRemoteMap[cacheKey].writeSync(generateRemotes(remote, command, enableSsrInit));
++function getRemoteVirtualModule(remote, command) {
++	if (!cacheRemoteMap[remote]) {
++		cacheRemoteMap[remote] = new VirtualModule(remote, LOAD_REMOTE_TAG, ".mjs");
++		cacheRemoteMap[remote].writeSync(generateRemotes(remote, command));
+ 	}
+-	return cacheRemoteMap[cacheKey];
++	return cacheRemoteMap[remote];
+ }
+ const usedRemotesMap = {};
+ function addUsedRemote(remoteKey, remoteModule) {
+@@ -1634,93 +1458,38 @@ function addUsedRemote(remoteKey, remoteModule) {
+ function getUsedRemotesMap() {
+ 	return usedRemotesMap;
+ }
+-function getRemoteFromId(id, remotes) {
+-	const remoteName = Object.keys(remotes).filter((name) => id === name || id.startsWith(name + "/")).sort((a, b) => b.length - a.length)[0];
+-	return remoteName ? remotes[remoteName] : void 0;
+-}
+-function generateRemotes(id, command, enableSsrInit = false) {
+-	const useReactProxy = hasPackageDependency("react");
+-	const options = getNormalizeModuleFederationOptions();
+-	const isLoadedFirst = options.shareStrategy === "loaded-first";
+-	const remote = getRemoteFromId(id, options.remotes);
+-	const registerRemoteCode = isLoadedFirst && remote ? `runtime.registerRemotes([${JSON.stringify({
+-		entryGlobalName: remote.entryGlobalName,
+-		name: remote.name,
+-		type: remote.type,
+-		entry: remote.entry,
+-		shareScope: remote.shareScope ?? "default"
+-	})}]);` : "";
+-	const reactImportLine = useReactProxy ? `import __mfReactDefault from "react";
+-    import * as __mfReactNamespace from "react";
+-    const __mfReact = __mfReactDefault ?? __mfReactNamespace.default ?? __mfReactNamespace;` : "";
++function generateRemotes(id, command) {
++	const useReactProxy = command === "serve" && hasPackageDependency("react");
++	const reactImportLine = useReactProxy ? `import * as __mfReact from "react";` : "";
+ 	const importLine = command === "build" ? `${getRuntimeModuleCacheBootstrapCode()}
+-    import { hostInitPromise as __mfHostInitPromise } from ${JSON.stringify(getHostAutoInitPath())};` : `${getRuntimeInitBootstrapCode(enableSsrInit)}
+-    const { initPromise, initResolve, initReject, moduleCache: __mfModuleCache } = globalThis[globalKey];
+-    if (typeof window !== "undefined") {
+-      import(${JSON.stringify(getHostAutoInitPath())})
+-        .then((mod) => mod.hostInitPromise)
+-        .then(initResolve, initReject);
+-    }`;
++    import { hostInitPromise as __mfHostInitPromise } from ${JSON.stringify(getHostAutoInitPath())};` : `${getRuntimeInitBootstrapCode()}
++    const { initPromise, moduleCache: __mfModuleCache } = globalThis[globalKey];`;
+ 	const exportLine = command === "serve" ? `if (__mfRemotePending) {
+-  __mfRemotePending = __mfRemotePending.then((mod) => {
+-    if (mod !== undefined) exportModule = mod;
+-    return exportModule;
+-  });
+-}
+-export { exportModule as __moduleExports };
+-export const __mf_remote_pending = __mfRemotePending || Promise.resolve(exportModule);
+-export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : command === "build" ? `if (__mfRemotePending) {
+-  __mfRemotePending = __mfRemotePending.then((mod) => {
+-    if (mod !== undefined) exportModule = mod;
+-    return exportModule;
+-  });
+-}
+-export { exportModule as __moduleExports };
+-export const __mf_remote_pending = __mfRemotePending || Promise.resolve(exportModule);
+-export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : "export default exportModule";
+-	const remoteLoadRuntimePromise = command === "build" ? "__mfHostInitPromise" : "initPromise";
+-	const remoteLoadFailureHandler = command === "build" ? `.catch((error) => {
+-            delete __mfModuleCache.remote[pendingKey];
+-            throw error;
+-          })` : `.catch(() => {
+-            delete __mfModuleCache.remote[pendingKey];
+-          })`;
++  const mod = await __mfRemotePending;
++  if (mod !== undefined) exportModule = mod;
++}
++export const __moduleExports = exportModule;
++export const __mf_remote_pending = Promise.resolve(exportModule);
++export default exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : command === "build" ? `if (__mfRemotePending) {
++  const mod = await __mfRemotePending;
++  if (mod !== undefined) exportModule = mod;
++}
++export const __moduleExports = exportModule;
++export const __mf_remote_pending = Promise.resolve(exportModule);
++export default exportModule?.__esModule ? exportModule.default : exportModule.default ?? exportModule` : "export default exportModule";
+ 	return `
+     ${reactImportLine}
+     ${importLine}
+-    ${`
+-    function __mfStartRemoteLoad() {
+-      ${`
+-      const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};
+-      if (!__mfModuleCache.remote[pendingKey]) {
+-        __mfModuleCache.remote[pendingKey] = ${remoteLoadRuntimePromise}
+-          .then((runtime) => {
+-            ${registerRemoteCode}
+-            return runtime.loadRemote(${JSON.stringify(id)});
+-          })
+-          .then((mod) => {
+-            __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
+-            delete __mfModuleCache.remote[pendingKey];
+-            return mod;
+-          })
+-          ${remoteLoadFailureHandler};
+-      }
+-      return __mfModuleCache.remote[pendingKey];`}
+-    }
++    ${command !== "build" ? `
+     function __mfCreateRemoteProxy(pendingPromise) {
+       const listeners = new Set();
+-      const ensurePending = () => {
+-        pendingPromise ||= __mfStartRemoteLoad();
+-        pendingPromise?.finally(() => {
+-          for (const listener of listeners) listener();
+-        });
+-        return pendingPromise;
+-      };
++      pendingPromise?.finally(() => {
++        for (const listener of listeners) listener();
++      });
+       const getModule = () => __mfModuleCache.remote[${JSON.stringify(id)}];
+       const proxyTarget = function (...args) {
+         ${useReactProxy ? `const [, setVersion] = __mfReact.useState(0);
+         __mfReact.useEffect(() => {
+-          ensurePending();
+           const listener = () => setVersion((value) => value + 1);
+           listeners.add(listener);
+           if (getModule()) listener();
+@@ -1731,33 +1500,18 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
+         if (fn !== undefined && fn !== null) {
+           ${useReactProxy ? `return __mfReact.createElement(fn, args[0]);` : `return fn.apply(this, args);`}
+         }
+-        ${useReactProxy ? `return null;` : `throw ensurePending();`}
++        ${useReactProxy ? `return null;` : `throw pendingPromise;`}
+       };
+       return new Proxy(proxyTarget, {
+         get(_target, prop) {
+           if (prop === "__mf_is_remote_proxy") return true;
+           if (prop === "__esModule") return true;
+           if (prop === "then") return undefined;
+-          // Allow React's dev-mode console.warn to stringify the proxy without
+-          // throwing "Cannot convert object to primitive value".
+-          if (prop === Symbol.toPrimitive || prop === "toString")
+-            return () => "[MF remote proxy: pending]";
+           const mod = getModule();
+           if (mod) {
+             return prop in mod ? mod[prop] : mod.default?.[prop];
+           }
+-          // When the module is pending and React.lazy() checks for "default",
+-          // return the proxy function itself so React renders it (returns null)
+-          // rather than crashing on undefined.
+-          ${useReactProxy ? `if (prop === "default") return proxyTarget;
+-          return undefined;` : `throw ensurePending();`}
+-        },
+-        has(_target, prop) {
+-          const mod = getModule();
+-          if (mod) return prop in mod;
+-          // Tell React that "default" exists when module is pending so it
+-          // doesn't warn "lazy: Expected the result of a dynamic import()".
+-          ${useReactProxy ? `return prop === "default" || prop === "__esModule" || prop === "__mf_is_remote_proxy";` : `return false;`}
++          ${useReactProxy ? `return undefined;` : `throw pendingPromise;`}
+         },
+         ownKeys() {
+           const mod = getModule();
+@@ -1785,12 +1539,40 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
+           return target.apply(thisArg, args);
+         }
+       });
+-    }`}
++    }` : ""}
+     let __mfRemotePending;
+     let exportModule = __mfModuleCache.remote[${JSON.stringify(id)}]
+     if (exportModule === undefined) {
+-      __mfRemotePending = __mfStartRemoteLoad();
+-      exportModule = __mfCreateRemoteProxy(__mfRemotePending);
++      ${command !== "build" ? `const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};
++      if (!__mfModuleCache.remote[pendingKey]) {
++        __mfModuleCache.remote[pendingKey] = initPromise
++          .then((runtime) => runtime.loadRemote(${JSON.stringify(id)}))
++          .then((mod) => {
++            __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
++            delete __mfModuleCache.remote[pendingKey];
++            return mod;
++          })
++          .catch(() => {
++            delete __mfModuleCache.remote[pendingKey];
++          });
++      }` : ""}
++      ${command !== "build" ? `__mfRemotePending = __mfModuleCache.remote[pendingKey];
++      exportModule = __mfCreateRemoteProxy(__mfRemotePending);` : `const pendingKey = ${JSON.stringify(`__mf_pending__${id}`)};
++      if (!__mfModuleCache.remote[pendingKey]) {
++        __mfModuleCache.remote[pendingKey] = __mfHostInitPromise
++          .then((runtime) => runtime.loadRemote(${JSON.stringify(id)}))
++          .then((mod) => {
++            __mfModuleCache.remote[${JSON.stringify(id)}] = mod;
++            delete __mfModuleCache.remote[pendingKey];
++            return mod;
++          })
++          .catch((error) => {
++            delete __mfModuleCache.remote[pendingKey];
++            throw error;
++          });
++      }
++      __mfRemotePending = __mfModuleCache.remote[pendingKey];
++      exportModule = {};`}
+     }
+     ${exportLine}
+   `;
+@@ -1800,41 +1582,9 @@ export default exportModule?.__mf_is_remote_proxy ? exportModule : exportModule?
+ function getFirstHtmlEntryFile(entryFiles) {
+ 	return entryFiles.find((file) => file.endsWith(".html"));
+ }
+-function stripQueryAndHash(file) {
+-	return file.split(/[?#]/)[0];
+-}
+-function getBuildInput(config) {
+-	return config.build?.rollupOptions?.input ?? config.build?.rolldownOptions?.input;
+-}
+-function patchHashEntryFileName(output, entryName, fileName) {
+-	const originalEntryFileNames = output.entryFileNames;
+-	output.entryFileNames = (chunkInfo, ...args) => {
+-		if (chunkInfo?.name === entryName) return fileName;
+-		if (typeof originalEntryFileNames === "function") return originalEntryFileNames(chunkInfo, ...args);
+-		return originalEntryFileNames || "assets/[name]-[hash].js";
+-	};
+-}
+-function patchHashEntryFileNames(config, entryName, fileName) {
+-	if (!fileName?.includes?.("[hash")) return;
+-	config.build ??= {};
+-	config.build.rollupOptions ??= {};
+-	config.build.rolldownOptions ??= {};
+-	const patchOutput = (output) => patchHashEntryFileName(output, entryName, fileName);
+-	const patchBundlerOutput = (bundlerOptions) => {
+-		const output = bundlerOptions.output;
+-		if (Array.isArray(output)) {
+-			output.forEach(patchOutput);
+-			return;
+-		}
+-		patchOutput(bundlerOptions.output ??= {});
+-	};
+-	patchBundlerOutput(config.build.rollupOptions);
+-	patchBundlerOutput(config.build.rolldownOptions);
+-}
+-const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClientInjected, skipTransformFor = [] }) => {
++const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClientInjected }) => {
+ 	const DEV_HTML_PROXY_PREFIX = "virtual:mf-html-entry-proxy?";
+-	const ENTRY_BOOTSTRAP_PARAM = "mf-entry-bootstrap";
+-	const ENTRY_BOOTSTRAP_QUERY = `?${ENTRY_BOOTSTRAP_PARAM}`;
++	const ENTRY_BOOTSTRAP_QUERY = "?mf-entry-bootstrap";
+ 	const waitsForInit = entryName === "hostInit";
+ 	const getEntryPath = () => typeof entryPath === "function" ? entryPath() : entryPath;
+ 	let devEntryPath = "";
+@@ -1845,16 +1595,12 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 	let viteConfig;
+ 	let clientInjected = forceClientInjected ?? false;
+ 	let emittedFileName;
+-	let skipTransformIds = /* @__PURE__ */ new Set();
+ 	function skipSvelteKitSsrBuild() {
+ 		return (_command === "build" || viteConfig?.command === "build") && viteConfig?.build?.ssr && hasPackageDependency("@sveltejs/kit");
+ 	}
+ 	function isSvelteKitServerModule(id) {
+ 		return hasPackageDependency("@sveltejs/kit") && (id.includes(".svelte-kit/generated/") || id.includes("/@sveltejs/kit/src/runtime/server/"));
+ 	}
+-	function hasEntryBootstrapParam(id) {
+-		return id.includes(ENTRY_BOOTSTRAP_PARAM) || decodeURIComponent(id).includes(ENTRY_BOOTSTRAP_PARAM);
+-	}
+ 	function rewriteSvelteKitInlineStart(html, initPath) {
+ 		return html.replace(/<script>([\s\S]*?)<\/script>/gi, (scriptTag, body) => {
+ 			if (!body.includes("kit.start(app, element);") || !body.includes("Promise.all([")) return scriptTag;
+@@ -1903,48 +1649,16 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		}
+ 		return patched;
+ 	}
+-	function getBootstrapSource(initSrc, entrySrc, useSystemImportFallback = false) {
+-		const importHelper = useSystemImportFallback ? `const __mfImport = (src) =>
+-  globalThis.System && typeof globalThis.System.import === 'function'
+-    ? globalThis.System.import(src)
+-    : import(src);
+-` : "";
+-		const importExpression = (src) => useSystemImportFallback ? `__mfImport(${JSON.stringify(src)})` : `import(${JSON.stringify(src)})`;
+-		const remotePreloads = getNormalizeModuleFederationOptions()?.shareStrategy !== "loaded-first" ? Object.entries(getUsedRemotesMap()).flatMap(([remoteKey, remotes]) => Array.from(remotes).filter((remote) => remote !== remoteKey)).sort().map((remote) => `__mfPreloadRemote(${JSON.stringify(remote)})`).join(",") : "";
+-		const preloadBlock = remotePreloads ? `
++	function getBootstrapSource(initSrc, entrySrc) {
++		const remotePreloads = Object.values(getUsedRemotesMap()).flatMap((remotes) => Array.from(remotes)).filter((remote) => remote.includes("/")).sort().map((remote) => `runtime.loadRemote(${JSON.stringify(remote)})`).join(",");
++		return `${getRuntimeModuleCacheBootstrapCode()}
++(async () => {
++  const { initHost } = await import(${JSON.stringify(initSrc)});
+   const runtime = await initHost();
+-  const __mfPreloadRemote = (remote) => {
+-    const pendingKey = "__mf_pending__" + remote;
+-    if (!__mfModuleCache.remote[pendingKey]) {
+-      __mfModuleCache.remote[pendingKey] = runtime.loadRemote(remote)
+-        .then((mod) => {
+-          __mfModuleCache.remote[remote] = mod;
+-          delete __mfModuleCache.remote[pendingKey];
+-          return mod;
+-        })
+-        .catch((error) => {
+-          delete __mfModuleCache.remote[pendingKey];
+-          throw error;
+-        });
+-    }
+-    return __mfModuleCache.remote[pendingKey];
+-  };
+   const __mfRemotePreloads = [${remotePreloads}];
+-  await Promise.allSettled(__mfRemotePreloads);` : `await initHost();`;
+-		const importCode = `
+-(async () => {
+-  const { initHost } = await ${importExpression(initSrc)};
+-  ${preloadBlock}
+-})().then(() => ${importExpression(entrySrc)});
++  await Promise.all(__mfRemotePreloads);
++})().then(() => import(${JSON.stringify(entrySrc)}));
+ `;
+-		return [
+-			getRuntimeModuleCacheBootstrapCode(),
+-			importHelper,
+-			importCode
+-		].join("\n");
+-	}
+-	function getSystemBootstrapSource(initSrc, entrySrc) {
+-		return getBootstrapSource(initSrc, entrySrc, true);
+ 	}
+ 	function injectHtml() {
+ 		return inject === "html" && (htmlFilePath || hasPackageDependency("@sveltejs/kit"));
+@@ -1953,32 +1667,6 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		if (inject === "html" && hasPackageDependency("@sveltejs/kit")) return false;
+ 		return inject === "entry" || !htmlFilePath;
+ 	}
+-	function normalizeDevHtmlProxyId(id) {
+-		return decodeViteId(id).replace(/^\0/, "");
+-	}
+-	function normalizeModuleId(id) {
+-		return id.split("?")[0].replace(/\\/g, "/");
+-	}
+-	function resolveProjectId(id) {
+-		if (id.startsWith("\0") || id.startsWith("virtual:")) return normalizeModuleId(id);
+-		return normalizeModuleId(path$1.isAbsolute(id) ? id : path$1.resolve(viteConfig.root, id));
+-	}
+-	function addEntryFile(file) {
+-		const normalized = normalizeModuleId(file);
+-		if (!entryFiles.includes(normalized)) entryFiles.push(normalized);
+-	}
+-	function addHtmlScriptEntries(htmlPath) {
+-		if (!fs$1.existsSync(htmlPath)) return;
+-		const htmlContent = fs$1.readFileSync(htmlPath, "utf-8");
+-		const scriptRegex = /<script\b(?=[^>]*\btype=["']module["'])(?=[^>]*\bsrc=["']([^"']+)["'])[^>]*>/gi;
+-		let match;
+-		while ((match = scriptRegex.exec(htmlContent)) !== null) {
+-			const scriptSrc = stripQueryAndHash(match[1]);
+-			if (/^(?:[a-z]+:)?\/\//i.test(scriptSrc)) continue;
+-			addEntryFile(scriptSrc);
+-			addEntryFile(scriptSrc.startsWith("/") ? path$1.resolve(viteConfig.root, scriptSrc.slice(1)) : path$1.resolve(path$1.dirname(htmlPath), scriptSrc));
+-		}
+-	}
+ 	return [{
+ 		name: "add-entry",
+ 		apply: "serve",
+@@ -1988,30 +1676,16 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		configResolved(config) {
+ 			viteConfig = config;
+ 			const resolvedEntryPath = getEntryPath();
+-			if (resolvedEntryPath.startsWith("virtual:mf")) devEntryPath = config.base + VITE_ID_PREFIX.slice(1) + resolvedEntryPath;
++			if (resolvedEntryPath.startsWith("virtual:mf")) devEntryPath = config.base + "@id/" + resolvedEntryPath;
+ 			else {
+ 				const normalized = resolvedEntryPath.replace(/\\\\?/g, "/");
+ 				const root = config.root.replace(/\\\\?/g, "/").replace(/\/$/, "");
+ 				const relativePath = normalized.startsWith(root + "/") ? normalized.slice(root.length) : "/" + normalized.replace(/^[A-Za-z]:[\\/]/, "");
+ 				devEntryPath = config.base + relativePath.replace(/^\//, "");
+ 			}
+-			skipTransformIds = new Set(skipTransformFor.map(resolveProjectId));
+ 		},
+ 		configureServer(server) {
+-			server.middlewares.use((req, res, next) => {
+-				const rawUrl = req.url?.split("#")[0] ?? "";
+-				if (normalizeDevHtmlProxyId(rawUrl.split("?")[0]) === DEV_HTML_PROXY_PREFIX.slice(0, -1)) {
+-					const query = rawUrl.slice(rawUrl.indexOf("?") + 1);
+-					const params = new URLSearchParams(query);
+-					const initSrc = params.get("init");
+-					const entrySrc = params.get("entry");
+-					if (initSrc && entrySrc) {
+-						res.statusCode = 200;
+-						res.setHeader("Content-Type", "application/javascript");
+-						res.end(getBootstrapSource(initSrc, entrySrc));
+-						return;
+-					}
+-				}
++			server.middlewares.use((req, _res, next) => {
+ 				if (!fileName) {
+ 					next();
+ 					return;
+@@ -2023,27 +1697,25 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		transformIndexHtml: {
+ 			order: "pre",
+ 			handler(c) {
+-				const shouldWrapEntryHtml = _command === "serve" && inject === "entry" && waitsForInit;
+-				if (!injectHtml() && !shouldWrapEntryHtml) return;
++				if (!injectHtml()) return;
+ 				clientInjected = true;
+ 				const base = viteConfig.base.replace(/\/$/, "");
+ 				const stripBase = (p) => base && p.startsWith(base + "/") ? p.slice(base.length) : p;
+ 				const html = rewriteEntryScripts(c, (originalSrc) => {
+-					return toViteEncodedId(`${DEV_HTML_PROXY_PREFIX}${new URLSearchParams({
++					return `/@id/${DEV_HTML_PROXY_PREFIX}${new URLSearchParams({
+ 						init: sanitizeDevEntryPath(stripBase(devEntryPath)),
+ 						entry: sanitizeDevEntryPath(stripBase(originalSrc))
+-					}).toString()}`);
++					}).toString()}`;
+ 				});
+ 				return html === c ? injectEntryScript(c, stripBase(devEntryPath)) : html;
+ 			}
+ 		},
+ 		resolveId(id) {
+-			if (normalizeDevHtmlProxyId(id).startsWith(DEV_HTML_PROXY_PREFIX)) return id;
++			if (id.startsWith(DEV_HTML_PROXY_PREFIX)) return id;
+ 		},
+ 		load(id) {
+-			const normalizedId = normalizeDevHtmlProxyId(id);
+-			if (!normalizedId.startsWith(DEV_HTML_PROXY_PREFIX)) return;
+-			const params = new URLSearchParams(normalizedId.slice(28));
++			if (!id.startsWith(DEV_HTML_PROXY_PREFIX)) return;
++			const params = new URLSearchParams(id.slice(28));
+ 			const initSrc = params.get("init");
+ 			const entrySrc = params.get("entry");
+ 			if (!initSrc || !entrySrc) return;
+@@ -2056,30 +1728,24 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 	}, {
+ 		name: "add-entry",
+ 		enforce: "post",
+-		applyToEnvironment() {
+-			return true;
+-		},
+-		config(config) {
+-			patchHashEntryFileNames(config, entryName, fileName);
+-		},
+ 		configResolved(config) {
+ 			viteConfig = config;
+-			skipTransformIds = new Set(skipTransformFor.map(resolveProjectId));
+-			const ctx = this;
+-			const envName = ctx != null && typeof ctx === "object" ? ctx["environment"] : void 0;
+-			if (envName?.name && envName.name !== "client") return;
+-			const inputOptions = getBuildInput(config);
++			const inputOptions = config.build.rollupOptions.input;
+ 			if (!inputOptions) htmlFilePath = path$1.resolve(config.root, "index.html");
+-			else if (typeof inputOptions === "string") entryFiles = [normalizeModuleId(inputOptions)];
+-			else if (Array.isArray(inputOptions)) entryFiles = inputOptions.map(normalizeModuleId);
+-			else if (typeof inputOptions === "object") entryFiles = Object.values(inputOptions).map((input) => normalizeModuleId(String(input)));
++			else if (typeof inputOptions === "string") entryFiles = [inputOptions];
++			else if (Array.isArray(inputOptions)) entryFiles = inputOptions;
++			else if (typeof inputOptions === "object") entryFiles = Object.values(inputOptions);
+ 			if (entryFiles.length > 0) htmlFilePath = getFirstHtmlEntryFile(entryFiles);
+-			if (htmlFilePath) addHtmlScriptEntries(htmlFilePath);
++			if (_command === "serve" && htmlFilePath && fs$1.existsSync(htmlFilePath)) {
++				const htmlContent = fs$1.readFileSync(htmlFilePath, "utf-8");
++				const scriptRegex = /<script\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
++				let match;
++				while ((match = scriptRegex.exec(htmlContent)) !== null) entryFiles.push(match[1]);
++			}
+ 		},
+ 		buildStart() {
+ 			if (_command === "serve") return;
+ 			if (skipSvelteKitSsrBuild()) return;
+-			if (this.environment?.name === "ssr") return;
+ 			const hasHash = fileName?.includes?.("[hash");
+ 			const emitFileOptions = {
+ 				name: entryName,
+@@ -2089,14 +1755,16 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 			};
+ 			if (!hasHash) emitFileOptions.fileName = fileName;
+ 			emitFileId = this.emitFile(emitFileOptions);
+-			if (htmlFilePath) addHtmlScriptEntries(htmlFilePath);
++			if (htmlFilePath && fs$1.existsSync(htmlFilePath)) {
++				const htmlContent = fs$1.readFileSync(htmlFilePath, "utf-8");
++				const scriptRegex = /<script\s+[^>]*src=["']([^"']+)["'][^>]*>/gi;
++				let match;
++				while ((match = scriptRegex.exec(htmlContent)) !== null) entryFiles.push(match[1]);
++			}
+ 		},
+ 		generateBundle(_options, bundle) {
+ 			if (skipSvelteKitSsrBuild()) return;
+ 			if (!injectHtml()) return;
+-			if (!emitFileId) return;
+-			const htmlFileNames = Object.keys(bundle).filter((fileName) => fileName.endsWith(".html"));
+-			if (htmlFileNames.length === 0) return;
+ 			const file = this.getFileName(emitFileId);
+ 			emittedFileName = file;
+ 			const resolvePath = (htmlFileName) => {
+@@ -2117,8 +1785,9 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 				}
+ 				return viteConfig.base + file;
+ 			};
++			const bootstrapDir = getEntryFileNamesDir(viteConfig.build?.rollupOptions?.output);
+ 			let bootstrapIndex = 0;
+-			for (const fileName of htmlFileNames) {
++			for (const fileName in bundle) if (fileName.endsWith(".html")) {
+ 				let htmlAsset = bundle[fileName];
+ 				if (htmlAsset.type === "chunk") return;
+ 				let htmlContent = htmlAsset.source.toString() || "";
+@@ -2127,13 +1796,11 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 				let rewritten = false;
+ 				htmlContent = htmlContent.replace(scriptRegex, (scriptTag, entrySrc) => {
+ 					rewritten = true;
+-					const bootstrapSource = getSystemBootstrapSource(initPath, entrySrc);
+-					const bootstrapHash = createHash("sha256").update(bootstrapSource).digest("hex").slice(0, 8);
+-					const bootstrapFileName = `mf-entry-bootstrap-${bootstrapIndex++}-${bootstrapHash}.js`;
++					const bootstrapFileName = `${bootstrapDir}mf-entry-bootstrap-${bootstrapIndex++}.js`;
+ 					const bootstrapRef = this.emitFile({
+ 						type: "asset",
+ 						fileName: bootstrapFileName,
+-						source: bootstrapSource
++						source: getBootstrapSource(bootstrapDir ? rebaseImport(initPath, bootstrapDir) : initPath, bootstrapDir ? rebaseImport(entrySrc, bootstrapDir) : entrySrc)
+ 					});
+ 					const bootstrapPath = viteConfig.base + this.getFileName(bootstrapRef);
+ 					return scriptTag.replace(entrySrc, bootstrapPath);
+@@ -2164,19 +1831,8 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 		transform(code, id) {
+ 			if (skipSvelteKitSsrBuild()) return;
+ 			if (isSvelteKitServerModule(id)) return;
+-			if (hasEntryBootstrapParam(id)) return;
+-			if (normalizeModuleId(id).endsWith(".html")) return;
+-			if (skipTransformIds.has(resolveProjectId(id))) return;
+-			const transformCtx = this;
+-			const transformEnv = transformCtx != null && typeof transformCtx === "object" ? transformCtx["environment"] : void 0;
+-			if (transformEnv?.name && transformEnv.name !== "client") return;
++			if (id.includes(ENTRY_BOOTSTRAP_QUERY)) return;
+ 			const isVinext = hasPackageDependency("vinext");
+-			if (isVinext && inject === "html" && id.includes("virtual:vite-rsc/remove-duplicate-server-css")) {
+-				const namespaceReactImport = `import * as React from 'react';`;
+-				if (code.includes(namespaceReactImport)) return;
+-				const rewritten = code.replace(/import\s+React\s+from\s+['"]react['"];?/, namespaceReactImport);
+-				return rewritten === code ? void 0 : mapCodeToCodeWithSourcemap(rewritten);
+-			}
+ 			if (isVinext && inject === "html" && (id.includes("virtual:vite-rsc/entry-browser") || id.includes("virtual:vinext-app-browser-entry"))) {
+ 				const injection = `import ${JSON.stringify(getEntryPath())};\n`;
+ 				if (code.includes(injection.trim())) {
+@@ -2186,16 +1842,9 @@ const addEntry = ({ entryName, entryPath, fileName, inject = "entry", forceClien
+ 				clientInjected = true;
+ 				return mapCodeToCodeWithSourcemap(injection + code);
+ 			}
+-			if (_command === "serve" && inject === "entry" && waitsForInit && !clientInjected && /(?:^|\/)nuxt\/dist\/app\/entry\.js(?:\?|$)/.test(id) && code.includes("vueApp.mount(vueAppRootContainer);")) {
+-				clientInjected = true;
+-				const injection = `await import(${JSON.stringify(getEntryPath())}).then(({ initHost }) => initHost());\n      `;
+-				return mapCodeToCodeWithSourcemap(code.replace("vueApp.mount(vueAppRootContainer);", `${injection}vueApp.mount(vueAppRootContainer);`));
+-			}
+-			const isHydrationEntryFallback = inject === "entry" && entryFiles.length === 0 && (!htmlFilePath || !fs$1.existsSync(htmlFilePath)) && !clientInjected && !id.includes("node_modules") && (id.startsWith("\0") || /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) && /hydrateRoot|createRoot|ReactDOM\.render/.test(code);
+-			const isNuxtClientEntryFallback = _command === "serve" && inject === "entry" && entryFiles.length === 0 && (!htmlFilePath || !fs$1.existsSync(htmlFilePath)) && !clientInjected && !hasEntryBootstrapParam(id) && !id.includes("node_modules/.vite") && /(?:^|\/)nuxt\/dist\/app\/entry\.async\.js(?:\?|$)/.test(id) && code.includes("entry();");
+-			if (injectEntry() && entryFiles.some((file) => resolveProjectId(id) === file) || _command === "serve" && inject === "html" && !isVinext && !clientInjected && !id.startsWith("\0") && !id.includes("node_modules") && /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id) || isHydrationEntryFallback || isNuxtClientEntryFallback) {
++			if (injectEntry() && entryFiles.some((file) => id.endsWith(file)) || _command === "serve" && inject === "html" && !isVinext && !clientInjected && !id.startsWith("\0") && !id.includes("node_modules") && /\.(js|ts|mjs|vue|jsx|tsx)(\?|$)/.test(id)) {
+ 				clientInjected = true;
+-				if (!waitsForInit || _command === "serve" && inject === "entry" && isHydrationEntryFallback) return mapCodeToCodeWithSourcemap(`import ${JSON.stringify(getEntryPath())};\n` + code);
++				if (!waitsForInit) return mapCodeToCodeWithSourcemap(`import ${JSON.stringify(getEntryPath())};\n` + code);
+ 				const entrySrc = id.includes("?") ? `${id}&${ENTRY_BOOTSTRAP_QUERY.slice(1)}` : `${id}${ENTRY_BOOTSTRAP_QUERY}`;
+ 				return mapCodeToCodeWithSourcemap(getBootstrapSource(getEntryPath(), entrySrc));
+ 			}
+@@ -2227,14 +1876,11 @@ function checkAliasConflicts(options) {
+ 				const replacement = aliasEntry.replacement;
+ 				if (!matchesSharedKey(aliasEntry, sharedKey)) continue;
+ 				if (replacement === "$1") break;
+-				if (typeof replacement === "string") {
+-					if (getPackageNameFromNodeModulePath(replacement) === (sharedKey.endsWith("/") ? sharedKey.slice(0, -1) : sharedKey)) continue;
+-					conflicts.push({
+-						sharedModule: sharedKey,
+-						alias: String(aliasEntry.find),
+-						target: replacement
+-					});
+-				}
++				if (typeof replacement === "string") conflicts.push({
++					sharedModule: sharedKey,
++					alias: String(aliasEntry.find),
++					target: replacement
++				});
+ 			}
+ 			if (conflicts.length > 0) {
+ 				mfWarn("Detected alias conflicts with shared modules:");
+@@ -2247,7 +1893,11 @@ function checkAliasConflicts(options) {
+ 	};
+ }
+ //#endregion
+-//#region src/plugins/hmr/react.ts
++//#region src/plugins/pluginDevRemoteHmr.ts
++const REMOTE_HMR_ENDPOINT = "__mf_hmr";
++const REMOTE_HMR_EVENT = "mf:remote-update";
++const REMOTE_HMR_CONNECT_RETRY_DELAY_MS = 1e3;
++const REMOTE_HMR_CONNECT_MAX_RETRIES = 10;
+ /**
+ * Proxy module served for `/@react-refresh` on MF remote dev servers.
+ * Delegates to the host page's RefreshRuntime instance via
+@@ -2267,112 +1917,6 @@ const REACT_REFRESH_PROXY_MODULE = [
+ 	`export const __hmr_import = __rt.__hmr_import;`,
+ 	`export default __rt.default || __rt;`
+ ].join("\n");
+-const reactAdapter = {
+-	name: "react",
+-	pluginNames: ["vite:react-refresh", "vite:react-swc:refresh"],
+-	remote: { configureServer({ server }) {
+-		server.middlewares.use((req, res, next) => {
+-			if (req.url?.replace(/\?.*$/, "") !== "/@react-refresh") return next();
+-			res.setHeader("Content-Type", "application/javascript; charset=utf-8");
+-			res.setHeader("Access-Control-Allow-Origin", "*");
+-			res.end(REACT_REFRESH_PROXY_MODULE);
+-		});
+-	} }
+-};
+-//#endregion
+-//#region src/plugins/hmr/vue.ts
+-/**
+-* In dev mode each Vite dev server serves its own copy of Vue
+-* (`/node_modules/.vite/deps/vue.js`). When a remote module is loaded into the
+-* host page, the remote's Vue copy evaluates and runs:
+-*
+-*     globalThis.__VUE_HMR_RUNTIME__ = createHotReloadAPI()
+-*
+-* which silently overwrites the host's runtime. After that, `createRecord` for
+-* host components lives in the orphaned first runtime, but `reload(hmrId, ...)`
+-* goes through the second runtime — the lookup misses and HMR stops working.
+-*
+-* This guard pins `__VUE_HMR_RUNTIME__` to the first writer (the host's Vue)
+-* via a property trap on `globalThis`. Subsequent writes from remote-side Vue
+-* copies are silently dropped. Must execute before any Vue module loads —
+-* injected as a plain (non-module) script at `head-prepend`.
+-*
+-* `singleton: true` in `shared` is not sufficient: in dev mode MF's share-scope
+-* does not actually dedupe Vue across dev servers, so without this guard the
+-* last-loaded copy wins.
+-*/
+-const VUE_HMR_RUNTIME_GUARD_SCRIPT = `
+-(function () {
+-  var h = null;
+-  Object.defineProperty(globalThis, '__VUE_HMR_RUNTIME__', {
+-    get: function () { return h; },
+-    set: function (v) { if (h === null) h = v; },
+-    configurable: true,
+-    enumerable: true,
+-  });
+-})();`;
+-/**
+-* `@vitejs/plugin-vue` derives an SFC's `__hmrId` from a hash of the file path
+-* relative to Vite's `root`. With module federation, host and remote are
+-* separate Vite projects with independent roots — so an SFC at `src/App.vue`
+-* in both will hash to the same id. Once both copies of Vue collapse onto the
+-* shared `__VUE_HMR_RUNTIME__` (see the guard above), the host's instance and
+-* the remote's instance both register under that single id. A remote-only
+-* file change then calls `rerender(id, newRender)`, which iterates *every*
+-* instance under that id — including the host one — and applies the remote's
+-* render function to the host instance. The host's `setupState` doesn't have
+-* the remote's bindings, so the render throws and Vue falls back to a full
+-* reload required warning.
+-*
+-* Fix: rewrite the remote's emitted `__hmrId` literal to be prefixed with the
+-* federation `name`, so the remote's instances live under a distinct key. The
+-* accept callback emitted by plugin-vue reads `_sfc_main.__hmrId` /
+-* `updated.__hmrId` at runtime, so rewriting the literal once is enough.
+-*/
+-const SFC_HMR_ID_LITERAL_RE = /(\.__hmrId\s*=\s*["'`])([^"'`]+)(["'`])/g;
+-function rewriteSfcHmrId(code, federationName) {
+-	let matched = false;
+-	return {
+-		code: code.replace(SFC_HMR_ID_LITERAL_RE, (_match, prefix, id, suffix) => {
+-			matched = true;
+-			if (id.startsWith(`${federationName}-`)) return `${prefix}${id}${suffix}`;
+-			return `${prefix}${federationName}-${id}${suffix}`;
+-		}),
+-		matched
+-	};
+-}
+-let pluginVueRegressionWarned = false;
+-function warnPluginVueRegression() {
+-	if (pluginVueRegressionWarned) return;
+-	pluginVueRegressionWarned = true;
+-	mfWarn("Detected a Vue SFC module that calls `__VUE_HMR_RUNTIME__.createRecord(` but no `.__hmrId = \"...\"` literal could be rewritten. @vitejs/plugin-vue may have changed its output format — without the rewrite, host and remote SFCs that share a path will collide on the shared HMR runtime. Please report this to @module-federation/vite.");
+-}
+-const vueAdapter = {
+-	name: "vue",
+-	pluginNames: ["vite:vue", "vite:vue-jsx"],
+-	host: { transformIndexHtml() {
+-		return [{
+-			tag: "script",
+-			children: VUE_HMR_RUNTIME_GUARD_SCRIPT,
+-			injectTo: "head-prepend"
+-		}];
+-	} },
+-	remote: { transform(code, _id, ctx) {
+-		if (!code.includes("__VUE_HMR_RUNTIME__.createRecord(")) return;
+-		const { code: rewritten, matched } = rewriteSfcHmrId(code, ctx.options.name);
+-		if (!matched) {
+-			warnPluginVueRegression();
+-			return;
+-		}
+-		return rewritten === code ? void 0 : rewritten;
+-	} }
+-};
+-//#endregion
+-//#region src/plugins/hmr/fullReload.ts
+-const REMOTE_HMR_ENDPOINT = "__mf_hmr";
+-const REMOTE_HMR_EVENT = "mf:remote-update";
+-const REMOTE_HMR_CONNECT_RETRY_DELAY_MS = 1e3;
+-const REMOTE_HMR_CONNECT_MAX_RETRIES = 10;
+ function getBasePath$1(base) {
+ 	if (!base) return "/";
+ 	if (base.startsWith("http://") || base.startsWith("https://")) try {
+@@ -2391,6 +1935,9 @@ function getHmrWsPath(base, hmrPath) {
+ 	if (!normalizedPath || normalizedPath === "/") return normalizedBase;
+ 	return `${normalizedBase.endsWith("/") ? normalizedBase.slice(0, -1) : normalizedBase}/${normalizedPath.startsWith("/") ? normalizedPath.slice(1) : normalizedPath}`;
+ }
++function shouldIgnoreFile(file, options) {
++	return file.includes("/node_modules/") || file.includes("\\node_modules\\") || file.includes(`/${options.virtualModuleDir}/`) || file.includes(`\\${options.virtualModuleDir}\\`) || file.includes("/.vite/") || file.includes("\\.vite\\") || file.includes("/.__mf__temp/") || file.includes("\\.__mf__temp\\") || file.includes("/.mf/") || file.includes("\\.mf\\") || file.includes("/mf-manifest.json") || file.includes("\\mf-manifest.json") || file.includes("/mf-stats.json") || file.includes("\\mf-stats.json");
++}
+ function getRemoteHmrWsUrl(server) {
+ 	const hmr = server.config.server.hmr;
+ 	return `${hmr && typeof hmr === "object" && hmr.protocol ? hmr.protocol : server.config.server.https ? "wss" : "ws"}://${hmr && typeof hmr === "object" && hmr.host ? hmr.host : typeof server.config.server.host === "string" && server.config.server.host !== "0.0.0.0" ? server.config.server.host : "localhost"}:${hmr && typeof hmr === "object" && (hmr.clientPort || hmr.port) ? hmr.clientPort || hmr.port : server.config.server.port}${getHmrWsPath(server.config.base, hmr && typeof hmr === "object" ? hmr.path : "")}?token=${server.config.webSocketToken}`;
+@@ -2429,298 +1976,450 @@ function getStringPreview(value, max = 180) {
+ 	} catch {}
+ 	return rawValue.slice(0, max);
+ }
+-/**
+-* Installs the `/__mf_hmr` metadata endpoint on a remote dev server. The host
+-* fetches this to discover the remote's HMR WebSocket URL before opening a
+-* Node-to-Node relay socket. Always installed on remotes when `remoteHmr` is
+-* enabled — under `'native'` strategy the endpoint is unused but harmless;
+-* under `'full-reload'` it's the discovery hop for the host relay.
+-*/
+-function setupRemoteMetadataEndpoint(server, options) {
+-	const endpointPath = getRemoteHmrPath(server.config.base);
+-	const wsUrl = getRemoteHmrWsUrl(server);
+-	server.middlewares.use((req, res, next) => {
+-		if (req.url?.replace(/\?.*/, "") !== endpointPath) {
+-			next();
+-			return;
+-		}
+-		res.setHeader("Content-Type", "application/json");
+-		res.setHeader("Access-Control-Allow-Origin", "*");
+-		res.end(JSON.stringify({
+-			remote: options.name,
+-			event: REMOTE_HMR_EVENT,
+-			wsUrl
+-		}));
+-	});
++function isRemoteHmrEnabled(dev) {
++	return typeof dev === "object" && dev !== null && dev.remoteHmr === true;
+ }
+-/**
+-* Installs file-watcher broadcasts on a remote dev server. Every non-ignored
+-* change/add/unlink emits a `mf:remote-update` custom event on the remote's
+-* own WS channel. The host relay (see `setupHostFullReloadRelay`) listens
+-* for these events and triggers a host-side full reload in response.
+-*
+-* Only called under the `'full-reload'` strategy.
+-*/
+-function setupRemoteBroadcast(server, options) {
+-	const broadcast = (file) => {
+-		if (shouldIgnoreFile(file, options)) return;
+-		server.ws.send({
+-			type: "custom",
+-			event: REMOTE_HMR_EVENT,
+-			data: {
+-				remote: options.name,
+-				file,
+-				ts: Date.now()
++function pluginDevRemoteHmr(options) {
++	return {
++		name: "module-federation-dev-remote-hmr",
++		apply: "serve",
++		configureServer(server) {
++			if (!isRemoteHmrEnabled(options.dev)) return;
++			const isRemote = Object.keys(options.exposes).length > 0;
++			const isHost = Object.keys(options.remotes).length > 0;
++			if (isRemote) {
++				const endpointPath = getRemoteHmrPath(server.config.base);
++				const wsUrl = getRemoteHmrWsUrl(server);
++				server.middlewares.use((req, res, next) => {
++					if (req.url?.replace(/\?.*$/, "") !== "/@react-refresh") return next();
++					res.setHeader("Content-Type", "application/javascript; charset=utf-8");
++					res.setHeader("Access-Control-Allow-Origin", "*");
++					res.end(REACT_REFRESH_PROXY_MODULE);
++				});
++				server.middlewares.use((req, res, next) => {
++					if (req.url?.replace(/\?.*/, "") !== endpointPath) {
++						next();
++						return;
++					}
++					res.setHeader("Content-Type", "application/json");
++					res.setHeader("Access-Control-Allow-Origin", "*");
++					res.end(JSON.stringify({
++						remote: options.name,
++						event: REMOTE_HMR_EVENT,
++						wsUrl
++					}));
++				});
++				const broadcast = (file) => {
++					if (shouldIgnoreFile(file, options)) return;
++					server.ws.send({
++						type: "custom",
++						event: REMOTE_HMR_EVENT,
++						data: {
++							remote: options.name,
++							file,
++							ts: Date.now()
++						}
++					});
++				};
++				server.watcher.on("change", broadcast);
++				server.watcher.on("add", broadcast);
++				server.watcher.on("unlink", broadcast);
++				server.httpServer?.once("close", () => {
++					server.watcher.off("change", broadcast);
++					server.watcher.off("add", broadcast);
++					server.watcher.off("unlink", broadcast);
++				});
++			}
++			if (isHost) {
++				const connections = [];
++				const reconnectTimers = /* @__PURE__ */ new Map();
++				let isTearingDown = false;
++				const clearReconnectTimer = (remoteName) => {
++					const timer = reconnectTimers.get(remoteName);
++					if (!timer) return;
++					clearTimeout(timer);
++					reconnectTimers.delete(remoteName);
++				};
++				const scheduleReconnect = (remoteName, remote, attempt, reason) => {
++					if (isTearingDown) return;
++					if (attempt >= REMOTE_HMR_CONNECT_MAX_RETRIES) {
++						mfWarn(`Remote "${remoteName}" full HMR reconnect skipped after ${REMOTE_HMR_CONNECT_MAX_RETRIES} attempts: ${reason}`);
++						return;
++					}
++					clearReconnectTimer(remoteName);
++					const timer = setTimeout(() => {
++						reconnectTimers.delete(remoteName);
++						connectRemote(remoteName, remote, attempt + 1);
++					}, REMOTE_HMR_CONNECT_RETRY_DELAY_MS);
++					reconnectTimers.set(remoteName, timer);
++				};
++				const connectRemote = async (remoteName, remote, attempt = 0) => {
++					if (isTearingDown) return;
++					const endpoint = getRemoteHmrEndpoint(remote.entry, server);
++					if (!endpoint) {
++						mfWarn(`Failed to build HMR endpoint URL for remote "${remoteName}"`);
++						return;
++					}
++					try {
++						const metadataResponse = await fetch(endpoint);
++						if (!metadataResponse.ok) {
++							mfWarn(`Failed to fetch remote HMR metadata from "${remoteName}": ${metadataResponse.status}`);
++							scheduleReconnect(remoteName, remote, attempt, `HTTP ${metadataResponse.status}`);
++							return;
++						}
++						const metadata = await metadataResponse.json();
++						if (metadata.event !== REMOTE_HMR_EVENT || !metadata.wsUrl) {
++							mfWarn(`Remote "${remoteName}" returned unexpected HMR metadata shape`);
++							return;
++						}
++						const ws = new WebSocket(metadata.wsUrl, "vite-hmr");
++						ws.onmessage = (rawEvent) => {
++							const message = parseRemoteHmrMessage(rawEvent.data);
++							if (!message || message.event !== REMOTE_HMR_EVENT) return;
++							server.ws.send({ type: "full-reload" });
++						};
++						ws.onopen = () => clearReconnectTimer(remoteName);
++						ws.onerror = (error) => mfWarn(`Remote HMR socket error for "${remoteName}":`, error);
++						ws.onclose = () => scheduleReconnect(remoteName, remote, attempt, "socket closed");
++						connections.push(ws);
++					} catch (error) {
++						mfWarn(`Failed to connect remote HMR for "${remoteName}" on attempt ${attempt + 1}: ${getStringPreview(error)}`);
++						scheduleReconnect(remoteName, remote, attempt, getStringPreview(error));
++					}
++				};
++				const teardown = () => {
++					isTearingDown = true;
++					reconnectTimers.forEach((timer) => clearTimeout(timer));
++					reconnectTimers.clear();
++					connections.forEach((connection) => {
++						if (connection.readyState !== connection.CLOSING && connection.readyState !== connection.CLOSED) connection.close();
++					});
++					connections.length = 0;
++				};
++				for (const [remoteName, remote] of Object.entries(options.remotes)) connectRemote(remoteName, remote);
++				const triggerHostReload = (file) => {
++					if (shouldIgnoreFile(file, options)) return;
++					server.ws.send({ type: "full-reload" });
++				};
++				server.watcher.on("change", triggerHostReload);
++				server.watcher.on("add", triggerHostReload);
++				server.watcher.on("unlink", triggerHostReload);
++				server.httpServer?.once("close", teardown);
+ 			}
++		}
++	};
++}
++//#endregion
++//#region src/plugins/pluginDts.ts
++const DEFAULT_DEV_OPTIONS = {
++	disableLiveReload: true,
++	disableHotTypesReload: false,
++	disableDynamicRemoteTypeHints: false
++};
++const DYNAMIC_HINTS_PLUGIN = "@module-federation/dts-plugin/dynamic-remote-type-hints-plugin";
++const getIPv4 = () => process.env["FEDERATION_IPV4"] || "127.0.0.1";
++const DEV_TYPES_FOLDER = ".dev-server";
++const DEFAULT_PUBLIC_TYPES_FOLDER = "@mf-types";
++const forkDevWorkerPath = __require.resolve("@module-federation/dts-plugin/dist/fork-dev-worker.js");
++var DevWorker = class {
++	worker = rpc.createRpcWorker(forkDevWorkerPath, {}, void 0, false);
++	constructor(options) {
++		this.worker.connect(options);
++	}
++	update() {
++		this.worker.process?.send?.({
++			type: rpc.RpcGMCallTypes.CALL,
++			id: this.worker.id,
++			args: [void 0, "update"]
+ 		});
++	}
++	exit() {
++		this.worker.terminate();
++	}
++};
++const normalizeDevOptions = (dev) => {
++	if (dev === false) return false;
++	if (dev === true || typeof dev === "undefined") return { ...DEFAULT_DEV_OPTIONS };
++	return {
++		...DEFAULT_DEV_OPTIONS,
++		...dev
+ 	};
+-	server.watcher.on("change", broadcast);
+-	server.watcher.on("add", broadcast);
+-	server.watcher.on("unlink", broadcast);
+-	server.httpServer?.once("close", () => {
+-		server.watcher.off("change", broadcast);
+-		server.watcher.off("add", broadcast);
+-		server.watcher.off("unlink", broadcast);
++};
++const buildDtsModuleFederationConfig = (options) => {
++	const exposes = {};
++	Object.entries(options.exposes).forEach(([key, value]) => {
++		if (value.import) exposes[key] = value.import;
+ 	});
+-}
+-/**
+-* Installs the host-side full-reload relay. For each configured remote:
+-*   1. Fetches the remote's `/__mf_hmr` metadata to get its WS URL.
+-*   2. Opens a Node-to-Node WebSocket to that URL.
+-*   3. On any `mf:remote-update` message, broadcasts `{ type: 'full-reload' }`
+-*      to the host's own browser-facing WS.
+-*
+-* Also reloads on local host file changes. Retries failed connections up to
+-* `REMOTE_HMR_CONNECT_MAX_RETRIES` times with a fixed delay.
+-*
+-* Only called under the `'full-reload'` strategy.
+-*/
+-function setupHostFullReloadRelay(server, options) {
+-	const connections = [];
+-	const reconnectTimers = /* @__PURE__ */ new Map();
+-	let isTearingDown = false;
+-	const clearReconnectTimer = (remoteName) => {
+-		const timer = reconnectTimers.get(remoteName);
+-		if (!timer) return;
+-		clearTimeout(timer);
+-		reconnectTimers.delete(remoteName);
++	const remotes = {};
++	Object.entries(options.remotes).forEach(([key, remote]) => {
++		if (!remote.entry) return;
++		remotes[key] = `${remote.entryGlobalName?.startsWith("http") || remote.entryGlobalName?.includes(".json") ? remote.name || key : remote.entryGlobalName || remote.name || key}@${remote.entry}`;
++	});
++	return {
++		...options,
++		exposes,
++		remotes
+ 	};
+-	const scheduleReconnect = (remoteName, remote, attempt, reason) => {
+-		if (isTearingDown) return;
+-		if (attempt >= REMOTE_HMR_CONNECT_MAX_RETRIES) {
+-			mfWarn(`Remote "${remoteName}" full HMR reconnect skipped after ${REMOTE_HMR_CONNECT_MAX_RETRIES} attempts: ${reason}`);
+-			return;
++};
++const resolveOutputDir = (config) => {
++	const { outDir } = config.build;
++	if (path$1.isAbsolute(outDir)) return path$1.relative(config.root, outDir);
++	return outDir;
++};
++const ensureRuntimePlugin = (options, pluginId) => {
++	if (!options.runtimePlugins.some((plugin) => {
++		if (typeof plugin === "string") return plugin === pluginId;
++		return plugin[0] === pluginId;
++	})) options.runtimePlugins.push(pluginId);
++};
++const getExposeImportPaths = (options) => {
++	return Object.values(options.exposes).map((value) => {
++		return value.import;
++	}).filter((value) => Boolean(value));
++};
++const usesVueSfcExposes = (options) => {
++	return getExposeImportPaths(options).some((value) => value.endsWith(".vue"));
++};
++const resolveDtsPluginOptions = (dts, options, context) => {
++	if (dts === false) return false;
++	const inferredGenerateTypesDefaults = { generateAPITypes: true };
++	if (usesVueSfcExposes(options) && hasPackageDependency("vue-tsc", context)) inferredGenerateTypesDefaults.compilerInstance = "vue-tsc";
++	if (dts === true || typeof dts === "undefined") return { generateTypes: inferredGenerateTypesDefaults };
++	const generateTypes = dts.generateTypes;
++	return {
++		...dts,
++		generateTypes: generateTypes === false ? false : {
++			...inferredGenerateTypesDefaults,
++			...generateTypes === true || typeof generateTypes === "undefined" ? {} : generateTypes
+ 		}
+-		clearReconnectTimer(remoteName);
+-		const timer = setTimeout(() => {
+-			reconnectTimers.delete(remoteName);
+-			connectRemote(remoteName, remote, attempt + 1);
+-		}, REMOTE_HMR_CONNECT_RETRY_DELAY_MS);
+-		reconnectTimers.set(remoteName, timer);
+ 	};
+-	const connectRemote = async (remoteName, remote, attempt = 0) => {
+-		if (isTearingDown) return;
+-		const endpoint = getRemoteHmrEndpoint(remote.entry, server);
+-		if (!endpoint) {
+-			mfWarn(`Failed to build HMR endpoint URL for remote "${remoteName}"`);
++};
++const getBasePath = (base) => {
++	if (base.startsWith("http://") || base.startsWith("https://")) return new URL(base).pathname.replace(/\/$/, "") || "/";
++	return base.replace(/\/$/, "") || "/";
++};
++const joinBaseAndAsset = (base, assetFileName) => {
++	const basePath = getBasePath(base);
++	return `${basePath === "/" ? "" : basePath}/${assetFileName}`.replace(/\/{2,}/g, "/");
++};
++const getDevDtsAssetPaths = (options) => {
++	const { outputDir, publicTypesFolder, root, base } = options;
++	return {
++		apiFilePath: path$1.resolve(root, outputDir, `${DEV_TYPES_FOLDER}.d.ts`),
++		apiRequestPath: joinBaseAndAsset(base, `${publicTypesFolder}.d.ts`),
++		zipFilePath: path$1.resolve(root, outputDir, `${DEV_TYPES_FOLDER}.zip`),
++		zipRequestPath: joinBaseAndAsset(base, `${publicTypesFolder}.zip`)
++	};
++};
++const createDevDtsAssetMiddleware = (assetPaths) => {
++	return (req, res, next) => {
++		const requestPath = req.url?.split("?")[0];
++		const isZipRequest = requestPath === assetPaths.zipRequestPath;
++		const isApiRequest = requestPath === assetPaths.apiRequestPath;
++		if (!isZipRequest && !isApiRequest) {
++			next();
+ 			return;
+ 		}
+-		try {
+-			const metadataResponse = await fetch(endpoint);
+-			if (!metadataResponse.ok) {
+-				mfWarn(`Failed to fetch remote HMR metadata from "${remoteName}": ${metadataResponse.status}`);
+-				scheduleReconnect(remoteName, remote, attempt, `HTTP ${metadataResponse.status}`);
+-				return;
+-			}
+-			const metadata = await metadataResponse.json();
+-			if (metadata.event !== "mf:remote-update" || !metadata.wsUrl) {
+-				mfWarn(`Remote "${remoteName}" returned unexpected HMR metadata shape`);
+-				return;
+-			}
+-			const ws = new WebSocket(metadata.wsUrl, "vite-hmr");
+-			ws.onmessage = (rawEvent) => {
+-				const message = parseRemoteHmrMessage(rawEvent.data);
+-				if (!message || message.event !== "mf:remote-update") return;
+-				server.ws.send({ type: "full-reload" });
+-			};
+-			ws.onopen = () => clearReconnectTimer(remoteName);
+-			ws.onerror = (error) => mfWarn(`Remote HMR socket error for "${remoteName}":`, error);
+-			ws.onclose = () => scheduleReconnect(remoteName, remote, attempt, "socket closed");
+-			connections.push(ws);
+-		} catch (error) {
+-			mfWarn(`Failed to connect remote HMR for "${remoteName}" on attempt ${attempt + 1}: ${getStringPreview(error)}`);
+-			scheduleReconnect(remoteName, remote, attempt, getStringPreview(error));
++		const filePath = isZipRequest ? assetPaths.zipFilePath : assetPaths.apiFilePath;
++		if (!fs.existsSync(filePath)) {
++			res.statusCode = 404;
++			res.end();
++			return;
+ 		}
+-	};
+-	const teardown = () => {
+-		isTearingDown = true;
+-		reconnectTimers.forEach((timer) => clearTimeout(timer));
+-		reconnectTimers.clear();
+-		connections.forEach((connection) => {
+-			if (connection.readyState !== connection.CLOSING && connection.readyState !== connection.CLOSED) connection.close();
++		res.statusCode = 200;
++		res.setHeader("Content-Type", isZipRequest ? "application/x-gzip" : "application/typescript");
++		if (req.method === "HEAD") {
++			res.end();
++			return;
++		}
++		const stream = fs.createReadStream(filePath);
++		stream.on("error", () => {
++			if (!res.headersSent) res.statusCode = 500;
++			res.end();
+ 		});
+-		connections.length = 0;
+-	};
+-	for (const [remoteName, remote] of Object.entries(options.remotes)) connectRemote(remoteName, remote);
+-	const triggerHostReload = (file) => {
+-		if (shouldIgnoreFile(file, options)) return;
+-		server.ws.send({ type: "full-reload" });
+-	};
+-	server.watcher.on("change", triggerHostReload);
+-	server.watcher.on("add", triggerHostReload);
+-	server.watcher.on("unlink", triggerHostReload);
+-	server.httpServer?.once("close", teardown);
+-}
+-//#endregion
+-//#region src/plugins/pluginDevRemoteHmr.ts
+-/**
+-* Clears the federation runtime's `moduleCache` on every Vite `vite:beforeUpdate`
+-* event. Without this, after a remote SFC change Vite would patch the in-memory
+-* component, but `loadRemote()` would still return the cached stale module on
+-* the next call (e.g. after route navigation), making the patched version
+-* effectively unreachable.
+-*/
+-const FEDERATION_MODULE_CACHE_CLEAR_SCRIPT = `
+-if (import.meta.hot) {
+-  import.meta.hot.on('vite:beforeUpdate', function () {
+-    try {
+-      var f = globalThis.__FEDERATION__ || globalThis.__VMOK__;
+-      if (!f || !f.__INSTANCES__) return;
+-      for (var i = 0; i < f.__INSTANCES__.length; i++) {
+-        if (f.__INSTANCES__[i] && f.__INSTANCES__[i].moduleCache)
+-          f.__INSTANCES__[i].moduleCache.clear();
+-      }
+-    } catch (e) {}
+-  });
+-}`;
+-const HMR_ADAPTERS = [reactAdapter, vueAdapter];
+-function resolveAdapters(plugins) {
+-	const pluginNames = new Set(plugins.map((p) => p.name));
+-	return HMR_ADAPTERS.filter((adapter) => adapter.pluginNames.some((name) => pluginNames.has(name)));
+-}
+-function hasCrossFederationHmr(plugins) {
+-	return resolveAdapters(plugins).length > 0;
+-}
+-function isRemoteHmrEnabled(dev) {
+-	return typeof dev === "object" && dev !== null && !!dev.remoteHmr;
+-}
+-/**
+-* `'native'` — a matched framework adapter owns HMR through Vite's native
+-* channel (e.g. React Fast Refresh via the `/@react-refresh` proxy, Vue's
+-* patched `__VUE_HMR_RUNTIME__`). The broadcast/relay path stays idle.
+-*
+-* `'full-reload'` — no adapter matched, or the user explicitly opted in with
+-* `remoteHmr: 'full-reload'` to bypass adapters: the plugin's broadcast/relay
+-* machinery triggers a page reload on every remote file change.
+-*/
+-function resolveHmrStrategy(dev, plugins) {
+-	if (typeof dev === "object" && dev !== null && dev.remoteHmr === "full-reload") return "full-reload";
+-	return hasCrossFederationHmr(plugins) ? "native" : "full-reload";
+-}
+-function shouldIgnoreFile(file, options) {
+-	return file.includes("/node_modules/") || file.includes("\\node_modules\\") || file.includes(`/${options.virtualModuleDir}/`) || file.includes(`\\${options.virtualModuleDir}\\`) || file.includes("/.vite/") || file.includes("\\.vite\\") || file.includes("/.mf/") || file.includes("\\.mf\\") || file.includes("/mf-manifest.json") || file.includes("\\mf-manifest.json") || file.includes("/mf-stats.json") || file.includes("\\mf-stats.json");
+-}
+-function collectHostTags(server, options, adapters) {
+-	const ctx = {
+-		server,
+-		options
++		res.on("close", () => {
++			stream.destroy();
++		});
++		stream.pipe(res);
+ 	};
+-	const tags = [];
+-	for (const adapter of adapters) {
+-		const adapterTags = adapter.host?.transformIndexHtml?.(ctx);
+-		if (adapterTags) tags.push(...adapterTags);
+-	}
+-	tags.push({
+-		tag: "script",
+-		attrs: { type: "module" },
+-		children: FEDERATION_MODULE_CACHE_CLEAR_SCRIPT,
+-		injectTo: "head"
++};
++const normalizeDevDtsOptions = (dts, context) => {
++	return normalizeOptions(isTSProject(dts, context), {
++		generateTypes: { compileInChildProcess: true },
++		consumeTypes: { consumeAPITypes: true },
++		extraOptions: {},
++		displayErrorInTerminal: typeof dts === "object" && dts ? dts.displayErrorInTerminal : void 0
++	}, "mfOptions.dts")(dts);
++};
++const logDtsError = (error, dtsOptions) => {
++	if (dtsOptions === false) return;
++	if (typeof dtsOptions === "object" && dtsOptions && dtsOptions.displayErrorInTerminal === false) return;
++	mfError(error);
++};
++function pluginDts(options) {
++	if (options.dts === false) return [];
++	const baseDtsModuleFederationConfig = buildDtsModuleFederationConfig(options);
++	const getDtsModuleFederationConfig = (context) => ({
++		...baseDtsModuleFederationConfig,
++		dts: resolveDtsPluginOptions(options.dts, options, context)
+ 	});
+-	return tags;
+-}
+-function pluginDevRemoteHmr(options) {
+-	const isHost = Object.keys(options.remotes).length > 0;
+-	const isRemote = Object.keys(options.exposes).length > 0;
+-	let adapters = [];
+-	let strategy = "full-reload";
+-	return {
+-		name: "module-federation-dev-remote-hmr",
++	let resolvedConfig;
++	let devWorker;
++	let normalizedDevOptions;
++	let hasGeneratedBundle = false;
++	return [{
++		name: "module-federation-dts-dev",
+ 		apply: "serve",
++		config(config) {
++			normalizedDevOptions = normalizeDevOptions(options.dev);
++			if (!normalizedDevOptions) return;
++			if (normalizedDevOptions.disableDynamicRemoteTypeHints) return;
++			ensureRuntimePlugin(options, DYNAMIC_HINTS_PLUGIN);
++			const define = config.define ? { ...config.define } : {};
++			if (!("FEDERATION_IPV4" in define)) define.FEDERATION_IPV4 = JSON.stringify(getIPv4());
++			config.define = define;
++		},
+ 		configResolved(config) {
+-			adapters = resolveAdapters(config.plugins);
+-			strategy = resolveHmrStrategy(options.dev, config.plugins);
++			resolvedConfig = config;
+ 		},
+ 		configureServer(server) {
+-			if (!isRemoteHmrEnabled(options.dev)) return;
+-			if (isRemote) {
+-				for (const adapter of adapters) adapter.remote?.configureServer?.({
+-					server,
+-					options
++			if (!normalizedDevOptions || !resolvedConfig) return;
++			const devOptions = normalizedDevOptions;
++			if (devOptions.disableDynamicRemoteTypeHints && devOptions.disableHotTypesReload && devOptions.disableLiveReload) return;
++			if (!options.name) throw createModuleFederationError("name is required if you want to enable dev server!");
++			const outputDir = resolveOutputDir(resolvedConfig);
++			const dtsModuleFederationConfig = getDtsModuleFederationConfig(resolvedConfig.root);
++			const normalizedDtsOptions = normalizeDevDtsOptions(dtsModuleFederationConfig.dts, resolvedConfig.root);
++			if (typeof normalizedDtsOptions !== "object") return;
++			const normalizedGenerateTypes = normalizeOptions(Boolean(normalizedDtsOptions), { compileInChildProcess: true }, "mfOptions.dts.generateTypes")(normalizedDtsOptions.generateTypes);
++			const remote = normalizedGenerateTypes === false ? void 0 : {
++				implementation: normalizedDtsOptions.implementation,
++				context: resolvedConfig.root,
++				outputDir,
++				moduleFederationConfig: { ...dtsModuleFederationConfig },
++				hostRemoteTypesFolder: normalizedGenerateTypes.typesFolder || DEFAULT_PUBLIC_TYPES_FOLDER,
++				...normalizedGenerateTypes,
++				typesFolder: DEV_TYPES_FOLDER
++			};
++			if (remote) server.middlewares.use(createDevDtsAssetMiddleware(getDevDtsAssetPaths({
++				outputDir,
++				publicTypesFolder: remote.hostRemoteTypesFolder || DEFAULT_PUBLIC_TYPES_FOLDER,
++				root: resolvedConfig.root,
++				base: resolvedConfig.base
++			})));
++			if (remote && !remote.tsConfigPath && normalizedDtsOptions.tsConfigPath) remote.tsConfigPath = normalizedDtsOptions.tsConfigPath;
++			const normalizedConsumeTypes = normalizeOptions(Boolean(normalizedDtsOptions), { consumeAPITypes: true }, "mfOptions.dts.consumeTypes")(normalizedDtsOptions.consumeTypes);
++			const host = normalizedConsumeTypes === false ? void 0 : {
++				implementation: normalizedDtsOptions.implementation,
++				context: resolvedConfig.root,
++				moduleFederationConfig: dtsModuleFederationConfig,
++				typesFolder: normalizedConsumeTypes.typesFolder || "@mf-types",
++				abortOnError: false,
++				...normalizedConsumeTypes
++			};
++			const extraOptions = normalizedDtsOptions.extraOptions || {};
++			if (!remote && !host && devOptions.disableLiveReload) return;
++			const startDevWorker = async () => {
++				let remoteTypeUrls;
++				if (host) remoteTypeUrls = await new Promise((resolve) => {
++					consumeTypesAPI({
++						host,
++						extraOptions,
++						displayErrorInTerminal: normalizedDtsOptions.displayErrorInTerminal
++					}, resolve);
+ 				});
+-				setupRemoteMetadataEndpoint(server, options);
+-				if (strategy === "full-reload") setupRemoteBroadcast(server, options);
++				devWorker = new DevWorker({
++					name: options.name,
++					remote,
++					host: host ? {
++						...host,
++						remoteTypeUrls
++					} : void 0,
++					extraOptions,
++					disableLiveReload: devOptions.disableLiveReload,
++					disableHotTypesReload: devOptions.disableHotTypesReload
++				});
++				const update = () => devWorker?.update();
++				server.watcher.on("change", update);
++				server.watcher.on("add", update);
++				server.watcher.on("unlink", update);
++				server.httpServer?.once("close", () => {
++					devWorker?.exit();
++					server.watcher.off("change", update);
++					server.watcher.off("add", update);
++					server.watcher.off("unlink", update);
++				});
++			};
++			startDevWorker().catch((error) => {
++				logDtsError(error, normalizedDtsOptions);
++			});
++		}
++	}, {
++		name: "module-federation-dts-build",
++		apply: "build",
++		configResolved(config) {
++			resolvedConfig = config;
++		},
++		async generateBundle() {
++			if (hasGeneratedBundle) return;
++			hasGeneratedBundle = true;
++			if (!resolvedConfig) return;
++			let normalizedDtsOptions;
++			try {
++				normalizedDtsOptions = normalizeDtsOptions(getDtsModuleFederationConfig(resolvedConfig.root), resolvedConfig.root);
++			} catch (error) {
++				logDtsError(error, options.dts);
++				return;
+ 			}
+-			if (isHost) {
+-				for (const adapter of adapters) adapter.host?.configureServer?.({
+-					server,
+-					options
++			if (typeof normalizedDtsOptions !== "object") return;
++			const context = resolvedConfig.root;
++			const outputDir = resolveOutputDir(resolvedConfig);
++			let consumeOptions;
++			try {
++				consumeOptions = normalizeConsumeTypesOptions({
++					context,
++					dtsOptions: normalizedDtsOptions,
++					pluginOptions: getDtsModuleFederationConfig(resolvedConfig.root)
+ 				});
+-				if (strategy === "full-reload") setupHostFullReloadRelay(server, options);
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
++				return;
+ 			}
+-		},
+-		transform: {
+-			order: "post",
+-			handler(code, id) {
+-				if (!isRemote || !isRemoteHmrEnabled(options.dev)) return;
+-				if (!adapters.length) return;
+-				let result = code;
+-				const adapterCtx = { options };
+-				for (const adapter of adapters) {
+-					const next = adapter.remote?.transform?.(result, id, adapterCtx);
+-					if (typeof next === "string") result = next;
+-				}
+-				return result === code ? void 0 : result;
++			if (consumeOptions?.host?.typesOnBuild) try {
++				await consumeTypesAPI(consumeOptions);
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
+ 			}
+-		},
+-		transformIndexHtml: {
+-			order: "pre",
+-			handler(_html, ctx) {
+-				if (!isRemoteHmrEnabled(options.dev)) return;
+-				if (!isHost || !ctx.server) return;
+-				return collectHostTags(ctx.server, options, adapters);
++			let generateOptions;
++			try {
++				generateOptions = normalizeGenerateTypesOptions({
++					context,
++					outputDir,
++					dtsOptions: normalizedDtsOptions,
++					pluginOptions: getDtsModuleFederationConfig(resolvedConfig.root)
++				});
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
++				return;
++			}
++			if (!generateOptions) return;
++			try {
++				await generateTypesAPI({ dtsManagerOptions: generateOptions });
++			} catch (error) {
++				logDtsError(error, normalizedDtsOptions);
+ 			}
+ 		}
+-	};
++	}];
+ }
+ //#endregion
+ //#region src/virtualModules/index.ts
+-function initVirtualModules(command, remoteEntryId, enableSsrInit = false) {
++function initVirtualModules(command, remoteEntryId) {
+ 	writeLocalSharedImportMap();
+ 	writeHostAutoInit(remoteEntryId, command);
+-	writeRuntimeInitStatus(command, enableSsrInit);
++	writeRuntimeInitStatus(command);
+ }
+ //#endregion
+ //#region src/utils/bundleHelpers.ts
+-function isOutputChunk$1(chunk) {
+-	return chunk.type === "chunk";
+-}
+-function escapeRegExp(value) {
+-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+-}
+-function getProxyBaseName(fileName) {
+-	return fileName.replace(/^.*\//, "").replace(/\.js$/, "").replace(/-[A-Za-z0-9_-]+$/, "");
+-}
+-function extractFunctionDeclaration(code, functionName) {
+-	const funcRe = new RegExp(`function\\s+${functionName}\\s*\\([^)]*\\)\\s*\\{`);
+-	const funcStart = code.search(funcRe);
+-	if (funcStart < 0) return;
+-	let depth = 0;
+-	for (let i = code.indexOf("{", funcStart); i < code.length; i++) if (code[i] === "{") depth++;
+-	else if (code[i] === "}") {
+-		depth--;
+-		if (depth === 0) return code.slice(funcStart, i + 1);
+-	}
+-}
+ /**
+ * Resolve the local alias for a non-inlineable proxy binding.
+ * If Rollup's deconflict renamed the alias but didn't update references
+@@ -2733,156 +2432,15 @@ function resolveProxyAlias(binding, proxyLocal, code, fullImport, claimedLocals
+ 	const claimedImportLocals = /* @__PURE__ */ new Set();
+ 	const importRe = /import\s*\{([^}]+)\}\s*from\s*["'][^"']+["']\s*;?/g;
+ 	let match;
+-	while ((match = importRe.exec(codeWithoutImport)) !== null) for (const spec of match[1].split(",")) {
+-		const parts = spec.trim().split(/\s+as\s+/);
+-		claimedImportLocals.add((parts[1] || parts[0]).trim());
+-	}
+-	const local = !localUsedInCode && !claimedLocals.has(proxyLocal) && !claimedImportLocals.has(proxyLocal) ? proxyLocal : binding.local;
+-	return {
+-		imported: binding.imported,
+-		local
+-	};
+-}
+-function collectLoadShareProxyChunks(bundle, loadShareTag) {
+-	const proxyChunks = /* @__PURE__ */ new Map();
+-	for (const [fileName, chunk] of Object.entries(bundle)) {
+-		if (!isOutputChunk$1(chunk)) continue;
+-		if (fileName.includes(loadShareTag) && fileName.includes("commonjs-proxy")) proxyChunks.set(fileName, {
+-			code: chunk.code,
+-			fileName
+-		});
+-	}
+-	return proxyChunks;
+-}
+-function collectSystemProxyInfos(proxyChunks, loadShareTag) {
+-	const systemProxyInfo = /* @__PURE__ */ new Map();
+-	for (const [proxyFileName, proxyInfo] of Array.from(proxyChunks.entries())) {
+-		const depsMatch = proxyInfo.code.match(/System\.register\(\[([\s\S]*?)\]/);
+-		if (!depsMatch) continue;
+-		const loadShareDep = Array.from(depsMatch[1].matchAll(/["']([^"']+)["']/g)).map((m) => m[1]).find((dep) => dep.includes(loadShareTag) && !dep.includes("commonjs-proxy"));
+-		if (!loadShareDep) continue;
+-		const loadShareBindings = {};
+-		for (const m of proxyInfo.code.matchAll(/([A-Za-z_$][\w$]*)\s*=\s*module\d+\.([A-Za-z_$][\w$]*)/g)) loadShareBindings[m[1]] = m[2];
+-		const exportMap = {};
+-		const objectExportMatch = proxyInfo.code.match(/exports\(\s*\{([\s\S]*?)\}\s*\)/);
+-		if (objectExportMatch) for (const m of objectExportMatch[1].matchAll(/([A-Za-z_$][\w$]*)\s*:\s*([A-Za-z_$][\w$]*)/g)) {
+-			const [, exported, local] = m;
+-			const funcBody = extractFunctionDeclaration(proxyInfo.code, local);
+-			if (funcBody) exportMap[exported] = {
+-				type: "helper",
+-				code: funcBody
+-			};
+-		}
+-		for (const m of proxyInfo.code.matchAll(/exports\(\s*["']([^"']+)["']\s*,([\s\S]*?)\);/g)) {
+-			const exported = m[1];
+-			const expression = m[2];
+-			for (const [local, exportName] of Object.entries(loadShareBindings).reverse()) if (new RegExp(`\\b${local}\\b`).test(expression)) {
+-				exportMap[exported] = {
+-					type: "reexport",
+-					exportName
+-				};
+-				break;
+-			}
+-		}
+-		if (Object.keys(exportMap).length > 0) systemProxyInfo.set(proxyFileName, {
+-			loadShareDep,
+-			exportMap
+-		});
+-	}
+-	return systemProxyInfo;
+-}
+-function rewriteEsmProxyConsumers(code, proxyChunks) {
+-	let nextCode = code;
+-	const claimedLocals = /* @__PURE__ */ new Set();
+-	for (const [proxyFileName, proxyInfo] of Array.from(proxyChunks.entries())) {
+-		const proxyBaseName = getProxyBaseName(proxyFileName);
+-		const importMatch = new RegExp(`import\\s*\\{([^}]+)\\}\\s*from\\s*["']([^"']*${escapeRegExp(proxyBaseName)}[^"']*)["']\\s*;?`).exec(nextCode);
+-		if (!importMatch) continue;
+-		const fullImport = importMatch[0];
+-		const bindings = importMatch[1].split(",").map((s) => {
+-			const parts = s.trim().split(/\s+as\s+/);
+-			return {
+-				imported: parts[0].trim(),
+-				local: (parts[1] || parts[0]).trim()
+-			};
+-		});
+-		const exportMapMatch = proxyInfo.code.match(/export\s*\{([^}]+)\}/);
+-		if (!exportMapMatch) continue;
+-		const exportMap = {};
+-		for (const entry of exportMapMatch[1].split(",")) {
+-			const parts = entry.trim().split(/\s+as\s+/);
+-			if (parts.length === 2) exportMap[parts[1].trim()] = parts[0].trim();
+-		}
+-		const inlineable = [];
+-		const nonInlineable = [];
+-		const pendingLocals = new Set(bindings.map((binding) => binding.local));
+-		for (const b of bindings) {
+-			pendingLocals.delete(b.local);
+-			const proxyLocal = exportMap[b.imported];
+-			if (!proxyLocal) {
+-				claimedLocals.add(b.local);
+-				nonInlineable.push(b);
+-				continue;
+-			}
+-			const funcBody = extractFunctionDeclaration(proxyInfo.code, proxyLocal);
+-			if (funcBody) {
+-				inlineable.push({
+-					local: b.local,
+-					funcBody: funcBody.replace(new RegExp(`function\\s+${proxyLocal}\\s*\\(`), `function ${b.local}(`)
+-				});
+-				claimedLocals.add(b.local);
+-			} else {
+-				const unavailableLocals = new Set(claimedLocals);
+-				pendingLocals.forEach((local) => unavailableLocals.add(local));
+-				const resolvedBinding = resolveProxyAlias(b, proxyLocal, nextCode, fullImport, unavailableLocals);
+-				claimedLocals.add(resolvedBinding.local);
+-				nonInlineable.push(resolvedBinding);
+-			}
+-		}
+-		const hasRenamedAlias = nonInlineable.some((b) => bindings.find((ob) => ob.imported === b.imported)?.local !== b.local);
+-		if (inlineable.length === 0 && !hasRenamedAlias) continue;
+-		let replacement = "";
+-		if (nonInlineable.length > 0) replacement = `import{${nonInlineable.map((b) => b.imported === b.local ? b.imported : `${b.imported} as ${b.local}`).join(",")}}from"${importMatch[2]}";`;
+-		replacement += inlineable.map((f) => f.funcBody).join("");
+-		nextCode = nextCode.replace(fullImport, () => replacement);
+-	}
+-	return nextCode;
+-}
+-function rewriteSystemProxyConsumers(code, systemProxyInfo) {
+-	if (!code.includes("System.register(")) return code;
+-	let nextCode = code;
+-	for (const [proxyFileName, proxyInfo] of Array.from(systemProxyInfo.entries())) {
+-		const proxyBaseName = getProxyBaseName(proxyFileName);
+-		const depMatch = new RegExp(`["']([^"']*${escapeRegExp(proxyBaseName)}[^"']*)["']`).exec(nextCode);
+-		if (!depMatch) continue;
+-		let setterIndex = 0;
+-		const depListMatch = nextCode.match(/System\.register\(\[([\s\S]*?)\]/);
+-		if (depListMatch) setterIndex = Array.from(depListMatch[1].matchAll(/["']([^"']+)["']/g)).map((m) => m[1]).findIndex((dep) => dep.includes(proxyBaseName));
+-		if (setterIndex < 0) continue;
+-		const settersStart = nextCode.indexOf("setters: [");
+-		if (settersStart < 0) continue;
+-		const setterMatch = Array.from(nextCode.slice(settersStart).matchAll(/\((module\d+)\)\s*=>\s*\{([\s\S]*?)\}/g))[setterIndex];
+-		if (!setterMatch) continue;
+-		const [fullSetter, moduleLocal, setterBody] = setterMatch;
+-		const helpersToInline = [];
+-		const nextSetterBody = setterBody.replace(new RegExp(`([A-Za-z_$][\\w$]*)\\s*=\\s*${moduleLocal}\\.([A-Za-z_$][\\w$]*);?`, "g"), (assignment, local, imported) => {
+-			const mapped = proxyInfo.exportMap[imported];
+-			if (!mapped) return assignment;
+-			if (mapped.type === "helper") {
+-				helpersToInline.push(mapped.code.replace(new RegExp(`function\\s+${imported}\\s*\\(`), `function ${local}(`));
+-				return "";
+-			}
+-			return `${local} = ${moduleLocal}.${mapped.exportName};`;
+-		});
+-		if (nextSetterBody === setterBody && helpersToInline.length === 0) continue;
+-		const nextSetter = fullSetter.replace(setterBody, () => nextSetterBody);
+-		nextCode = nextCode.replace(fullSetter, () => nextSetter);
+-		nextCode = nextCode.replace(depMatch[0], JSON.stringify(proxyInfo.loadShareDep));
+-		if (helpersToInline.length > 0) nextCode = nextCode.replace("execute: (function() {", () => {
+-			return `execute: (function() {${helpersToInline.join("")}`;
+-		});
++	while ((match = importRe.exec(codeWithoutImport)) !== null) for (const spec of match[1].split(",")) {
++		const parts = spec.trim().split(/\s+as\s+/);
++		claimedImportLocals.add((parts[1] || parts[0]).trim());
+ 	}
+-	return nextCode;
++	const local = !localUsedInCode && !claimedLocals.has(proxyLocal) && !claimedImportLocals.has(proxyLocal) ? proxyLocal : binding.local;
++	return {
++		imported: binding.imported,
++		local
++	};
+ }
+ function findRemoteEntryFile(filename, bundle) {
+ 	for (const [_, fileData] of Object.entries(bundle)) if (filename.replace(/[\[\]]/g, "_").replace(/\.[^/.]+$/, "") === fileData.name || fileData.name === "remoteEntry") return fileData.fileName;
+@@ -2978,19 +2536,9 @@ const processModuleAssets = (bundle, filesMap, moduleMatcher, options = {}) => {
+ 				foundCssViaMetadata = true;
+ 			}
+ 			if (!foundCssViaMetadata && chunkContainsCssModules(fileData.modules)) for (const cssAsset of Array.from(bundleCssAssets)) trackAsset(filesMap, matchKey, cssAsset, false, "css");
+-			const visited = /* @__PURE__ */ new Set();
+-			const queue = [fileName];
+-			for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+-				const cur = queue[queueIndex];
+-				if (visited.has(cur)) continue;
+-				visited.add(cur);
+-				const chunk = bundle[cur];
+-				if (!chunk || chunk.type !== "chunk") continue;
+-				if (chunk.dynamicImports) for (const dynamicImport of chunk.dynamicImports) {
+-					if (!bundle[dynamicImport]) continue;
+-					trackAsset(filesMap, matchKey, dynamicImport, true, isCSSFile(dynamicImport) ? "css" : "js");
+-				}
+-				if (chunk.imports) for (const imp of chunk.imports) queue.push(imp);
++			if (fileData.dynamicImports) for (const dynamicImport of fileData.dynamicImports) {
++				if (!bundle[dynamicImport]) continue;
++				trackAsset(filesMap, matchKey, dynamicImport, true, isCSSFile(dynamicImport) ? "css" : "js");
+ 			}
+ 		}
+ 	}
+@@ -3036,56 +2584,7 @@ const buildFileToShareKeyMap = async (shareKeys, resolveFn) => {
+ 	return fileToShareKey;
+ };
+ //#endregion
+-//#region src/utils/pathNormalization.ts
+-const COMMON_SHARED_SUBPATHS = {
+-	react: [
+-		"react/jsx-runtime",
+-		"react/jsx-dev-runtime",
+-		"react/compiler-runtime"
+-	],
+-	"react-dom": [
+-		"react-dom/client",
+-		"react-dom/server",
+-		"react-dom/server.browser"
+-	],
+-	"solid-js": [
+-		"solid-js/web",
+-		"solid-js/store",
+-		"solid-js/html",
+-		"solid-js/h"
+-	]
+-};
+-function removeTrailingSlash(value) {
+-	return value.endsWith("/") ? value.slice(0, -1) : value;
+-}
+-function ensureTrailingSlash(value) {
+-	return `${removeTrailingSlash(value)}/`;
+-}
+-function getBasePath(base) {
+-	return removeTrailingSlash(base || "/");
+-}
+-function isNuxtClientBase(base) {
+-	return getBasePath(base).endsWith("/_nuxt");
+-}
+-function normalizeNodeModulePath(source) {
+-	return source.replace(/\\/g, "/").replace(/\?.*$/, "");
+-}
+-function isNodeModulePath(source) {
+-	return source.includes("/node_modules/") || source.includes("\\node_modules\\");
+-}
+-function filterId(id) {
+-	return typeof id === "string" && !id.includes("\0");
+-}
+-function getMatchingNodeModuleSubpath(source, candidates) {
+-	const normalized = normalizeNodeModulePath(source);
+-	return [...candidates].sort((a, b) => b.length - a.length).find((candidate) => normalized.includes(`/node_modules/${candidate}/`) || normalized.includes(`/node_modules/${candidate}.`));
+-}
+-function getCommonSharedSubpaths(sharedKey) {
+-	return COMMON_SHARED_SUBPATHS[removeTrailingSlash(sharedKey)] || [];
+-}
+-function getCommonSharedSubpathFromNodeModulePath(source, sharedKey) {
+-	return getMatchingNodeModuleSubpath(source, getCommonSharedSubpaths(removeTrailingSlash(sharedKey)));
+-}
++//#region src/utils/publicPath.ts
+ /**
+ * Resolves the public path for remote entries
+ * @param options - Module Federation options
+@@ -3095,121 +2594,11 @@ function getCommonSharedSubpathFromNodeModulePath(source, sharedKey) {
+ */
+ function resolvePublicPath(options, viteBase, originalBase) {
+ 	if (options.publicPath && options.publicPath !== "auto") return options.publicPath;
+-	if (!originalBase) return "auto";
+-	if (viteBase) return ensureTrailingSlash(viteBase);
++	if (originalBase === "") return "auto";
++	if (viteBase) return viteBase.replace(/\/?$/, "/");
+ 	return "auto";
+ }
+ //#endregion
+-//#region src/virtualModules/virtualExposesSSR.ts
+-/**
+-* Virtual module ID for the SSR exposes map.
+-* Separate from the browser exposes: no CSS injection, no document references,
+-* and shared packages are imported as bare specifiers (externals in the SSR build).
+-*/
+-function getVirtualExposesSSRId(options) {
+-	return `virtual:mf-exposes-ssr:${`${options.internalName}__${options.filename}`.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+-}
+-/**
+-* Generates the SSR exposes map module.
+-*
+-* Differences from the browser version (virtualExposes.ts):
+-* - No CSS asset injection (document APIs unavailable on Node)
+-* - Shared packages (react, react-dom, etc.) must be externals in the SSR
+-*   build so Node resolves them via its own module cache — this is what
+-*   guarantees the React singleton is shared with react-dom/server.
+-*/
+-function generateExposesSSR(options) {
+-	return `
+-    export default {
+-    ${Object.keys(options.exposes).map((key) => {
+-		return `
+-        ${JSON.stringify(key)}: async () => {
+-          const importModule = await import(${JSON.stringify(options.exposes[key].import)})
+-          const exportModule = {}
+-          Object.assign(exportModule, importModule)
+-          Object.defineProperty(exportModule, "__esModule", {
+-            value: true,
+-            enumerable: false
+-          })
+-          return exportModule
+-        }
+-      `;
+-	}).join(",")}
+-  }
+-  `;
+-}
+-//#endregion
+-//#region src/virtualModules/virtualRemoteEntrySSR.ts
+-const REMOTE_ENTRY_SSR_ID = "virtual:mf-REMOTE_ENTRY_SSR_ID";
+-function getRemoteEntrySSRId(options) {
+-	return `${REMOTE_ENTRY_SSR_ID}:${`${options.internalName}__${options.filename}`.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+-}
+-function getSsrRemoteEntryFileName(browserFilename) {
+-	const ext = browserFilename.match(/\.[^.]+$/)?.[0] || ".js";
+-	return `${browserFilename.slice(0, browserFilename.length - ext.length)}.ssr${ext}`;
+-}
+-/**
+-* Generates the SSR remote entry module.
+-*
+-* This is intentionally minimal — no HMR shim, no loadShare virtual modules,
+-* no browser globals. Shared packages (react, react-dom, etc.) are imported
+-* as externals by the SSR build, so Node's require cache provides the singleton.
+-*
+-* The container API (init / get) mirrors the browser entry so the MF runtime
+-* can call it the same way on the server.
+-*/
+-function generateRemoteEntrySSR(options) {
+-	const virtualExposesSSRId = getVirtualExposesSSRId(options);
+-	return `
+-  import { init as runtimeInit } from "@module-federation/runtime";
+-
+-  let exposesMapPromise;
+-
+-  async function getExposesMap() {
+-    exposesMapPromise ??= import(${JSON.stringify(virtualExposesSSRId)}).then((mod) => mod.default ?? mod);
+-    return exposesMapPromise;
+-  }
+-
+-  /**
+-   * Called by the MF runtime on the host to register this remote's share scope.
+-   * On the server the host has already initialised the runtime, so we just need
+-   * to set up a minimal runtime instance for the remote container.
+-   */
+-  async function init(shared = {}, initScope = []) {
+-    const initRes = runtimeInit({
+-      name: ${JSON.stringify(options.name)},
+-      remotes: [],
+-      shared: {},
+-    });
+-    const initToken = { from: ${JSON.stringify(options.name)} };
+-    if (initScope.indexOf(initToken) >= 0) return;
+-    initScope.push(initToken);
+-    initRes.initShareScopeMap(${JSON.stringify(options.shareScope)}, shared);
+-    try {
+-      await Promise.all(
+-        await initRes.initializeSharing(${JSON.stringify(options.shareScope)}, {
+-          strategy: ${JSON.stringify(options.shareStrategy ?? "version-first")},
+-          from: 'build',
+-          initScope,
+-        })
+-      );
+-    } catch (e) {
+-      console.error('[Module Federation SSR]', e);
+-    }
+-    return initRes;
+-  }
+-
+-  async function getExposes(moduleName) {
+-    const exposesMap = await getExposesMap();
+-    if (!(moduleName in exposesMap))
+-      throw new Error(\`[Module Federation] Module \${moduleName} does not exist in container.\`);
+-    return exposesMap[moduleName]().then((res) => () => res);
+-  }
+-
+-  export { init, getExposes as get };
+-  `;
+-}
+-//#endregion
+ //#region src/plugins/pluginMFManifest.ts
+ /**
+ * Resolves the build version for the module federation manifest.
+@@ -3240,7 +2629,6 @@ const Manifest = () => {
+ 	};
+ 	let root;
+ 	let remoteEntryFile;
+-	let ssrRemoteEntryFile;
+ 	let publicPath;
+ 	let _command;
+ 	let _originalConfigBase;
+@@ -3277,8 +2665,8 @@ const Manifest = () => {
+ 								type: "module"
+ 							},
+ 							ssrRemoteEntry: {
+-								name: getSsrRemoteEntryFileName(filename),
+-								path: "/__mf_ssr__/",
++								name: filename,
++								path: "",
+ 								type: "module"
+ 							},
+ 							varRemoteEntry: varFilename ? {
+@@ -3309,7 +2697,6 @@ const Manifest = () => {
+ 			_originalConfigBase = config.base;
+ 		},
+ 		configResolved(config) {
+-			viteConfig = config;
+ 			root = config.root;
+ 			let base = config.base;
+ 			if (_command === "serve") base = (config.server.origin || "") + config.base;
+@@ -3319,10 +2706,7 @@ const Manifest = () => {
+ 			if (!mfManifestName) return;
+ 			let filesMap = {};
+ 			const foundRemoteEntryFile = findRemoteEntryFile(mfOptions.filename, bundle);
+-			const expectedSsrRemoteEntryFile = getSsrRemoteEntryFileName(mfOptions.filename);
+-			const foundSsrRemoteEntryFile = Object.values(bundle).find((file) => file.fileName === expectedSsrRemoteEntryFile)?.fileName;
+ 			if (foundRemoteEntryFile) remoteEntryFile = foundRemoteEntryFile;
+-			ssrRemoteEntryFile = foundSsrRemoteEntryFile || expectedSsrRemoteEntryFile;
+ 			const allCssAssets = mfOptions.bundleAllCSS && !disableAssetsAnalyze ? collectCssAssets(bundle) : /* @__PURE__ */ new Set();
+ 			if (!disableAssetsAnalyze) {
+ 				const exposesModules = Object.keys(mfOptions.exposes).map((item) => mfOptions.exposes[item].import);
+@@ -3364,11 +2748,6 @@ const Manifest = () => {
+ 			path: "",
+ 			type: "module"
+ 		};
+-		const ssrRemoteEntry = {
+-			name: ssrRemoteEntryFile || getSsrRemoteEntryFileName(filename),
+-			path: _command === "serve" ? "/__mf_ssr__/" : "",
+-			type: "module"
+-		};
+ 		const varRemoteEntry = varFilename ? {
+ 			name: varFilename,
+ 			path: "",
+@@ -3380,11 +2759,10 @@ const Manifest = () => {
+ 			alias: remoteKey,
+ 			entry: "*"
+ 		})));
+-		const shared = Array.from(getUsedShares()).flatMap((shareKey) => {
++		const shared = Array.from(getUsedShares()).map((shareKey) => {
+ 			const shareItem = getNormalizeShareItem(shareKey);
+-			if (!shareItem) return [];
+ 			const assets = preloadMap[shareKey] || createEmptyAssetMap();
+-			return [{
++			return {
+ 				id: `${name}:${shareKey}`,
+ 				name: shareKey,
+ 				version: shareItem.version,
+@@ -3400,7 +2778,7 @@ const Manifest = () => {
+ 						sync: assets.css.sync
+ 					}
+ 				}
+-			}];
++			};
+ 		});
+ 		const exposes = Object.entries(options.exposes).map(([key, value]) => {
+ 			const formatKey = key.replace("./", "");
+@@ -3432,7 +2810,7 @@ const Manifest = () => {
+ 					buildName: name
+ 				},
+ 				remoteEntry,
+-				ssrRemoteEntry,
++				ssrRemoteEntry: remoteEntry,
+ 				varRemoteEntry,
+ 				types: {
+ 					path: "",
+@@ -3552,6 +2930,7 @@ function pluginModuleParseEnd_default(excludeFn, options) {
+ }
+ //#endregion
+ //#region src/plugins/pluginProxyRemoteEntry.ts
++const filter$1 = createFilter();
+ function pluginProxyRemoteEntry_default({ options, remoteEntryId, virtualExposesId }) {
+ 	let viteConfig, _command, root;
+ 	return {
+@@ -3591,15 +2970,14 @@ function pluginProxyRemoteEntry_default({ options, remoteEntryId, virtualExposes
+ 		},
+ 		transform(code, id) {
+ 			return mapCodeToCodeWithSourcemap((() => {
+-				if (!filterId(id)) return;
++				if (!filter$1(id)) return;
+ 				if (id.includes(remoteEntryId)) return parsePromise.then((_) => generateRemoteEntry(options, virtualExposesId, _command));
+ 				if (id === virtualExposesId) return generateExposes(options);
+ 				if (id.includes(getHostAutoInitPath())) {
+ 					if (_command === "serve") {
+ 						const host = typeof viteConfig.server?.host === "string" && viteConfig.server.host !== "0.0.0.0" ? viteConfig.server.host : "localhost";
+-						const resolvedPublicPath = resolvePublicPath(options, viteConfig.base);
+-						const publicPath = JSON.stringify((resolvedPublicPath === "auto" ? "/" : resolvedPublicPath) + options.filename);
+-						const fallbackOrigin = `//${host}:${viteConfig.server?.port}`;
++						const publicPath = JSON.stringify(resolvePublicPath(options, viteConfig.base) + options.filename);
++						const fallbackOrigin = `http://${host}:${viteConfig.server?.port}`;
+ 						const ssrRemoteEntry = "data:text/javascript," + encodeURIComponent("export async function init(){return {loadRemote:async()=>({}),loadShare:async()=>({})}}");
+ 						return `
+           const origin = typeof window !== 'undefined' && (${!options.ignoreOrigin}) ? window.origin : ${JSON.stringify(fallbackOrigin)};
+@@ -3650,59 +3028,39 @@ function pluginProxyRemoteEntry_default({ options, remoteEntryId, virtualExposes
+ }
+ //#endregion
+ //#region src/plugins/pluginProxyRemotes.ts
++const filter = createFilter();
+ function isNodeModulesImporter(importer) {
+ 	return importer?.includes("/node_modules/") || importer?.includes("\\node_modules\\");
+ }
+-function appendAlias(config, alias) {
+-	config.resolve ??= {};
+-	const existingAlias = config.resolve.alias;
+-	if (!existingAlias) {
+-		config.resolve.alias = [alias];
+-		return;
+-	}
+-	if (Array.isArray(existingAlias)) {
+-		existingAlias.push(alias);
+-		return;
+-	}
+-	config.resolve.alias = [...Object.entries(existingAlias).map(([find, replacement]) => ({
+-		find,
+-		replacement
+-	})), alias];
+-}
+ function pluginProxyRemotes_default(options) {
+ 	let command;
+ 	let root = process.cwd();
+-	let enableSsrInit = false;
+ 	const { remotes } = options;
+ 	function resolveRemoteId(source, importer, remoteName) {
+ 		if (source === remoteName) {
+ 			const installedPackageEntry = getInstalledPackageEntry(source, { cwd: root });
+ 			if (installedPackageEntry && (importer === void 0 || isNodeModulesImporter(importer))) return installedPackageEntry;
+ 		}
+-		const remoteModule = getRemoteVirtualModule(source, command, enableSsrInit);
++		const remoteModule = getRemoteVirtualModule(source, command);
+ 		addUsedRemote(remoteName, source);
+ 		refreshHostAutoInit();
+-		return remoteModule.getImportId();
++		return remoteModule.getPath();
+ 	}
+ 	return {
+ 		name: "proxyRemotes",
+-		enforce: "pre",
+ 		config(config, { command: _command }) {
+ 			command = _command;
+ 			root = config.root || process.cwd();
+ 			Object.keys(remotes).forEach((key) => {
+ 				const remote = remotes[key];
+-				appendAlias(config, {
++				config.resolve.alias.push({
+ 					find: new RegExp(`^(${remote.name}(\/.*|$))`),
+ 					replacement: "$1"
+ 				});
+ 			});
+ 		},
+-		configResolved() {
+-			enableSsrInit = command === "serve" && parseInt(version, 10) >= 8;
+-		},
+ 		resolveId(source, importer) {
+-			if (!filterId(source)) return;
++			if (!filter(source)) return;
+ 			for (const remote of Object.values(remotes)) {
+ 				if (source !== remote.name && !source.startsWith(`${remote.name}/`)) continue;
+ 				return resolveRemoteId(source, importer, remote.name);
+@@ -3751,7 +3109,7 @@ function tryResolveFromProjectRoot(source) {
+ 	const browserEntry = getInstalledPackageEntry(source, { cwd: getPackageDetectionCwd() });
+ 	if (browserEntry) return browserEntry;
+ 	try {
+-		return createRequire(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(source);
++		return createRequire$1(new URL(`file://${path.join(getPackageDetectionCwd(), "package.json")}`)).resolve(source);
+ 	} catch {
+ 		return;
+ 	}
+@@ -3762,31 +3120,14 @@ function isBuildConfigImporter(importer) {
+ }
+ function matchesSharedSource(source, key) {
+ 	const keyBase = key.endsWith("/") ? key.slice(0, -1) : key;
+-	if (keyBase === "vue" && (source === "vue/dist/vue.esm-bundler.js" || source === "vue/dist/vue.runtime.esm-bundler.js")) return true;
+ 	if (key.endsWith("/")) return source === keyBase || source.startsWith(`${keyBase}/`);
+-	if (getCommonSharedSubpaths(keyBase).includes(source)) return true;
+ 	return source === keyBase;
+ }
+ function findSharedKey(source, shared) {
+-	const keys = Object.keys(shared || {});
+-	return keys.find((key) => source === key) ?? keys.find((key) => matchesSharedSource(source, key));
+-}
+-function findSharedKeyForSource(source, shared) {
+-	const key = findSharedKey(source, shared);
+-	if (key) return key;
+-	const explicitSharedSubpathKeys = Object.keys(shared || {}).filter((sharedKey) => getPackageName(sharedKey) !== sharedKey && !sharedKey.endsWith("/"));
+-	if (isNodeModulePath(source)) {
+-		const explicitSubpathKey = getMatchingNodeModuleSubpath(source, explicitSharedSubpathKeys);
+-		if (explicitSubpathKey) return explicitSubpathKey;
+-		const normalizedSource = normalizeNodeModulePath(source);
+-		const explicitSubpathEntryKey = explicitSharedSubpathKeys.find((sharedKey) => {
+-			const entry = getInstalledPackageEntry(sharedKey, { cwd: getPackageDetectionCwd() });
+-			return entry ? normalizeNodeModulePath(entry) === normalizedSource : false;
+-		});
+-		if (explicitSubpathEntryKey) return explicitSubpathEntryKey;
+-	}
+-	const packageName = getPackageNameFromNodeModulePath(source);
+-	return packageName ? findSharedKey(packageName, shared) : void 0;
++	return Object.keys(shared || {}).find((key) => matchesSharedSource(source, key));
++}
++function isNodeModulePath(source) {
++	return source.includes("/node_modules/") || source.includes("\\node_modules\\");
+ }
+ /**
+ * Reads the dependencies of an installed package from its package.json.
+@@ -3811,7 +3152,6 @@ function excludeSharedSubDependencies(shared) {
+ 		for (const dep of deps) {
+ 			const depKey = sharedKeyByBase.get(dep);
+ 			if (depKey && depKey !== parentKey) {
+-				if (shared[depKey]?.shareConfig.singleton === true || shared[depKey]?.shareConfig.import === false) continue;
+ 				mfWarn(`"${dep}" is a dependency of shared package "${parentKey}" and is also shared separately. This may cause initialization order issues in dev mode. Consider sharing only "${parentKey}".\n  Auto-excluding "${dep}" from shared modules for dev mode.`);
+ 				delete shared[depKey];
+ 				sharedKeys.delete(depKey);
+@@ -3827,28 +3167,15 @@ function proxySharedModule(options) {
+ 	let useDirectReactImport = false;
+ 	let useRolldown = false;
+ 	const savePrebuild = new PromiseStore();
+-	let devServer;
+-	const materializedLoadShareSources = /* @__PURE__ */ new Set();
+ 	return [
+ 		{
+ 			name: "generateLocalSharedImportMap",
+ 			enforce: "post",
+-			configureServer(server) {
+-				devServer = server;
+-				setLocalSharedImportMapInvalidator(() => {
+-					const module = server.moduleGraph.getModuleById(getResolvedLocalSharedImportMapId());
+-					if (module) server.moduleGraph.invalidateModule(module);
+-				});
+-			},
+-			resolveId(source) {
+-				if (source === getLocalSharedImportMapPath()) return getResolvedLocalSharedImportMapId();
+-			},
+ 			load(id) {
+-				if (id === getResolvedLocalSharedImportMapId()) return parsePromise.then((_) => generateLocalSharedImportMap());
++				if (id.includes(getLocalSharedImportMapPath())) return parsePromise.then((_) => generateLocalSharedImportMap());
+ 			},
+-			closeBundle() {
+-				if (devServer) return;
+-				setLocalSharedImportMapInvalidator(void 0);
++			transform(_, id) {
++				if (id.includes(getLocalSharedImportMapPath())) return mapCodeToCodeWithSourcemap(parsePromise.then((_) => generateLocalSharedImportMap()));
+ 			}
+ 		},
+ 		{
+@@ -3885,13 +3212,7 @@ function proxySharedModule(options) {
+ 			name: "proxyPreBuildShared:resolve-shared-loadShare",
+ 			enforce: "pre",
+ 			async resolveId(source, importer) {
+-				function shouldSkipTaggedImporterProxy(sharedKey, tag) {
+-					if (!importer?.includes(tag)) return false;
+-					const taggedModule = VirtualModule.findModule(tag, importer);
+-					if (!taggedModule) return true;
+-					return taggedModule.name === sharedKey || matchesSharedSource(source, taggedModule.name);
+-				}
+-				const key = findSharedKeyForSource(source, shared);
++				const key = findSharedKey(source, shared);
+ 				if (!key) return;
+ 				if (useDirectReactImport && key === "react") return;
+ 				if (/\.css$/.test(source)) return;
+@@ -3899,18 +3220,15 @@ function proxySharedModule(options) {
+ 				if (useDirectReactImport && source === "react") return;
+ 				if (importer && importer.includes("localSharedImportMap")) return;
+ 				if (importer && (importer.includes("hostAutoInit") || importer.includes("__H_A_I__"))) return;
+-				if (shouldSkipTaggedImporterProxy(key, "__loadShare__")) return;
+-				if (shouldSkipTaggedImporterProxy(key, "__prebuild__")) return;
+-				const shareSource = key === "vue" && source.startsWith("vue/dist/") ? key : isNodeModulePath(source) ? getCommonSharedSubpathFromNodeModulePath(source, key) || key : source;
+-				const loadSharePath = getLoadShareModulePath(shareSource, useRolldown);
+-				if (!materializedLoadShareSources.has(shareSource)) {
+-					materializedLoadShareSources.add(shareSource);
+-					writeLoadShareModule(shareSource, shared[key], _command, useRolldown);
+-					if (shared[key].shareConfig.import !== false) writePreBuildLibPath(shareSource, shared[key]);
+-					addUsedShares(shareSource);
+-					writeLocalSharedImportMap();
+-					refreshHostAutoInit();
+-				}
++				if (importer && importer.includes("__loadShare__")) return;
++				if (importer && importer.includes("__prebuild__")) return;
++				if (key.endsWith("/") && source !== key.slice(0, -1)) return;
++				const loadSharePath = getLoadShareModulePath(source, useRolldown);
++				writeLoadShareModule(source, shared[key], _command, useRolldown);
++				if (shared[key].shareConfig.import !== false) writePreBuildLibPath(source, shared[key]);
++				addUsedShares(source);
++				writeLocalSharedImportMap();
++				refreshHostAutoInit();
+ 				return this.resolve(loadSharePath, importer, { skipSelf: true });
+ 			}
+ 		},
+@@ -3988,28 +3306,9 @@ function wrapDynamicImport(original) {
+ }
+ function applyRewrites(code, imports, id) {
+ 	if (imports.length === 0) return;
+-	const ms = new CodeRewriter(code);
++	const ms = new MagicString(code);
+ 	let changed = false;
+ 	let counter = 0;
+-	let namedProxyHelperDeclared = false;
+-	const namedProxyHelper = `function __mfCreateNamedRemoteProxy(ns, key) {
+-  const target = function (...args) {
+-    const value = ns[key];
+-    return typeof value === "function" ? value.apply(this, args) : value;
+-  };
+-  return new Proxy(target, {
+-    get(_target, prop) {
+-      if (prop === "then") return undefined;
+-      const value = ns[key];
+-      if (prop === Symbol.toPrimitive) return () => value;
+-      const item = value == null ? undefined : value[prop];
+-      return typeof item === "function" ? item.bind(value) : item;
+-    },
+-    apply(target, thisArg, args) {
+-      return target.apply(thisArg, args);
+-    }
+-  });
+-}`;
+ 	for (const imp of imports) switch (imp.kind) {
+ 		case "static": {
+ 			const src = JSON.stringify(imp.source);
+@@ -4019,23 +3318,9 @@ function applyRewrites(code, imports, id) {
+ 				const importParts = [];
+ 				if (imp.defaultLocal) importParts.push(`default as ${imp.defaultLocal}`);
+ 				importParts.push(`__moduleExports as ${nsId}`);
++				const destructParts = imp.named.map((s) => s.imported === s.local ? s.local : `${s.imported}: ${s.local}`);
+ 				let rewrite = `import { ${importParts.join(", ")} } from ${src};`;
+-				if (imp.named.length > 0) {
+-					const isProxyId = `__mf_is_proxy_${counter++}`;
+-					const tempNames = imp.named.map((_s) => `__mf_named_${counter++}`);
+-					const destructParts = imp.named.map((s, index) => `${s.imported}: ${tempNames[index]}`);
+-					const bindingLines = imp.named.map((s, index) => {
+-						const temp = tempNames[index];
+-						return `const ${s.local} = ${isProxyId} ? __mfCreateNamedRemoteProxy(${nsId}, ${JSON.stringify(s.imported)}) : ${temp};`;
+-					});
+-					if (!namedProxyHelperDeclared) {
+-						rewrite += `\n${namedProxyHelper}`;
+-						namedProxyHelperDeclared = true;
+-					}
+-					rewrite += `\nconst ${isProxyId} = ${nsId} && ${nsId}.__mf_is_remote_proxy;`;
+-					rewrite += `\nconst { ${destructParts.join(", ")} } = ${isProxyId} ? {} : ${nsId};`;
+-					rewrite += `\n${bindingLines.join("\n")}`;
+-				}
++				if (destructParts.length > 0) rewrite += `\nconst { ${destructParts.join(", ")} } = ${nsId};`;
+ 				ms.overwrite(imp.start, imp.end, rewrite);
+ 			}
+ 			changed = true;
+@@ -4069,7 +3354,7 @@ function applyRewrites(code, imports, id) {
+ 	if (!changed) return;
+ 	return {
+ 		code: ms.toString(),
+-		map: ms.generateMap(id)
++		map: ms.generateMap({ hires: true })
+ 	};
+ }
+ async function collectFromAST(ast, code, isRemoteImport) {
+@@ -4138,7 +3423,7 @@ async function collectFromEsLexer(code, isRemoteImport) {
+ 	await init;
+ 	let imports;
+ 	try {
+-		[imports] = parse(code);
++		[imports] = parse$1(code);
+ 	} catch {
+ 		return;
+ 	}
+@@ -4311,205 +3596,6 @@ function pluginRemoteNamedExports(options) {
+ 	};
+ }
+ //#endregion
+-//#region src/plugins/pluginSSRRemoteEntry.ts
+-/**
+-* Emits a Node-compatible SSR remote entry alongside the browser entry.
+-*
+-* Format strategy:
+-*  - Emit a dedicated ESM SSR entry alongside the browser entry.
+-*  - Keep the SSR entry out of the browser remote graph for Rollup builds by
+-*    emitting it as a generated asset.
+-*
+-* In both cases shared packages (react, react-dom, etc.) are marked as external
+-* so Node resolves them through its own module cache, guaranteeing the singleton
+-* is shared with react-dom/server.
+-*/
+-function pluginSSRRemoteEntry(options) {
+-	const remoteEntrySSRId = getRemoteEntrySSRId(options);
+-	const virtualExposesSSRId = getVirtualExposesSSRId(options);
+-	let isRolldown = false;
+-	let ssrOutputFilename = "";
+-	const ssrOnlyExternals = [
+-		"@module-federation/runtime",
+-		"@module-federation/runtime-core",
+-		"@module-federation/sdk",
+-		...options.ssrExternals ?? []
+-	];
+-	const ssrOnlyExternalPattern = new RegExp(`^(${ssrOnlyExternals.map((e) => e.replace(/[/\\^$*+?.()|[\]{}]/g, "\\$&")).join("|")})(\\/.*)?$`);
+-	const ssrModuleIds = new Set([remoteEntrySSRId, virtualExposesSSRId]);
+-	const resolvedAbsToPackage = /* @__PURE__ */ new Map();
+-	let isServe = false;
+-	let viteConfig;
+-	let isNuxtProject = false;
+-	const findNuxtExposesChunk = (bundle) => {
+-		const exposeKeys = Object.keys(options.exposes);
+-		if (exposeKeys.length === 0) return;
+-		return Object.values(bundle).find((file) => {
+-			if (file.type !== "chunk" || !file.fileName.startsWith("_nuxt/") || !file.fileName.endsWith(".js")) return false;
+-			const code = file.code || "";
+-			return exposeKeys.every((key) => code.includes(JSON.stringify(key)));
+-		})?.fileName;
+-	};
+-	return [{
+-		name: "mf:ssr-remote-entry:pre",
+-		enforce: "pre",
+-		configResolved(config) {
+-			isServe = config.command === "serve";
+-			for (const pkg of ssrOnlyExternals) {
+-				const aliasEntry = (config.resolve?.alias)?.find((a) => a.find === pkg || a.find instanceof RegExp && a.find.test(pkg));
+-				if (aliasEntry?.replacement) resolvedAbsToPackage.set(aliasEntry.replacement, pkg);
+-			}
+-		},
+-		resolveId(id, importer) {
+-			if (id === remoteEntrySSRId || id.startsWith(remoteEntrySSRId)) return id;
+-			if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) return id;
+-			if (!importer || !ssrModuleIds.has(importer)) return;
+-			if (ssrOnlyExternalPattern.test(id)) return {
+-				id,
+-				external: true
+-			};
+-			const pkg = resolvedAbsToPackage.get(id);
+-			if (pkg) return {
+-				id: pkg,
+-				external: true
+-			};
+-			if (id.startsWith(".") || id.startsWith("/") || id.startsWith("file:")) return this.resolve(id, importer, { skipSelf: true }).then((resolved) => {
+-				if (resolved) ssrModuleIds.add(resolved.id);
+-				return resolved;
+-			});
+-		}
+-	}, {
+-		name: "mf:ssr-remote-entry",
+-		configResolved(config) {
+-			viteConfig = config;
+-			isNuxtProject = isNuxtProjectRoot(config.root);
+-		},
+-		configureServer(server) {
+-			const base = "/__mf_ssr__";
+-			const basePath = getBasePath(viteConfig?.base);
+-			const ssrEntryFileName = getSsrRemoteEntryFileName(options.filename);
+-			if (isNuxtProject || isNuxtClientBase(basePath)) server.middlewares.use((req, _res, next) => {
+-				if (req.url?.replace(/\?.*/, "") === `${basePath}/${ssrEntryFileName}`) req.url = `${basePath}/__mf_ssr__/${ssrEntryFileName}`;
+-				next();
+-			});
+-			const ssrEnv = server.environments?.ssr;
+-			const clientEnv = server.environments?.client;
+-			if (typeof (ssrEnv?.fetchModule ?? clientEnv?.fetchModule) === "function") server.middlewares.use("/__mf_runner__", async (req, res) => {
+-				res.setHeader("Access-Control-Allow-Origin", "*");
+-				if (req.method === "OPTIONS") {
+-					res.setHeader("Access-Control-Allow-Methods", "POST");
+-					res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+-					res.statusCode = 204;
+-					res.end();
+-					return;
+-				}
+-				if (req.method !== "POST") {
+-					res.statusCode = 405;
+-					res.end("Method not allowed");
+-					return;
+-				}
+-				try {
+-					const chunks = [];
+-					await new Promise((resolve, reject) => {
+-						req.on("data", (chunk) => chunks.push(chunk));
+-						req.on("end", resolve);
+-						req.on("error", reject);
+-					});
+-					const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+-					if (body.name === "getBuiltins") {
+-						const builtins = (clientEnv ?? ssrEnv)?.config?.resolve?.builtins ?? [];
+-						res.setHeader("Content-Type", "application/json");
+-						res.end(JSON.stringify({ result: builtins }));
+-						return;
+-					}
+-					if (body.name !== "fetchModule") {
+-						res.statusCode = 400;
+-						res.end(JSON.stringify({ error: { message: `Unsupported invoke: ${body.name}` } }));
+-						return;
+-					}
+-					const [id, importer, opts] = body.data;
+-					const fetchEnv = ssrEnv ?? clientEnv;
+-					const fetchFn = fetchEnv.fetchModule.bind(fetchEnv);
+-					let result;
+-					try {
+-						result = await fetchFn(id, importer, opts);
+-					} catch (fetchErr) {
+-						const bareId = decodeViteId(id);
+-						try {
+-							const { createRequire } = await import("module");
+-							const resolved = createRequire(new URL(`file://${server.config.root}/package.json`)).resolve(bareId.replace(/^\0/, ""));
+-							const { pathToFileURL } = await import("url");
+-							result = {
+-								externalize: pathToFileURL(resolved).href,
+-								type: "module"
+-							};
+-						} catch {
+-							throw fetchErr;
+-						}
+-					}
+-					res.setHeader("Content-Type", "application/json");
+-					res.end(JSON.stringify({ result }));
+-				} catch (e) {
+-					res.setHeader("Content-Type", "application/json");
+-					res.end(JSON.stringify({ error: { message: String(e instanceof Error ? e.message : e) } }));
+-				}
+-			});
+-			const ssrPath = `${base}/${ssrEntryFileName}`;
+-			server.middlewares.use(ssrPath, (_req, res) => {
+-				const exposesUrl = `${base}/${options.filename.replace(/\.[^.]+$/, "")}.exposes.js`;
+-				const code = generateRemoteEntrySSR(options).replace(JSON.stringify(virtualExposesSSRId), JSON.stringify(exposesUrl));
+-				res.setHeader("Content-Type", "application/javascript");
+-				res.setHeader("Access-Control-Allow-Origin", "*");
+-				res.end(code);
+-			});
+-		},
+-		resolveId(id) {
+-			if (id === remoteEntrySSRId || id.startsWith(remoteEntrySSRId)) return id;
+-			if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) return id;
+-			if (id === `/__mf_ssr__/${getSsrRemoteEntryFileName(options.filename)}`) return remoteEntrySSRId;
+-			if (id === `/__mf_ssr__/${options.filename.replace(/\.[^.]+$/, "")}.exposes.js`) return virtualExposesSSRId;
+-		},
+-		load(id) {
+-			if (id === remoteEntrySSRId || id.startsWith(remoteEntrySSRId)) return generateRemoteEntrySSR(options);
+-			if (id === virtualExposesSSRId || id.startsWith(virtualExposesSSRId)) return generateExposesSSR(options);
+-		},
+-		buildStart() {
+-			if (isServe) return;
+-			isRolldown = getIsRolldown(this);
+-			ssrOutputFilename = getSsrRemoteEntryFileName(options.filename);
+-			const environmentName = this.environment?.name;
+-			const hasSsrEnvironment = Boolean(viteConfig?.environments?.ssr);
+-			const isLegacySsrBuild = Boolean(this.environment?.config?.build?.ssr);
+-			if (hasSsrEnvironment) {
+-				if (isNuxtProject) {
+-					if (environmentName === "ssr") return;
+-				} else if (environmentName !== "ssr") return;
+-			} else if (isLegacySsrBuild) {} else if (environmentName && environmentName !== "client") return;
+-			if (Object.keys(options.exposes).length === 0) return;
+-			if (isRolldown) this.emitFile({
+-				type: "chunk",
+-				id: remoteEntrySSRId,
+-				name: "ssrRemoteEntry",
+-				fileName: ssrOutputFilename,
+-				preserveSignature: "strict"
+-			});
+-			else this.emitFile({
+-				type: "asset",
+-				fileName: ssrOutputFilename,
+-				source: generateRemoteEntrySSR(options)
+-			});
+-		},
+-		generateBundle(_options, bundle) {
+-			const exposesChunk = findNuxtExposesChunk(bundle);
+-			const ssrAsset = bundle[ssrOutputFilename];
+-			if (exposesChunk && ssrAsset?.type === "asset" && typeof ssrAsset.source === "string") ssrAsset.source = ssrAsset.source.replace(/import\("virtual:mf-exposes-ssr:[^"]+"\)/g, `import("./${exposesChunk}")`);
+-			if (!isRolldown) return;
+-			const chunk = bundle[ssrOutputFilename];
+-			if (!chunk || chunk.type !== "chunk") return;
+-		}
+-	}];
+-}
+-//#endregion
+ //#region src/plugins/pluginVarRemoteEntry.ts
+ const VarRemoteEntry = () => {
+ 	const mfOptions = getNormalizeModuleFederationOptions();
+@@ -4689,32 +3775,17 @@ var normalizeOptimizeDeps_default = {
+ //#endregion
+ //#region src/index.ts
+ const patchedManualChunks = /* @__PURE__ */ new WeakSet();
+-const PRELOAD_HELPER_CHUNK = "vite-preload-helper";
+-const PRELOAD_HELPER_TEST = /\0?vite\/preload-helper/;
+-function normalizeVinextRscPreloadHints(code) {
+-	return code.replace(/(:HL\[[^\]\n]*?,)"stylesheet"/g, "$1\"style\"").replace(/(:HL\[[^\]\n]*?,)\\"stylesheet\\"/g, "$1\\\"style\\\"");
+-}
+-function ignoreFederationGeneratedFiles(config, options) {
+-	config.server ??= {};
+-	config.server.watch ??= {};
+-	const federationIgnore = (file) => shouldIgnoreFile(file, options);
+-	const ignored = config.server.watch.ignored;
+-	if (!ignored) {
+-		config.server.watch.ignored = federationIgnore;
+-		return;
+-	}
+-	if (Array.isArray(ignored)) {
+-		ignored.push(federationIgnore);
+-		return;
+-	}
+-	config.server.watch.ignored = [ignored, federationIgnore];
+-}
++const COMMON_PREFIX_SHARED_PREBUILDS = {
++	"react/": ["react/jsx-runtime", "react/jsx-dev-runtime"],
++	"react-dom/": [
++		"react-dom/client",
++		"react-dom/server",
++		"react-dom/server.browser"
++	]
++};
+ function isSharedResolverInternalImporter(importer) {
+ 	return !!importer && (importer.includes("__loadShare__") || importer.includes("__prebuild__"));
+ }
+-function isCommonJsImporter(importer) {
+-	return !!importer && (importer.endsWith(".cjs") || importer.includes("/cjs/"));
+-}
+ function isOutputChunk(chunk) {
+ 	return chunk.type === "chunk";
+ }
+@@ -4758,35 +3829,24 @@ function isFederationHtmlPreloadDependency(dep, includeSharedRuntime = false) {
+ 	if (file.includes("__mfe_internal__") || file.includes("virtual_mf-") || file.includes("virtualExposes") || file.includes("localSharedImportMap") || file.includes("hostInit")) return true;
+ 	return includeSharedRuntime && (file.includes("preload-helper") || file.includes("rolldown-runtime") || file.startsWith("dist-"));
+ }
+-function canResolveSharedSubpath(subpath, projectRoot) {
+-	try {
+-		createRequire(new URL(`file://${projectRoot}/package.json`)).resolve(subpath);
+-		return true;
+-	} catch {
+-		return false;
+-	}
+-}
+ /**
+-* Plugin that runs FIRST to register generated virtual modules in the config hook.
+-* This prevents 504 "Outdated Optimize Dep" errors by ensuring ids are known
++* Plugin that runs FIRST to create virtual module files in the config hook.
++* This prevents 504 "Outdated Optimize Dep" errors by ensuring files exist
+ * before Vite's optimization phase.
+ */
+ function createEarlyVirtualModulesPlugin(options) {
+-	const { shared, remotes } = options;
++	const { shared, remotes, virtualModuleDir } = options;
+ 	const isLitShare = (pkg) => pkg === "lit" || pkg.startsWith("lit/");
+ 	return {
+ 		name: "vite:module-federation-early-init",
+ 		enforce: "pre",
+ 		config(config, { command: _command }) {
+-			if (_command === "serve") ignoreFederationGeneratedFiles(config, options);
+ 			const root = config.root || process.cwd();
+ 			setPackageDetectionCwd(root);
+ 			const isVinext = hasPackageDependency("vinext");
+-			setSsrRemotes(Object.entries(options.remotes).map(([key, r]) => ({
+-				name: key,
+-				entry: r.entry,
+-				type: r.type ?? "module"
+-			})));
++			initVirtualModuleInfrastructure(root, virtualModuleDir);
++			VirtualModule.setRoot(root);
++			VirtualModule.ensureVirtualPackageExists();
+ 			initVirtualModules(_command, getRemoteEntryId(options));
+ 			const isRolldown = getIsRolldown(this);
+ 			if (remotes && Object.keys(remotes).length > 0) {
+@@ -4808,10 +3868,9 @@ function createEarlyVirtualModulesPlugin(options) {
+ 						optimizeDeps.rolldownOptions.plugins ??= [];
+ 						optimizeDeps.rolldownOptions.plugins.push({
+ 							name: "module-federation:optimize-shared-resolver",
+-							resolveId(source, importer, options) {
+-								if (options?.kind?.startsWith("require")) return;
++							resolveId(source, importer) {
+ 								if (isSharedResolverInternalImporter(importer)) return;
+-								if (isCommonJsImporter(importer)) return;
++								if (source !== "react/jsx-runtime" && source !== "react/jsx-dev-runtime") return;
+ 								const key = findSharedKey(source, shared);
+ 								if (!key) return;
+ 								if (source.endsWith(".css")) return;
+@@ -4832,10 +3891,6 @@ function createEarlyVirtualModulesPlugin(options) {
+ 						optimizeDeps.esbuildOptions.plugins.push({
+ 							name: "module-federation:optimize-shared-proxy",
+ 							setup(build) {
+-								build.onResolve({ filter: createViteEncodedIdPrefixRegExp("virtual:mf:") }, (args) => ({
+-									path: args.path,
+-									external: true
+-								}));
+ 								build.onResolve({ filter: /.*/ }, (args) => {
+ 									if (!args.importer || args.namespace === "mf-shared") return;
+ 									if (isSharedResolverInternalImporter(args.importer)) return;
+@@ -4852,21 +3907,22 @@ function createEarlyVirtualModulesPlugin(options) {
+ 									const key = findSharedKey(args.path, shared);
+ 									if (!key) return;
+ 									const shareItem = shared[key];
+-									const optimizedLoadSharePath = toViteOptimizedDepVirtualId(getLoadShareModulePath(args.path, isRolldown));
++									const loadSharePath = getLoadShareModulePath(args.path, isRolldown);
+ 									writeLoadShareModule(args.path, shareItem, _command, isRolldown);
+ 									if (shareItem.shareConfig?.import !== false) writePreBuildLibPath(args.path, shareItem);
+ 									addUsedShares(args.path);
+ 									return {
+ 										loader: "js",
+ 										resolveDir: root,
+-										contents: `import * as __mfShared from ${JSON.stringify(optimizedLoadSharePath)};
+-export * from ${JSON.stringify(optimizedLoadSharePath)};
++										contents: `import * as __mfShared from ${JSON.stringify(loadSharePath)};
++export * from ${JSON.stringify(loadSharePath)};
+ export default __mfShared.default ?? __mfShared;`
+ 									};
+ 								});
+ 							}
+ 						});
+ 					}
++					config.optimizeDeps.include.push(virtualRuntimeInitStatus.getImportId());
+ 				}
+ 				for (const key of Object.keys(shared)) {
+ 					const shareItem = shared[key];
+@@ -4874,11 +3930,10 @@ export default __mfShared.default ?? __mfShared;`
+ 						if (_command === "serve" && shareItem.shareConfig?.import !== false) {
+ 							const optimizeDeps = config.optimizeDeps ??= {};
+ 							optimizeDeps.include ??= [];
+-							optimizeDeps.exclude ??= [];
+-							for (const subpath of getCommonSharedSubpaths(key)) {
++							for (const subpath of COMMON_PREFIX_SHARED_PREBUILDS[key] || []) {
+ 								writePreBuildLibPath(subpath, shareItem);
+-								if (canResolveSharedSubpath(subpath, root)) optimizeDeps.include.push(subpath);
+-								else optimizeDeps.exclude.push(subpath);
++								optimizeDeps.include.push(subpath);
++								optimizeDeps.include.push(getPreBuildLibImportId(subpath));
+ 							}
+ 						}
+ 						continue;
+@@ -4895,61 +3950,17 @@ export default __mfShared.default ?? __mfShared;`
+ 						const optimizeDeps = config.optimizeDeps ??= {};
+ 						optimizeDeps.include ??= [];
+ 						optimizeDeps.exclude ??= [];
+-						if (isLitShare(key)) optimizeDeps.exclude.push(key);
+-						else optimizeDeps.include.push(key);
+-						for (const subpath of getCommonSharedSubpaths(key)) {
+-							getLoadShareModulePath(subpath, isRolldown);
+-							writeLoadShareModule(subpath, shareItem, _command, isRolldown);
+-							writePreBuildLibPath(subpath, shareItem);
+-							addUsedShares(subpath);
+-							if (canResolveSharedSubpath(subpath, root)) optimizeDeps.include.push(subpath);
+-							else optimizeDeps.exclude.push(subpath);
+-						}
++						const shouldBypassOptimizeDep = isLitShare(key);
++						if (isRolldown || shouldBypassOptimizeDep) optimizeDeps.exclude.push(key);
++						if (!isRolldown && !shouldBypassOptimizeDep) optimizeDeps.include.push(getLoadShareImportId(key, isRolldown));
++						optimizeDeps.include.push(getPreBuildLibImportId(key));
+ 					}
+ 				}
+ 				writeLocalSharedImportMap();
+ 			}
+-		},
+-		configResolved(config) {
+-			if (parseInt(version, 10) < 8) return;
+-			if (!(Object.keys(options.exposes).length > 0 || Object.keys(options.remotes).length > 0)) return;
+-			if (options.runtimePlugins.some((p) => {
+-				return (typeof p === "string" ? p : p[0]) === "@module-federation/vite/ssrEntryLoader";
+-			})) return;
+-			const pluginRequire = createRequire(import.meta.url);
+-			const projectRequire = createRequire(new URL(`file://${config.root}/package.json`));
+-			const sharedKeys = Object.keys(options.shared ?? {});
+-			const commonSharedPkgs = [
+-				"react",
+-				"react-dom",
+-				"react/jsx-runtime",
+-				"react/jsx-dev-runtime",
+-				"react/compiler-runtime",
+-				"@module-federation/runtime",
+-				"@module-federation/runtime-core",
+-				"@module-federation/sdk"
+-			];
+-			const resolvedShared = {};
+-			for (const pkg of [...commonSharedPkgs, ...sharedKeys]) try {
+-				resolvedShared[pkg] = projectRequire.resolve(pkg);
+-			} catch {
+-				try {
+-					resolvedShared[pkg] = pluginRequire.resolve(pkg);
+-				} catch {}
+-			}
+-			const ssrEntryLoaderSpecifier = "@module-federation/vite/ssrEntryLoader";
+-			try {
+-				pluginRequire.resolve(ssrEntryLoaderSpecifier);
+-				options.runtimePlugins.push([ssrEntryLoaderSpecifier, { resolvedShared }]);
+-			} catch {}
+ 		}
+ 	};
+ }
+-const SSR_ONLY_PLUGINS = new Set(["@module-federation/vite/ssrEntryLoader"]);
+-function loadPluginDts(options) {
+-	if (options.dts === false) return [];
+-	return [import("./pluginDts-DDx4TPN8.mjs").then(({ default: pluginDts }) => pluginDts(options))];
+-}
+ function federation(mfUserOptions) {
+ 	if (isTestEnv()) return [];
+ 	const options = normalizeModuleFederationOptions(mfUserOptions);
+@@ -4961,33 +3972,6 @@ function federation(mfUserOptions) {
+ 	let command;
+ 	let desiredRolldownOutput;
+ 	return [
+-		{
+-			name: "vite:module-federation-virtual-modules",
+-			enforce: "pre",
+-			resolveId(id) {
+-				let virtualModule = VirtualModule.findById(id);
+-				if (!virtualModule) {
+-					materializeCachedLoadShareModule({
+-						id,
+-						shared: options.shared,
+-						command,
+-						isRolldown: getIsRolldown(this),
+-						findSharedKey,
+-						addUsedShares,
+-						writeLocalSharedImportMap
+-					});
+-					virtualModule = VirtualModule.findById(id);
+-				}
+-				if (!virtualModule) return;
+-				return virtualModule.getResolvedId();
+-			},
+-			load(id) {
+-				const virtualModule = VirtualModule.findById(id);
+-				if (!virtualModule) return;
+-				if (command === "build" && (id.includes("__loadShare__") || id.includes("__loadRemote__"))) return;
+-				return virtualModule.code;
+-			}
+-		},
+ 		createEarlyVirtualModulesPlugin(options),
+ 		...isVinext ? [{
+ 			name: "module-federation-vinext-react-server-build-alias",
+@@ -4996,14 +3980,13 @@ function federation(mfUserOptions) {
+ 			resolveId(id) {
+ 				const reactServerEntryMap = {
+ 					"react/jsx-runtime": "react/cjs/react-jsx-runtime.production.js",
+-					"react/jsx-dev-runtime": "react/cjs/react-jsx-dev-runtime.production.js",
+-					"react/compiler-runtime": "react/cjs/react-compiler-runtime.production.js"
++					"react/jsx-dev-runtime": "react/cjs/react-jsx-dev-runtime.production.js"
+ 				};
+ 				if (!(id in reactServerEntryMap)) return;
+ 				const environmentName = this.environment?.name;
+ 				if (!environmentName || environmentName === "client") return;
+ 				const target = reactServerEntryMap[id];
+-				const reactPackageJson = createRequire(new URL(`file://${process.cwd()}/package.json`)).resolve("react/package.json");
++				const reactPackageJson = createRequire$1(new URL(`file://${process.cwd()}/package.json`)).resolve("react/package.json");
+ 				return path.join(path.dirname(reactPackageJson), target.replace(/^react\//, ""));
+ 			}
+ 		}] : [],
+@@ -5013,27 +3996,17 @@ function federation(mfUserOptions) {
+ 			config(_config, env) {
+ 				command = env.command;
+ 			},
+-			configResolved() {
+-				initVirtualModules(command, remoteEntryId, parseInt(version, 10) >= 8);
++			configResolved(config) {
++				VirtualModule.setRoot(config.root);
++				VirtualModule.ensureVirtualPackageExists();
++				initVirtualModules(command, remoteEntryId);
+ 			}
+ 		},
+ 		aliasToArrayPlugin_default,
+ 		checkAliasConflicts({ shared }),
+ 		normalizeOptimizeDeps_default,
+-		...loadPluginDts(options),
++		...pluginDts(options),
+ 		pluginDevRemoteHmr(options),
+-		{
+-			name: "mf:normalize-entry-chunks",
+-			enforce: "pre",
+-			apply: "build",
+-			generateBundle(_options, bundle) {
+-				for (const chunk of Object.values(bundle)) {
+-					if (typeof chunk !== "object" || chunk === null || chunk.type !== "chunk" || !chunk.isEntry) continue;
+-					const facadeId = chunk.facadeModuleId ?? "";
+-					if (facadeId.includes("__mf__virtual") || facadeId.startsWith("virtual:mf-") || facadeId.startsWith("virtual:mf:") || facadeId.startsWith("\0virtual:mf-") || facadeId.startsWith("\0virtual:mf:")) chunk.isEntry = false;
+-				}
+-			}
+-		},
+ 		...addEntry({
+ 			entryName: "remoteEntry",
+ 			entryPath: remoteEntryId,
+@@ -5043,8 +4016,7 @@ function federation(mfUserOptions) {
+ 			entryName: "hostInit",
+ 			entryPath: () => getHostAutoInitPath(),
+ 			inject: hostInitInjectLocation,
+-			forceClientInjected: Object.keys(options.exposes).length > 0,
+-			skipTransformFor: Object.values(options.exposes).map((expose) => expose.import)
++			forceClientInjected: Object.keys(options.exposes).length > 0
+ 		}),
+ 		...addEntry({
+ 			entryName: "virtualExposes",
+@@ -5081,9 +4053,7 @@ function federation(mfUserOptions) {
+ 							const resolvedDeps = existingResolveDependencies ? existingResolveDependencies(filename, deps, context) : deps;
+ 							const hostFile = path.basename(context.hostId);
+ 							if (context.hostType === "js" && (hostFile === options.filename || hostFile.includes("hostInit") || hostFile.includes("virtualExposes") || hostFile.includes("localSharedImportMap"))) return [];
+-							const hasFederationHtmlDeps = context.hostType === "html" && resolvedDeps.some((dep) => isFederationHtmlPreloadDependency(dep));
+-							const hasFederationJsDeps = context.hostType === "js" && resolvedDeps.some((dep) => isFederationHtmlPreloadDependency(dep));
+-							return hasFederationHtmlDeps || hasFederationJsDeps ? resolvedDeps.filter((dep) => !isFederationHtmlPreloadDependency(dep, true)) : resolvedDeps;
++							return context.hostType === "html" && resolvedDeps.some((dep) => isFederationHtmlPreloadDependency(dep)) ? resolvedDeps.filter((dep) => !isFederationHtmlPreloadDependency(dep, true)) : resolvedDeps;
+ 						}
+ 					};
+ 				}
+@@ -5099,8 +4069,6 @@ function federation(mfUserOptions) {
+ 					}
+ 					if (!output?.codeSplitting || typeof output.codeSplitting !== "object") return;
+ 					if (!("groups" in output.codeSplitting)) return;
+-					const groups = output.codeSplitting.groups;
+-					if (Array.isArray(groups) && groups.some((group) => typeof group?.name === "function" && patchedManualChunks.has(group.name))) return;
+ 					delete output.codeSplitting.groups;
+ 					if (Object.keys(output.codeSplitting).length === 0) delete output.codeSplitting;
+ 					if (warnedAboutCodeSplittingGroups) return;
+@@ -5108,45 +4076,27 @@ function federation(mfUserOptions) {
+ 					mfWarn("Ignoring `output.codeSplitting.groups` because it conflicts with module federation. Grouping shared dependency init wrappers with their dependent modules can break runtime init order and cause standalone remotes to fail before mount.");
+ 				};
+ 				let warnedAboutManualChunks = false;
+-				const applyManualChunks = (output, useCodeSplitting) => {
++				const applyManualChunks = (output) => {
+ 					ensureCodeSplitting(output);
+ 					const isPatchedByPlugin = typeof output.manualChunks === "function" && patchedManualChunks.has(output.manualChunks);
+ 					if (output.manualChunks && !isPatchedByPlugin && !warnedAboutManualChunks) {
+ 						warnedAboutManualChunks = true;
+ 						mfWarn("Ignoring `output.manualChunks` because it conflicts with module federation. Module federation transforms shared dependency imports with async init wrappers, and grouping these transformed modules into a single chunk creates circular async dependencies that cause the application to silently hang.");
+ 					}
+-					const mfChunkName = function(id) {
++					const mfManualChunks = function(id) {
+ 						if (id.includes(runtimeInitId)) return "runtimeInit";
+ 						if (id.includes("__loadShare__")) {
+ 							const match = id.match(/([^/\\]+__loadShare__[^/\\]+)/);
+ 							return match ? match[1] : "loadShare";
+ 						}
+-						return null;
+-					};
+-					patchedManualChunks.add(mfChunkName);
+-					if (!useCodeSplitting) {
+-						const mfManualChunks = function(id) {
+-							return mfChunkName(id) ?? void 0;
+-						};
+-						patchedManualChunks.add(mfManualChunks);
+-						output.manualChunks = mfManualChunks;
+-						return;
+-					}
+-					const groups = [{
+-						name: PRELOAD_HELPER_CHUNK,
+-						test: PRELOAD_HELPER_TEST,
+-						priority: 100
+-					}, { name: mfChunkName }];
+-					output.codeSplitting = {
+-						...output.codeSplitting || {},
+-						groups
+ 					};
+-					delete output.manualChunks;
++					patchedManualChunks.add(mfManualChunks);
++					output.manualChunks = mfManualChunks;
+ 				};
+ 				config.build.rollupOptions = config.build.rollupOptions || {};
+ 				const rollupOutput = config.build.rollupOptions.output;
+-				if (Array.isArray(rollupOutput)) rollupOutput.forEach((output) => applyManualChunks(output, false));
+-				else applyManualChunks(config.build.rollupOptions.output ||= {}, false);
++				if (Array.isArray(rollupOutput)) rollupOutput.forEach((output) => applyManualChunks(output));
++				else applyManualChunks(config.build.rollupOptions.output ||= {});
+ 				const buildWithRolldown = config.build;
+ 				buildWithRolldown.rolldownOptions = buildWithRolldown.rolldownOptions || {};
+ 				const rolldownOutput = buildWithRolldown.rolldownOptions.output;
+@@ -5156,10 +4106,10 @@ function federation(mfUserOptions) {
+ 					assetFileNames: output.assetFileNames
+ 				});
+ 				if (Array.isArray(rolldownOutput)) {
+-					rolldownOutput.forEach((output) => applyManualChunks(output, true));
++					rolldownOutput.forEach((output) => applyManualChunks(output));
+ 					desiredRolldownOutput = rolldownOutput.map((output) => snapshotRolldownOutput(output));
+ 				} else {
+-					applyManualChunks(buildWithRolldown.rolldownOptions.output ||= {}, true);
++					applyManualChunks(buildWithRolldown.rolldownOptions.output ||= {});
+ 					desiredRolldownOutput = [snapshotRolldownOutput(buildWithRolldown.rolldownOptions.output)];
+ 				}
+ 			},
+@@ -5189,8 +4139,9 @@ function federation(mfUserOptions) {
+ 				}
+ 			},
+ 			load(id) {
++				if (id.startsWith("\0")) return;
+ 				if (id.includes("__loadShare__") || id.includes("__loadRemote__")) {
+-					let code = VirtualModule.findById(id)?.code ?? readFileSync(id, "utf-8");
++					let code = readFileSync(id, "utf-8");
+ 					code = code.replace(/import\s+["'][^"']*__prebuild__[^"']*["']\s*;?/g, "");
+ 					code = code.replace(/export\s+\*\s+from\s+["'][^"']*__prebuild__[^"']*["']\s*;?/g, "");
+ 					/**
+@@ -5209,10 +4160,7 @@ function federation(mfUserOptions) {
+ 					*
+ 					* @see https://rollupjs.org/plugin-development/#synthetic-named-exports
+ 					*/
+-					if (!/\bexport\s+const\s+__moduleExports\b/.test(code) && !/\bexport\s*\{[^}]*__moduleExports/.test(code)) {
+-						const nextCode = code.replace("export default exportModule", "export const __moduleExports = exportModule;\nexport default exportModule.__esModule ? exportModule.default : exportModule");
+-						code = nextCode === code ? `${code}\nexport const __moduleExports = exportModule;\n` : nextCode;
+-					}
++					if (!code.includes("__moduleExports")) code = code.replace("export default exportModule", "export const __moduleExports = exportModule;\nexport default exportModule.__esModule ? exportModule.default : exportModule");
+ 					if (getIsRolldown(this)) return { code };
+ 					return {
+ 						code,
+@@ -5226,17 +4174,87 @@ function federation(mfUserOptions) {
+ 					if (!isFederationControlChunk(fileName, filename)) continue;
+ 					chunk.code = sanitizeFederationControlChunk(chunk.code, fileName, filename);
+ 				}
+-				const proxyChunks = collectLoadShareProxyChunks(bundle, LOAD_SHARE_TAG);
+-				if (proxyChunks.size > 0) {
+-					const systemProxyInfo = collectSystemProxyInfos(proxyChunks, LOAD_SHARE_TAG);
+-					for (const [fileName, chunk] of Object.entries(bundle)) {
+-						if (!isOutputChunk(chunk)) continue;
+-						if (proxyChunks.has(fileName)) continue;
+-						let code = chunk.code;
+-						if (!fileName.includes("__loadShare__")) code = rewriteEsmProxyConsumers(code, proxyChunks);
+-						code = rewriteSystemProxyConsumers(code, systemProxyInfo);
+-						if (code !== chunk.code) chunk.code = code;
++				const proxyChunks = /* @__PURE__ */ new Map();
++				for (const [fileName, chunk] of Object.entries(bundle)) {
++					if (!isOutputChunk(chunk)) continue;
++					if (fileName.includes("__loadShare__") && fileName.includes("commonjs-proxy")) proxyChunks.set(fileName, {
++						code: chunk.code,
++						fileName
++					});
++				}
++				if (proxyChunks.size > 0) for (const [fileName, chunk] of Object.entries(bundle)) {
++					if (!isOutputChunk(chunk)) continue;
++					if (fileName.includes("__loadShare__")) continue;
++					let code = chunk.code;
++					let modified = false;
++					const claimedLocals = /* @__PURE__ */ new Set();
++					for (const [proxyFileName, proxyInfo] of Array.from(proxyChunks.entries())) {
++						const proxyBaseName = proxyFileName.replace(/^.*\//, "").replace(/\.js$/, "").replace(/-[A-Za-z0-9_-]+$/, "");
++						const importMatch = new RegExp(`import\\s*\\{([^}]+)\\}\\s*from\\s*["']([^"']*${proxyBaseName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[^"']*)["']\\s*;?`).exec(code);
++						if (!importMatch) continue;
++						const fullImport = importMatch[0];
++						const bindings = importMatch[1].split(",").map((s) => {
++							const parts = s.trim().split(/\s+as\s+/);
++							return {
++								imported: parts[0].trim(),
++								local: (parts[1] || parts[0]).trim()
++							};
++						});
++						const proxyCode = proxyInfo.code;
++						const exportMapMatch = proxyCode.match(/export\s*\{([^}]+)\}/);
++						if (!exportMapMatch) continue;
++						const exportMap = {};
++						for (const entry of exportMapMatch[1].split(",")) {
++							const parts = entry.trim().split(/\s+as\s+/);
++							if (parts.length === 2) exportMap[parts[1].trim()] = parts[0].trim();
++						}
++						const inlineable = [];
++						const nonInlineable = [];
++						const pendingLocals = new Set(bindings.map((binding) => binding.local));
++						for (const b of bindings) {
++							pendingLocals.delete(b.local);
++							const proxyLocal = exportMap[b.imported];
++							if (!proxyLocal) {
++								claimedLocals.add(b.local);
++								nonInlineable.push(b);
++								continue;
++							}
++							const funcRe = new RegExp(`function\\s+${proxyLocal}\\s*\\([^)]*\\)\\s*\\{`);
++							if (funcRe.test(proxyCode)) {
++								const funcStart = proxyCode.search(funcRe);
++								let depth = 0;
++								let funcEnd = funcStart;
++								for (let i = proxyCode.indexOf("{", funcStart); i < proxyCode.length; i++) if (proxyCode[i] === "{") depth++;
++								else if (proxyCode[i] === "}") {
++									depth--;
++									if (depth === 0) {
++										funcEnd = i + 1;
++										break;
++									}
++								}
++								const renamedFunc = proxyCode.slice(funcStart, funcEnd).replace(new RegExp(`function\\s+${proxyLocal}\\s*\\(`), `function ${b.local}(`);
++								inlineable.push({
++									local: b.local,
++									funcBody: renamedFunc
++								});
++								claimedLocals.add(b.local);
++							} else {
++								const unavailableLocals = new Set(claimedLocals);
++								pendingLocals.forEach((local) => unavailableLocals.add(local));
++								const resolvedBinding = resolveProxyAlias(b, proxyLocal, code, fullImport, unavailableLocals);
++								claimedLocals.add(resolvedBinding.local);
++								nonInlineable.push(resolvedBinding);
++							}
++						}
++						const hasRenamedAlias = nonInlineable.some((b) => bindings.find((ob) => ob.imported === b.imported)?.local !== b.local);
++						if (inlineable.length === 0 && !hasRenamedAlias) continue;
++						let replacement = "";
++						if (nonInlineable.length > 0) replacement = `import{${nonInlineable.map((b) => b.imported === b.local ? b.imported : `${b.imported} as ${b.local}`).join(",")}}from"${importMatch[2]}";`;
++						replacement += inlineable.map((f) => f.funcBody).join("");
++						code = code.replace(fullImport, () => replacement);
++						modified = true;
+ 					}
++					if (modified) chunk.code = code;
+ 				}
+ 			}
+ 		},
+@@ -5274,20 +4292,24 @@ function federation(mfUserOptions) {
+ 					find: "@module-federation/runtime",
+ 					replacement: implementation
+ 				});
+-				config.build ||= {};
+-				config.build.commonjsOptions ||= {};
+-				config.build.commonjsOptions.strictRequires ??= "auto";
++				config.build = defu(config.build || {}, { commonjsOptions: { strictRequires: "auto" } });
++				const virtualDir = options.virtualModuleDir;
+ 				config.optimizeDeps ||= {};
+ 				config.optimizeDeps.include ||= [];
+ 				config.optimizeDeps.include.push("@module-federation/runtime");
++				config.optimizeDeps.include.push(virtualDir);
++				config.ssr ||= {};
++				config.ssr.noExternal ||= [];
++				if (Array.isArray(config.ssr.noExternal)) config.ssr.noExternal.push(virtualDir);
+ 				options.runtimePlugins.forEach((p) => {
+ 					const pluginPath = typeof p === "string" ? p : p[0];
+-					if (SSR_ONLY_PLUGINS.has(pluginPath)) return;
+ 					if (pluginPath && !pluginPath.startsWith(".") && !pluginPath.startsWith("/") && !pluginPath.startsWith("\0") && !pluginPath.startsWith("virtual:")) config.optimizeDeps.include.push(pluginPath);
+ 				});
+-				if (isRolldown) {
+-					config.build ??= {};
+-					config.build.target ??= "esnext";
++				if (isRolldown) config.build = defu(config.build || {}, { target: "esnext" });
++				else {
++					config.optimizeDeps.needsInterop ||= [];
++					config.optimizeDeps.needsInterop.push(virtualDir);
++					config.optimizeDeps.needsInterop.push(getLocalSharedImportMapPath());
+ 				}
+ 				const isAstro = hasPackageDependency("astro");
+ 				const resolvedTarget = options.target ?? (config.build?.ssr ? "node" : "web");
+@@ -5298,31 +4320,11 @@ function federation(mfUserOptions) {
+ 			}
+ 		},
+ 		...Manifest(),
+-		...pluginSSRRemoteEntry(options),
+ 		...VarRemoteEntry(),
+ 		{
+ 			name: "module-federation-vinext-fix-rsc-preload-as",
+ 			enforce: "post",
+-			configureServer(server) {
+-				if (!hasPackageDependency("vinext")) return;
+-				server.middlewares.use((req, res, next) => {
+-					if (!req.headers.accept?.includes("text/html")) {
+-						next();
+-						return;
+-					}
+-					const chunks = [];
+-					const end = res.end.bind(res);
+-					res.write = (chunk) => {
+-						if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+-						return true;
+-					};
+-					res.end = (chunk, ...args) => {
+-						if (chunk) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+-						return end(normalizeVinextRscPreloadHints(Buffer.concat(chunks).toString()), ...args);
+-					};
+-					next();
+-				});
+-			},
++			apply: "build",
+ 			generateBundle(_, bundle, _isWrite) {
+ 				if (!hasPackageDependency("vinext")) return;
+ 				for (const chunk of Object.values(bundle)) {
+@@ -5372,8 +4374,5 @@ function federation(mfUserOptions) {
+ 		})()
+ 	];
+ }
+-function createModuleFederationConfig(options) {
+-	return options;
+-}
+ //#endregion
+-export { createModuleFederationConfig, federation };
++export { federation };
+diff --git a/lib/packageUtils-Bbc6r6__.mjs b/lib/packageUtils-Bbc6r6__.mjs
+deleted file mode 100644
+index 9ea556a367c94093d7506e005ea97a13c1dfdadf..0000000000000000000000000000000000000000
+diff --git a/lib/packageUtils-se-UDhCa.cjs b/lib/packageUtils-se-UDhCa.cjs
+deleted file mode 100644
+index 118300a055259d761b425d37f1fe31a58117bee5..0000000000000000000000000000000000000000
+diff --git a/lib/pluginDts-7EoFboCu.cjs b/lib/pluginDts-7EoFboCu.cjs
+deleted file mode 100644
+index 9b0306d61df5eb0c58fc470219e5574ec08332b5..0000000000000000000000000000000000000000
+diff --git a/lib/pluginDts-DDx4TPN8.mjs b/lib/pluginDts-DDx4TPN8.mjs
+deleted file mode 100644
+index 700b15daee43e8cd535b6c164f0ecefabd479535..0000000000000000000000000000000000000000
+diff --git a/lib/utils/ssrEntryLoader.cjs b/lib/utils/ssrEntryLoader.cjs
+deleted file mode 100644
+index 82c9d088531047b4855caa2bdf74dab0f17a60e7..0000000000000000000000000000000000000000
+diff --git a/lib/utils/ssrEntryLoader.d.cts b/lib/utils/ssrEntryLoader.d.cts
+deleted file mode 100644
+index 1774ba4b60efbe47e6e338e6269e5e27ee9f6b83..0000000000000000000000000000000000000000
+diff --git a/lib/utils/ssrEntryLoader.d.mts b/lib/utils/ssrEntryLoader.d.mts
+deleted file mode 100644
+index 1933118d99873da7abdeb092e3833b02bad0de7b..0000000000000000000000000000000000000000
+diff --git a/lib/utils/ssrEntryLoader.mjs b/lib/utils/ssrEntryLoader.mjs
+deleted file mode 100644
+index 4545ad67d2aacb7d06c7efb47074712e2e7ce93a..0000000000000000000000000000000000000000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ overrides:
   '@module-federation/rspack>typescript': ^6.0.3
 
 patchedDependencies:
+  '@module-federation/vite':
+    hash: 84c32eacc85cfe6cc10cffd8468e1f1610c846fd34e270147f5ffb61b36924d1
+    path: patches/@module-federation__vite.patch
   '@uppy/core':
     hash: 8a9c2320245d028b3d5a7d9fabf33e5d501d5c59afc1e03f7576dc9c1cb6a3d8
     path: patches/@uppy__core.patch
@@ -305,7 +308,7 @@ importers:
         version: 0.4.0
       '@module-federation/vite':
         specifier: 'catalog:'
-        version: 1.16.4(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)
+        version: 1.16.4(patch_hash=84c32eacc85cfe6cc10cffd8468e1f1610c846fd34e270147f5ffb61b36924d1)(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -1415,7 +1418,7 @@ importers:
     devDependencies:
       '@module-federation/vite':
         specifier: 'catalog:'
-        version: 1.16.4(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)
+        version: 1.16.4(patch_hash=84c32eacc85cfe6cc10cffd8468e1f1610c846fd34e270147f5ffb61b36924d1)(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)
       vite:
         specifier: catalog:framework
         version: 8.0.16(@types/node@25.9.1)(@vitejs/devtools@0.1.22)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.48.0)(yaml@2.9.0)
@@ -18453,7 +18456,7 @@ snapshots:
       find-pkg: 2.0.0
       resolve: 1.22.8
 
-  '@module-federation/vite@1.16.4(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)':
+  '@module-federation/vite@1.16.4(patch_hash=84c32eacc85cfe6cc10cffd8468e1f1610c846fd34e270147f5ffb61b36924d1)(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@6.0.3)
       '@module-federation/runtime': 2.5.1(node-fetch@3.3.2)


### PR DESCRIPTION
- Bootstrap file lands in the entryFileNames directory (e.g. static/js/)
  instead of being stuck at build root
- Bootstrap imports are rebased relative to its new location, eliminating
  doubled path errors like static/js/static/js/

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR patches the `@module-federation/vite` package to fix a path duplication bug when the bootstrap file is emitted to a subdirectory via the `entryFileNames` configuration.

**Problem:** When `entryFileNames` was configured to output files into a subdirectory (e.g., `static/js/`), the Module Federation bootstrap file would be written with a doubled directory path (e.g., `static/js/static/js/`), because the plugin was not properly respecting the `entryFileNames` directory setting.

**Fix:** Adds a pnpm patch for `@module-federation/vite` that ensures the bootstrap file output correctly respects the `entryFileNames` directory, eliminating the doubled path issue.
<!-- kody-pr-summary:end -->