### PR TITLE
feat(portal-framework-core): replace custom plugin with local flag and preserve local plugins in upstream merge

### DIFF
--- a/libs/portal-framework-core/src/schemas/plugin-registry.v1.json
+++ b/libs/portal-framework-core/src/schemas/plugin-registry.v1.json
@@ -22,7 +22,7 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 65535,
-          "description": "Dev server port for this plugin's Module Federation remote entry. Required unless 'custom' or 'web_bundles' is provided."
+          "description": "Dev server port for this plugin's Module Federation remote entry. Required unless 'web_bundles' is provided."
         },
         "tunnelHost": {
           "type": "string",
@@ -33,6 +33,11 @@
           "enum": ["http", "https"],
           "default": "https",
           "description": "Protocol for tunnel connection. Defaults to https."
+        },
+        "local": {
+          "type": "boolean",
+          "default": false,
+          "description": "Marks this as a local-only plugin with no corresponding Go backend. The Vite middleware will inject this plugin into the /api/meta response even when the upstream server does not include it. Manifest URL is derived from port/tunnelHost using the same rules as Go plugins."
         },
         "web_bundles": {
           "type": "array",
@@ -49,10 +54,6 @@
         "build": {
           "$ref": "portal-meta.v1.json#/$defs/buildInfo",
           "description": "Build information for this plugin, included in the /api/meta response."
-        },
-        "custom": {
-          "$ref": "#/$defs/customPlugin",
-          "description": "Custom plugin definition for client-side-only or externally-hosted plugins not served by the Go backend. When present, the Vite middleware injects this plugin into /api/meta without requiring a corresponding Go plugin."
         }
       }
     },
@@ -72,30 +73,6 @@
             "type": "string"
           },
           "description": "Which app types this bundle serves. Empty array or omitted = all apps. Mirrors the Go WebBundle.TargetApps field."
-        }
-      }
-    },
-    "customPlugin": {
-      "type": "object",
-      "required": ["manifestUrl"],
-      "description": "Defines a plugin that the Go server does not know about. The Vite dev middleware adds it to the /api/meta response so the client loads it via Module Federation at runtime. This enables testing new plugins before they have a Go backend, loading 3rd-party plugins from external URLs, or running client-side-only test plugins.",
-      "properties": {
-        "manifestUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "URL to the mf-manifest.json for this custom plugin. Typically a local dev server like http://localhost:4180/mf-manifest.json."
-        },
-        "pluginId": {
-          "type": "string",
-          "pattern": "^[a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+$",
-          "description": "Namespaced plugin ID (e.g. 'test:my-plugin', 'custom:onboarding'). Defaults to 'custom:{name}' if omitted. Must follow the NamespacedId format used by the Plugin runtime."
-        },
-        "targetApps": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Which app types this custom plugin targets. Empty = all apps."
         }
       }
     }

--- a/libs/portal-framework-core/src/vite/__tests__/config.spec.ts
+++ b/libs/portal-framework-core/src/vite/__tests__/config.spec.ts
@@ -237,11 +237,13 @@ describe("setupPluginRegistryConfig", () => {
     );
   });
 
-  it("parses custom plugin entries correctly", () => {
+  it("parses local plugin entries correctly", () => {
     const registry = [
       {
-        name: "custom-plugin",
-        custom: { manifestUrl: "https://custom.example.com/mf-manifest.json" },
+        name: "local-plugin",
+        port: 4180,
+        tunnelHost: "local.tunnel.example.com",
+        local: true,
       },
     ];
 
@@ -254,9 +256,9 @@ describe("setupPluginRegistryConfig", () => {
     });
 
     const result = setupPluginRegistryConfig(baseOpts);
-    expect(result.portalConfig.plugins["custom-plugin"]).toEqual({
+    expect(result.portalConfig.plugins["local-plugin"]).toEqual({
       meta: {},
-      web_bundles: ["https://custom.example.com/mf-manifest.json"],
+      web_bundles: ["https://local.tunnel.example.com/mf-manifest.json"],
     });
   });
 

--- a/libs/portal-framework-core/src/vite/__tests__/express-middleware.spec.ts
+++ b/libs/portal-framework-core/src/vite/__tests__/express-middleware.spec.ts
@@ -101,10 +101,13 @@ describe("mergeUpstreamConfig", () => {
     expect(result.build).toBeUndefined();
   });
 
-  it("handles plugins only in local config (not in upstream)", async () => {
+  it("preserves local-only plugins not present in upstream", async () => {
     const { mergeUpstreamConfig } = await import("../express-middleware");
     const result = mergeUpstreamConfig(localConfig, upstreamConfig);
-    expect(result.plugins["localOnly"]).toBeUndefined();
+    expect(result.plugins["localOnly"]).toEqual({
+      meta: { localOnly: true },
+      web_bundles: ["http://localhost:4200/mf-manifest.json"],
+    });
   });
 
   it("handles plugins only in upstream config (not in local)", async () => {

--- a/libs/portal-framework-core/src/vite/config.ts
+++ b/libs/portal-framework-core/src/vite/config.ts
@@ -26,9 +26,9 @@ export function getBaseUrl(
   const tunnelHost = plugin?.tunnelHost || process.env.VITE_TUNNEL_HOST;
   if (!tunnelHost) {
     if (devPort === undefined) {
-      throw new Error(
-        `Plugin '${plugin?.name}' must specify either 'port', 'tunnelHost', or 'web_bundles'/'custom'`,
-      );
+        throw new Error(
+          `Plugin '${plugin?.name}' must specify either 'port', 'tunnelHost', or 'web_bundles'`,
+        );
     }
     return `http://localhost:${devPort}`;
   }
@@ -82,17 +82,7 @@ export function setupPluginRegistryConfig(opts: ConfigOptions): {
     const plugins: Record<string, PortalPluginConfig> = {};
 
     for (const entry of registry) {
-      const { name, custom, web_bundles, meta, build, port, tunnelHost, tunnelProtocol } =
-        entry;
-
-      if (custom) {
-        plugins[name] = {
-          meta: meta ?? {},
-          web_bundles: [custom.manifestUrl],
-          build: build,
-        };
-        continue;
-      }
+      const { name, web_bundles, meta, build, port } = entry;
 
       if (web_bundles && web_bundles.length > 0) {
         plugins[name] = {

--- a/libs/portal-framework-core/src/vite/express-middleware.ts
+++ b/libs/portal-framework-core/src/vite/express-middleware.ts
@@ -28,6 +28,14 @@ export function mergeUpstreamConfig(
     ),
   );
 
+  for (const [pluginName, localPlugin] of Object.entries(
+    portalConfig.plugins,
+  )) {
+    if (!(pluginName in mergedConfig.plugins)) {
+      mergedConfig.plugins[pluginName] = localPlugin;
+    }
+  }
+
   mergedConfig.feature_flags = {
     ...mergedConfig.feature_flags,
     ...upstreamConfig.feature_flags,

--- a/libs/portal-framework-core/src/vite/types.ts
+++ b/libs/portal-framework-core/src/vite/types.ts
@@ -35,22 +35,15 @@ export interface RegistryWebBundle {
   targetApps?: string[];
 }
 
-/** A custom plugin definition for client-side-only or externally-hosted plugins. See schemas/plugin-registry.v1.json */
-export interface CustomPlugin {
-  manifestUrl: string;
-  pluginId?: string;
-  targetApps?: string[];
-}
-
 export interface PortalPlugin {
   name: string;
   port?: number;
   tunnelHost?: string;
   tunnelProtocol?: "http" | "https";
+  local?: boolean;
   web_bundles?: RegistryWebBundle[];
   meta?: PluginMeta;
   build?: BuildInfo;
-  custom?: CustomPlugin;
 }
 
 export interface DevToolsOptions {


### PR DESCRIPTION
Replace the custom plugin object (with redundant manifestUrl) with a simple local: true boolean. Local plugins use the same port/tunnelHost URL derivation as Go plugins, reducing config duplication.

Fix mergeUpstreamConfig to preserve local-only plugins that don't exist in the upstream /api/meta response, enabling client-side-only plugins like onboarding to load even when the Go backend doesn't serve them.

---

<!-- kody-pr-summary:start -->
This pull request makes two key changes to the portal framework core:

1. **Replaces the `custom` plugin configuration with a `local` flag**: The `CustomPlugin` interface and `custom` property on `PortalPlugin` have been removed. Instead, a `local?: boolean` flag is added to `PortalPlugin`. Local plugins now use the existing `port`/`tunnelHost` mechanism to resolve their manifest URL, rather than requiring a separate `manifestUrl` through the custom configuration. The error message for missing configuration has been updated accordingly.

2. **Preserves local-only plugins during upstream config merge**: The `mergeUpstreamConfig` function now iterates over plugins defined in the local portal config and adds any that are not already present in the merged result. Previously, plugins that existed only in the local config (and not in upstream) were lost during the merge.
<!-- kody-pr-summary:end -->