### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/mf-bootstrap-entryFileNames-patch.md
+++ b/.changeset/mf-bootstrap-entryFileNames-patch.md
@@ -1,14 +1,14 @@
 ---
-"@lumeweb/portal-app-shell": patch
-"@lumeweb/portal-plugin-abuse": patch
-"@lumeweb/portal-plugin-abuse-report": patch
-"@lumeweb/portal-plugin-admin": patch
-"@lumeweb/portal-plugin-billing": patch
-"@lumeweb/portal-plugin-core": patch
-"@lumeweb/portal-plugin-dashboard": patch
-"@lumeweb/portal-plugin-ipfs": patch
-"@lumeweb/portal-plugin-lbry": patch
-"@lumeweb/portal-plugin-quota": patch
+@lumeweb/portal-app-shell: patch
+@lumeweb/portal-plugin-abuse: patch
+@lumeweb/portal-plugin-abuse-report: patch
+@lumeweb/portal-plugin-admin: patch
+@lumeweb/portal-plugin-billing: patch
+@lumeweb/portal-plugin-core: patch
+@lumeweb/portal-plugin-dashboard: patch
+@lumeweb/portal-plugin-ipfs: patch
+@lumeweb/portal-plugin-lbry: patch
+@lumeweb/portal-plugin-quota: patch
 ---
 
 Patch @module-federation/vite to respect entryFileNames directory for bootstrap file output. Fixes doubled path bug (static/js/static/js/) when bootstrap is emitted to a subdirectory.


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fix changeset syntax by removing quotes around package names in the YAML frontmatter

This PR corrects the changeset configuration file for the module-federation/vite bootstrap entryFileNames patch. The package names were incorrectly quoted in the YAML frontmatter, which would cause the changeset tool to fail to properly recognize and apply the patch version bumps to the affected packages (`@lumeweb/portal-app-shell` and related portal plugins). The underlying patch fixes a doubled path bug (e.g., `static/js/static/js/`) that occurs when the bootstrap file is emitted to a subdirectory.
<!-- kody-pr-summary:end -->