### PR TITLE
feat(framework): add unstorage-based query param persistence with plugin-owned config

### DIFF
--- a/apps/portal-app-shell/src/index.tsx
+++ b/apps/portal-app-shell/src/index.tsx
@@ -1,7 +1,10 @@
+import { setQueryParamStorageBase } from "@lumeweb/portal-framework-core";
 import React from "react";
 import { createRoot } from "react-dom/client";
 
 import App from "./App";
+
+setQueryParamStorageBase("pinner:qp:");
 
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);

--- a/libs/portal-framework-core/package.json
+++ b/libs/portal-framework-core/package.json
@@ -36,7 +36,8 @@
     "@lumeweb/portal-framework-ui-core": "workspace:*",
     "@lumeweb/portal-sdk": "workspace:*",
     "ajv": "^8.20.0",
-    "bin-pack": "^1.0.2"
+    "bin-pack": "^1.0.2",
+    "unstorage": "^1.17.5"
   },
   "devDependencies": {
     "@lumeweb/tsdown-config": "workspace:*",

--- a/libs/portal-framework-core/src/api/framework.ts
+++ b/libs/portal-framework-core/src/api/framework.ts
@@ -252,7 +252,15 @@ export class Framework {
     const allQueryParamConfigs = this.getPlugins()
       .flatMap((p) => p.queryParamConfig ?? []);
     if (allQueryParamConfigs.length > 0) {
-      await persistQueryParams(allQueryParamConfigs);
+      try {
+        await persistQueryParams(allQueryParamConfigs);
+      } catch (error) {
+        errors.push({
+          category: ERROR_CATEGORIES.PLUGIN,
+          error: error instanceof Error ? error : new Error(String(error)),
+          id: "query-param-persist",
+        });
+      }
     }
 
     // Initialize capabilities

--- a/libs/portal-framework-core/src/api/framework.ts
+++ b/libs/portal-framework-core/src/api/framework.ts
@@ -25,6 +25,7 @@ import { PortalMeta } from "../types/portal";
 import { getCurrentLocation } from "../util/location";
 import { validateNamespacedId } from "../util/namespace";
 import { fetchPortalMeta } from "../util/portalMeta";
+import { persistQueryParams } from "../util/queryParamPersist";
 import { validateFeature, validatePlugin } from "../util/validation";
 import { sortWidgets } from "../util/widget";
 
@@ -246,6 +247,12 @@ export class Framework {
           this.#capabilities.register(capability, plugin.id);
         });
       }
+    }
+
+    const allQueryParamConfigs = this.getPlugins()
+      .flatMap((p) => p.queryParamConfig ?? []);
+    if (allQueryParamConfigs.length > 0) {
+      await persistQueryParams(allQueryParamConfigs);
     }
 
     // Initialize capabilities

--- a/libs/portal-framework-core/src/index.ts
+++ b/libs/portal-framework-core/src/index.ts
@@ -73,4 +73,5 @@ export * from "./util/namespace";
 export { getPortalPluginManifests } from "./util/pluginManifest";
 export * from "./util/portalMeta";
 export * from "./util/refineConfig";
+export * from "./util/queryParamPersist";
 export * from "./util/validation";

--- a/libs/portal-framework-core/src/types/plugin.ts
+++ b/libs/portal-framework-core/src/types/plugin.ts
@@ -1,11 +1,9 @@
 import type React from "react";
 
-import { Framework } from "libs/portal-framework-core/src/api/framework";
-import * as Module from "node:module";
-
 import { FrameworkFeature } from "../types/api";
 import { BaseCapability } from "./capabilities";
 import { RouteDefinition } from "./navigation";
+import type { QueryParamPersistConfig } from "../util/queryParamPersist";
 import { PluginWidgets } from "./widget";
 
 export interface FeatureState {
@@ -28,6 +26,7 @@ export interface Plugin {
   features?: FrameworkFeature[];
   id: NamespacedId;
   initialize(framework: Framework): Promise<void>;
+  queryParamConfig?: QueryParamPersistConfig[];
   // Routes map to exposed components
   routes?: RouteDefinition[];
   widgets?: PluginWidgets;

--- a/libs/portal-framework-core/src/util/__tests__/queryParamPersist.spec.ts
+++ b/libs/portal-framework-core/src/util/__tests__/queryParamPersist.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+};
+
+vi.mock("unstorage", () => ({
+  createStorage: vi.fn(() => mockStorage),
+}));
+
+vi.mock("unstorage/drivers/localstorage", () => ({
+  default: vi.fn(() => ({})),
+}));
+
+describe("queryParamPersist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("window", {
+      location: { search: "" },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("setQueryParamStorageBase", () => {
+    it("sets the base prefix before storage is initialized", async () => {
+      vi.resetModules();
+      const { setQueryParamStorageBase, readPersistedParam } = await import(
+        "../queryParamPersist"
+      );
+
+      setQueryParamStorageBase("custom:base:");
+
+      mockStorage.getItem.mockResolvedValue("test-value");
+      const result = await readPersistedParam("someKey");
+      expect(result).toBe("test-value");
+    });
+
+    it("throws if called after first read/write (storage already initialized)", async () => {
+      vi.resetModules();
+      const { setQueryParamStorageBase, readPersistedParam } = await import(
+        "../queryParamPersist"
+      );
+
+      mockStorage.getItem.mockResolvedValue(null);
+      await readPersistedParam("anyKey");
+
+      expect(() => setQueryParamStorageBase("new:base:")).toThrow(
+        "setQueryParamStorageBase must be called before first read/write"
+      );
+    });
+  });
+
+  describe("persistQueryParams", () => {
+    it("reads URL search params and writes matching ones to storage", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", {
+        location: { search: "?ref=abc123&track=email" },
+      });
+
+      await persistQueryParams([
+        { param: "ref" },
+        { param: "track" },
+      ]);
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith("ref", "abc123");
+      expect(mockStorage.setItem).toHaveBeenCalledWith("track", "email");
+    });
+
+    it("skips if window is undefined (SSR)", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", undefined);
+
+      await persistQueryParams([{ param: "ref" }]);
+
+      expect(mockStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it("skips if URL has no search params", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", {
+        location: { search: "" },
+      });
+
+      await persistQueryParams([{ param: "ref" }]);
+
+      expect(mockStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it("supports as field for aliasing param names", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", {
+        location: { search: "?ref=abc123" },
+      });
+
+      await persistQueryParams([{ param: "ref", as: "referralCode" }]);
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith("referralCode", "abc123");
+      expect(mockStorage.setItem).not.toHaveBeenCalledWith("ref", expect.anything());
+    });
+
+    it("only persists params that exist in the URL", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", {
+        location: { search: "?ref=abc123" },
+      });
+
+      await persistQueryParams([
+        { param: "ref" },
+        { param: "missing" },
+      ]);
+
+      expect(mockStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(mockStorage.setItem).toHaveBeenCalledWith("ref", "abc123");
+    });
+
+    it("rejects values that fail validate", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", {
+        location: { search: "?intent=malicious" },
+      });
+
+      await persistQueryParams([{
+        param: "intent",
+        validate: (v) => v === "pinning" || v === "hosting",
+      }]);
+
+      expect(mockStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it("accepts values that pass validate", async () => {
+      vi.resetModules();
+      const { persistQueryParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", {
+        location: { search: "?intent=hosting" },
+      });
+
+      await persistQueryParams([{
+        param: "intent",
+        validate: (v) => v === "pinning" || v === "hosting",
+      }]);
+
+      expect(mockStorage.setItem).toHaveBeenCalledWith("intent", "hosting");
+    });
+  });
+
+  describe("readPersistedParam", () => {
+    it("returns stored value for a key", async () => {
+      vi.resetModules();
+      const { readPersistedParam } = await import("../queryParamPersist");
+
+      mockStorage.getItem.mockResolvedValue("stored-value");
+      const result = await readPersistedParam("myKey");
+
+      expect(result).toBe("stored-value");
+      expect(mockStorage.getItem).toHaveBeenCalledWith("myKey");
+    });
+
+    it("returns null if key not found", async () => {
+      vi.resetModules();
+      const { readPersistedParam } = await import("../queryParamPersist");
+
+      mockStorage.getItem.mockResolvedValue(null);
+      const result = await readPersistedParam("missingKey");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null if window is undefined (SSR)", async () => {
+      vi.resetModules();
+      const { readPersistedParam } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", undefined);
+
+      const result = await readPersistedParam("myKey");
+
+      expect(result).toBeNull();
+      expect(mockStorage.getItem).not.toHaveBeenCalled();
+    });
+
+    it("returns null if stored value is not a string", async () => {
+      vi.resetModules();
+      const { readPersistedParam } = await import("../queryParamPersist");
+
+      mockStorage.getItem.mockResolvedValue(123);
+      const result = await readPersistedParam("myKey");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("clearPersistedParams", () => {
+    it("removes specified keys from storage", async () => {
+      vi.resetModules();
+      const { clearPersistedParams } = await import("../queryParamPersist");
+
+      await clearPersistedParams(["key1", "key2"]);
+
+      expect(mockStorage.removeItem).toHaveBeenCalledWith("key1");
+      expect(mockStorage.removeItem).toHaveBeenCalledWith("key2");
+    });
+
+    it("no-ops if window is undefined (SSR)", async () => {
+      vi.resetModules();
+      const { clearPersistedParams } = await import("../queryParamPersist");
+
+      vi.stubGlobal("window", undefined);
+
+      await clearPersistedParams(["key1"]);
+
+      expect(mockStorage.removeItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/portal-framework-core/src/util/queryParamPersist.ts
+++ b/libs/portal-framework-core/src/util/queryParamPersist.ts
@@ -1,0 +1,63 @@
+import { createStorage, type Storage } from "unstorage";
+import localStorageDriver from "unstorage/drivers/localstorage";
+
+export interface QueryParamPersistConfig {
+  param: string;
+  as?: string;
+  validate?: (value: string) => boolean;
+}
+
+let _storage: Storage | null = null;
+let _base = "portal:qp:";
+
+export function setQueryParamStorageBase(base: string): void {
+  if (_storage) {
+    throw new Error("setQueryParamStorageBase must be called before first read/write");
+  }
+  _base = base;
+}
+
+async function getStorage(): Promise<Storage> {
+  if (!_storage) {
+    _storage = createStorage({
+      driver: localStorageDriver({ base: _base }),
+    });
+  }
+  return _storage;
+}
+
+export async function persistQueryParams(
+  params: QueryParamPersistConfig[],
+): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (params.length === 0) return;
+
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.toString() === "") return;
+
+  const storage = await getStorage();
+
+  for (const config of params) {
+    const value = urlParams.get(config.param);
+    if (value !== null && (!config.validate || config.validate(value))) {
+      await storage.setItem(config.as ?? config.param, value);
+    }
+  }
+}
+
+export async function readPersistedParam(key: string): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+
+  const storage = await getStorage();
+  const value = await storage.getItem(key);
+  return typeof value === "string" ? value : null;
+}
+
+export async function clearPersistedParams(
+  keys: string[],
+): Promise<void> {
+  if (typeof window === "undefined") return;
+
+  const storage = await getStorage();
+  await Promise.all(keys.map((key) => storage.removeItem(key)));
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add unstorage-based query parameter persistence system with plugin-owned configuration

This PR introduces a framework-level mechanism for automatically persisting URL query parameters to localStorage, allowing plugins to declare which query params should be captured and stored. This enables context from URL parameters (e.g., onboarding intent) to survive page navigation and refresh.

**Key changes:**

- **New `queryParamPersist` utility** (`portal-framework-core`): Provides `persistQueryParams()`, `readPersistedParam()`, `clearPersistedParams()`, and `setQueryParamStorageBase()` functions backed by `unstorage` with a localStorage driver. Supports param aliasing via the `as` field and value validation via a `validate` function. Gracefully no-ops in SSR environments.

- **Plugin interface extension**: The `Plugin` interface now accepts an optional `queryParamConfig` array, allowing each plugin to declare which URL query parameters it wants persisted and under what storage key names.

- **Framework initialization integration**: During framework startup, all plugin-declared `queryParamConfig` entries are collected and `persistQueryParams()` is called to capture matching URL parameters into storage before capabilities are initialized.

- **App shell configuration**: Sets the storage key prefix to `"pinner:qp:"` via `setQueryParamStorageBase()` before the first storage operation.
<!-- kody-pr-summary:end -->