### PR TITLE
fix(advanced-rest): add X-Total-Count header fallback

### DIFF
--- a/libs/advanced-rest/src/__tests__/provider.spec.ts
+++ b/libs/advanced-rest/src/__tests__/provider.spec.ts
@@ -41,6 +41,20 @@ describe("Nested REST Data Provider", () => {
       expect(response.total).toBe(100);
     });
 
+    it("should fall back to data.total when X-Total-Count header is missing", async () => {
+      nock(API_URL)
+        .get("/websites")
+        .reply(200, { data: [{ id: 1 }, { id: 2 }, { id: 3 }], total: 3 });
+
+      const response = await dp.getList({
+        meta: { template: "/websites" },
+        resource: "websites",
+      });
+
+      expect(response.data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      expect(response.total).toBe(3);
+    });
+
     it("should throw error for missing template params", async () => {
       await expect(
         dp.getList({

--- a/libs/advanced-rest/src/provider.ts
+++ b/libs/advanced-rest/src/provider.ts
@@ -273,7 +273,8 @@ export const dataProvider = (
       );
       const data = await parseResponse(response);
 
-      const total = Number(response.headers.get("x-total-count"));
+      const headerVal = response.headers.get("x-total-count");
+      const total = headerVal !== null ? Number(headerVal) : NaN;
       return parseListResponse(data, total);
     },
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes the `X-Total-Count` header handling in the advanced REST data provider to properly fall back to `data.total` when the header is missing.

Previously, when the `X-Total-Count` header was absent, `Number(null)` evaluated to `0`, which incorrectly set the total count to zero. This change checks for a null header value and returns `NaN` instead, allowing the `parseListResponse` function to fall back to the `total` property in the response body.
<!-- kody-pr-summary:end -->