### PR TITLE
fix(portal-framework-ui): restore plugin configs merge lost in Refine boundary refactor

### DIFF
--- a/.changeset/quick-foxes-drive.md
+++ b/.changeset/quick-foxes-drive.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-framework-ui: patch
+@lumeweb/portal-ap-shell: patch
+---
+
+## Fixes
+
+- restore plugin configs merge lost in Refine boundary refactor

--- a/libs/portal-framework-ui/src/components/app/AppComponent.tsx
+++ b/libs/portal-framework-ui/src/components/app/AppComponent.tsx
@@ -177,8 +177,10 @@ function AppContent({
     addMenuItems,
   ]);
 
+  const combinedPluginConfig = Object.assign({}, ...pluginConfigs);
+
   const options = {
-    ...pluginConfigs,
+    ...combinedPluginConfig,
     options: getDefaultRefineOptions(),
     routerProvider,
   } satisfies Partial<RefineProps>;


### PR DESCRIPTION
The ddab9efc refactor that moved useIdentifyUser inside the Refine
boundary accidentally dropped Object.assign({}, ...pluginConfigs) in
favor of ...pluginConfigs spread. Since pluginConfigs is an array,
spreading it into an object literal creates numeric keys instead of
merging the data providers, resources, and other Refine props.

This restores the original Object.assign merge that was present before
the refactor, fixing the "account Data provider not found" runtime
error caused by the dataProvider never being registered in Refine.

---

<!-- kody-pr-summary:start -->
Fix plugin configurations merge regression in Refine boundary refactor

This PR fixes a regression where plugin configurations were not being properly merged after the Refine boundary refactor. Previously, `pluginConfigs` (an array of config objects) was spread directly into the options object, which doesn't correctly merge the individual config objects. The fix introduces `Object.assign({}, ...pluginConfigs)` to properly combine all plugin config objects into a single object before spreading into the options.
<!-- kody-pr-summary:end -->