### PR TITLE
feat(tunnel): add local: prefix support for client-only plugins

### DIFF
--- a/tunnel-lib.sh
+++ b/tunnel-lib.sh
@@ -345,7 +345,8 @@ tunnel_single_app() {
 }
 
 # --- Generate Plugin Config JSON ---
-# Usage: tunnel_generate_plugin_config <base_port> <domain> <plugins_base_dir> [plugin1,plugin2,...]
+# Usage: tunnel_generate_plugin_config <base_port> <domain> <plugins_base_dir> [local:]plugin1,[local:]plugin2,...
+# Use "local:" prefix for client-only plugins (no Go backend, e.g. local:onboarding)
 tunnel_generate_plugin_config() {
     local base_port="${1:-4174}"
     local domain="${2:-$TUNNEL_DOMAIN}"
@@ -362,13 +363,23 @@ tunnel_generate_plugin_config() {
     # Build jq array using --arg and --argjson
     local jq_args=("--arg" "domain" "$domain")
     local idx=0
+    local -a local_indices=()
 
-    # Parse comma-separated list
+    # Parse comma-separated list (supports "local:" prefix for client-only plugins)
     IFS=',' read -ra plugins <<< "$plugin_list"
-    for name in "${plugins[@]}"; do
+    for entry in "${plugins[@]}"; do
         # Trim whitespace
-        name=$(echo "$name" | xargs)
-        [ -z "$name" ] && continue
+        entry=$(echo "$entry" | xargs)
+        [ -z "$entry" ] && continue
+
+        local is_local=false
+        local name="$entry"
+
+        # Check for local: prefix
+        if [[ "$entry" == local:* ]]; then
+            is_local=true
+            name="${entry#local:}"
+        fi
 
         local plugin_dir="$plugins_base_dir/portal-plugin-$name"
 
@@ -380,6 +391,7 @@ tunnel_generate_plugin_config() {
 
         jq_args+=("--arg" "name$idx" "$name")
         jq_args+=("--argjson" "port$idx" "$port")
+        local_indices[idx]=$is_local
         idx=$((idx + 1))
         port=$((port + 1))
     done
@@ -389,11 +401,14 @@ tunnel_generate_plugin_config() {
         return 0
     fi
 
-    # Build jq filter using jq string interpolation
     local filter="["
     for i in $(seq 0 $((idx - 1))); do
         [ "$i" -gt 0 ] && filter="$filter,"
-        filter="$filter{name: \$name$i, port: \$port$i, tunnelHost: \"\(\$name$i).\(\$domain)\"}"
+        filter="$filter{name: \$name$i, port: \$port$i, tunnelHost: \"\(\$name$i).\(\$domain)\""
+        if [ "${local_indices[$i]}" = true ]; then
+            filter="$filter, local: true"
+        fi
+        filter="$filter}"
     done
     filter="$filter]"
 

--- a/tunnel.sh
+++ b/tunnel.sh
@@ -61,7 +61,7 @@ Options:
   --host <name>       Override TUNNEL_HOST
   --port <number>     Override TUNNEL_PORT / TUNNEL_MAIN_PORT
   --env <path>        Path to root .env (default: auto-detect, walk up from CWD)
-  --plugins <list>    Override TUNNEL_PLUGINS (comma-separated, e.g. core,dashboard)
+  --plugins <list>    Override TUNNEL_PLUGINS (comma-separated, e.g. core,dashboard,local:onboarding)
   --dry-run           Print resolved config and exit without starting anything
   --kill              Kill all node processes originating from vite and exit
   --list              Discover all .env.tunnel files in the project


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add `local:` prefix support for client-only plugins in tunnel configuration

This change introduces a `local:` prefix that can be applied to plugin names in the `--plugins` option (e.g., `local:onboarding`) to designate them as client-only plugins that have no Go backend. When a plugin is marked with the `local:` prefix, the generated plugin config JSON includes a `"local": true` property, allowing the system to distinguish between full-stack plugins and frontend-only plugins. The prefix is stripped from the plugin name during processing so it doesn't affect plugin directory resolution or tunnel host naming.
<!-- kody-pr-summary:end -->