### PR TITLE
fix(portal-framework-core): coerce VITE_PORTAL_DOMAIN_IS_ROOT to boolean for zod schema

### DIFF
--- a/libs/portal-framework-core/src/vite/__tests__/localhost-plugin.spec.ts
+++ b/libs/portal-framework-core/src/vite/__tests__/localhost-plugin.spec.ts
@@ -4,8 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { localhostAccessPlugin } from "../localhost-plugin";
 
-/** Helper to call transformIndexHtml with correct typing.
- *  Vite's IndexHtmlTransform is a union type; our plugin returns HtmlTagDescriptor[] directly. */
 function callTransformIndexHtml(plugin: ReturnType<typeof localhostAccessPlugin>) {
   return (plugin.transformIndexHtml as () => HtmlTagDescriptor[])();
 }
@@ -44,7 +42,7 @@ describe("localhostAccessPlugin", () => {
     });
   });
 
-  it("returns VITE_PORTAL_DOMAIN_IS_ROOT script when env var is set", () => {
+  it("VITE_PORTAL_DOMAIN_IS_ROOT='true' injects boolean true", () => {
     vi.stubEnv("VITE_PORTAL_DOMAIN_IS_ROOT", "true");
     const plugin = localhostAccessPlugin();
     const result = callTransformIndexHtml(plugin);
@@ -52,10 +50,35 @@ describe("localhostAccessPlugin", () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       attrs: { type: "text/javascript" },
-      children: 'window.VITE_PORTAL_DOMAIN_IS_ROOT = "true";',
+      children: "window.VITE_PORTAL_DOMAIN_IS_ROOT = true;",
       injectTo: "head-prepend",
       tag: "script",
     });
+  });
+
+  it("VITE_PORTAL_DOMAIN_IS_ROOT='false' injects boolean false", () => {
+    vi.stubEnv("VITE_PORTAL_DOMAIN_IS_ROOT", "false");
+    const plugin = localhostAccessPlugin();
+    const result = callTransformIndexHtml(plugin);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      attrs: { type: "text/javascript" },
+      children: "window.VITE_PORTAL_DOMAIN_IS_ROOT = false;",
+      injectTo: "head-prepend",
+      tag: "script",
+    });
+  });
+
+  it("VITE_PORTAL_DOMAIN_IS_ROOT with arbitrary value coerces to boolean false", () => {
+    vi.stubEnv("VITE_PORTAL_DOMAIN_IS_ROOT", "1");
+    const plugin = localhostAccessPlugin();
+    const result = callTransformIndexHtml(plugin);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].children).toBe(
+      "window.VITE_PORTAL_DOMAIN_IS_ROOT = false;",
+    );
   });
 
   it("returns both scripts when both env vars are set", () => {
@@ -87,27 +110,5 @@ describe("localhostAccessPlugin", () => {
     for (const script of result) {
       expect(script.tag).toBe("script");
     }
-  });
-
-  it("VITE_PORTAL_DOMAIN_IS_ROOT value is JSON-stringified into script content", () => {
-    vi.stubEnv("VITE_PORTAL_DOMAIN_IS_ROOT", "my-custom-value");
-    const plugin = localhostAccessPlugin();
-    const result = callTransformIndexHtml(plugin);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].children).toBe(
-      'window.VITE_PORTAL_DOMAIN_IS_ROOT = "my-custom-value";',
-    );
-  });
-
-  it("VITE_PORTAL_DOMAIN_IS_ROOT produces valid JS for arbitrary string values", () => {
-    vi.stubEnv("VITE_PORTAL_DOMAIN_IS_ROOT", "it's a \"test\"");
-    const plugin = localhostAccessPlugin();
-    const result = callTransformIndexHtml(plugin);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].children).toBe(
-      'window.VITE_PORTAL_DOMAIN_IS_ROOT = "it\'s a \\"test\\"";',
-    );
   });
 });

--- a/libs/portal-framework-core/src/vite/localhost-plugin.ts
+++ b/libs/portal-framework-core/src/vite/localhost-plugin.ts
@@ -16,9 +16,10 @@ export function localhostAccessPlugin(): Plugin {
       }
 
       if (process.env.VITE_PORTAL_DOMAIN_IS_ROOT) {
+        const isRoot = process.env.VITE_PORTAL_DOMAIN_IS_ROOT === "true";
         scripts.push({
           attrs: { type: "text/javascript" },
-          children: `window.VITE_PORTAL_DOMAIN_IS_ROOT = ${JSON.stringify(process.env.VITE_PORTAL_DOMAIN_IS_ROOT)};`,
+          children: `window.VITE_PORTAL_DOMAIN_IS_ROOT = ${JSON.stringify(isRoot)};`,
           injectTo: "head-prepend",
           tag: "script",
         });


### PR DESCRIPTION
The previous JSON.stringify fix injected string values into
window.VITE_PORTAL_DOMAIN_IS_ROOT, but the env schema expects
z.boolean(). Coerce the string env var to a proper boolean via
=== 'true' before injection so the runtime validation passes.

---

<!-- kody-pr-summary:start -->
## Summary

This PR fixes a regression in `portal-framework-core` where the `VITE_PORTAL_DOMAIN_IS_ROOT` environment variable was being injected into the browser as a string value rather than a boolean, causing validation failures with the zod schema that expects a boolean type.

### Changes

**`localhost-plugin.ts`**: Modified the `VITE_PORTAL_DOMAIN_IS_ROOT` handling to coerce the environment variable to a boolean before injecting it into the window object. The value is now explicitly compared against the string `"true"`, and the resulting boolean is JSON-stringified, ensuring the injected script contains a proper JavaScript boolean (`true`/`false`) instead of a string (`"true"`/`"false"`).

**`localhost-plugin.spec.ts`**: Updated tests to reflect the new boolean coercion behavior:
- Updated the existing test to expect `window.VITE_PORTAL_DOMAIN_IS_ROOT = true;` (boolean) instead of `window.VITE_PORTAL_DOMAIN_IS_ROOT = "true";` (string)
- Added test for `VITE_PORTAL_DOMAIN_IS_ROOT='false'` injecting boolean `false`
- Added test verifying that arbitrary values (e.g., `"1"`) coerce to boolean `false`
- Removed tests for arbitrary string value injection, which are no longer applicable since the value is now coerced to a boolean
<!-- kody-pr-summary:end -->