### PR TITLE
feat(auth): useRedirectIfAuthenticated hook, fix ?to= param forwarding, add onboarding refineConfig capability

### DIFF
--- a/libs/portal-framework-auth/src/dataProviders/auth.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.ts
@@ -128,7 +128,7 @@ const OTP_PATH = "/otp";
 const DASHBOARD_PATH = "/dashboard";
 
 // Utility to sanitize redirect URLs - only allow relative paths or specific allowed domains
-const sanitizeRedirectUrl = (url: string | undefined): string => {
+export const sanitizeRedirectUrl = (url: string | undefined): string => {
   if (!url) return DASHBOARD_PATH;
 
   try {

--- a/libs/portal-framework-auth/src/dataProviders/auth.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.ts
@@ -460,7 +460,9 @@ export const createAuthProvider = (sdk: Sdk): AuthProviderWithEmitter => {
           error: processApiError(response.error, REGISTRATION_ERROR_NAME),
         }),
         ...(response.success && {
-          redirectTo: LOGIN_PATH,
+          redirectTo: params.redirectTo
+            ? `${LOGIN_PATH}?to=${encodeURIComponent(sanitizeRedirectUrl(params.redirectTo))}`
+            : LOGIN_PATH,
           successNotification: {
             description:
               "You have successfully registered. Please check your email to verify your account.",

--- a/libs/portal-framework-auth/src/hooks/useRedirectIfAuthenticated.ts
+++ b/libs/portal-framework-auth/src/hooks/useRedirectIfAuthenticated.ts
@@ -1,6 +1,8 @@
 import { type GoConfig, useGo, useIsAuthenticated } from "@refinedev/core";
 import { useEffect } from "react";
 
+import { sanitizeRedirectUrl } from "@/dataProviders/auth";
+
 /**
  * Redirects to a target path if the user is already authenticated.
  * Useful on login/register pages to bounce authenticated users away.
@@ -19,7 +21,8 @@ export function useRedirectIfAuthenticated(
 
   useEffect(() => {
     if (!isAuthLoading && authData?.authenticated) {
-      go({ to: to ?? fallback, type });
+      const safeTo = to ? sanitizeRedirectUrl(to) : fallback;
+      go({ to: safeTo, type });
     }
   }, [isAuthLoading, authData, to, fallback, type, go]);
 }

--- a/libs/portal-framework-auth/src/hooks/useRedirectIfAuthenticated.ts
+++ b/libs/portal-framework-auth/src/hooks/useRedirectIfAuthenticated.ts
@@ -1,0 +1,25 @@
+import { type GoConfig, useGo, useIsAuthenticated } from "@refinedev/core";
+import { useEffect } from "react";
+
+/**
+ * Redirects to a target path if the user is already authenticated.
+ * Useful on login/register pages to bounce authenticated users away.
+ *
+ * @param fallback - Path to redirect to when no `?to=` override is needed (default: "/dashboard")
+ * @param to - Override redirect target (e.g. from URL search params)
+ * @param type - Navigation type: "replace" (default, for login/register) or "push" (for mid-flow like OTP)
+ */
+export function useRedirectIfAuthenticated(
+  fallback = "/dashboard",
+  to?: string | null,
+  type: GoConfig["type"] = "replace",
+): void {
+  const { data: authData, isLoading: isAuthLoading } = useIsAuthenticated();
+  const go = useGo();
+
+  useEffect(() => {
+    if (!isAuthLoading && authData?.authenticated) {
+      go({ to: to ?? fallback, type });
+    }
+  }, [isAuthLoading, authData, to, fallback, type, go]);
+}

--- a/libs/portal-framework-auth/src/index.ts
+++ b/libs/portal-framework-auth/src/index.ts
@@ -31,3 +31,5 @@ export {
   ResetPasswordLayout,
   ResetPasswordReset,
 };
+
+export { useRedirectIfAuthenticated } from "./hooks/useRedirectIfAuthenticated";

--- a/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
@@ -4,7 +4,9 @@ import {
   withTheme,
 } from "@lumeweb/portal-framework-ui";
 import React from "react";
+import { useSearchParams } from "react-router";
 
+import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
 import { AuthPage } from "@/ui/components/common/AuthPage";
 import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
 
@@ -14,13 +16,21 @@ import { SocialLogin } from "./SocialLogin";
 function LoginIndex() {
   const socialLoginEnabled = useFeatureFlag("social_login");
   const registerUrl = useRegisterUrl();
+  const [searchParams] = useSearchParams();
+
+  const to = searchParams.get("to");
+  const registerUrlWithTo = to
+    ? `${registerUrl}?to=${encodeURIComponent(to)}`
+    : registerUrl;
+
+  useRedirectIfAuthenticated("/dashboard", to);
 
   return (
     <AuthPage
       beforeLink={<AuthPageTitle>Welcome back 👋</AuthPageTitle>}
       linkLabel="New user?"
       linkText="Create an account →"
-      linkUrl={registerUrl}
+      linkUrl={registerUrlWithTo}
       variant="login">
       {socialLoginEnabled && <SocialLogin />}
       <LoginForm />

--- a/libs/portal-framework-auth/src/ui/components/login/OtpForm.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/OtpForm.tsx
@@ -3,14 +3,10 @@ import {
   useResetPasswordUrl,
   withTheme,
 } from "@lumeweb/portal-framework-ui";
-import {
-  useGo,
-  useIsAuthenticated,
-  useLogin,
-  useParsed,
-} from "@refinedev/core";
-import { useEffect } from "react";
+import { useLogin, useParsed } from "@refinedev/core";
+import React from "react";
 
+import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
 import { AuthPage } from "@/ui/components/common/AuthPage";
 import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
 
@@ -21,17 +17,11 @@ export interface OtpParams {
 }
 
 function OtpForm(): JSX.Element {
-  const { data: authData, isLoading: isAuthLoading } = useIsAuthenticated();
-  const go = useGo();
   const parsed = useParsed<OtpParams>();
   const login = useLogin();
   const resetPasswordUrl = useResetPasswordUrl();
 
-  useEffect(() => {
-    if (!isAuthLoading && authData?.authenticated) {
-      go({ to: parsed.params?.to, type: "push" });
-    }
-  }, [isAuthLoading, authData, parsed.params?.to, go]);
+  useRedirectIfAuthenticated("/dashboard", parsed.params?.to, "push");
 
   const otpFormConfig = getOtpForm(
     (values) => login.mutate({ ...values, redirectTo: parsed.params?.to }),

--- a/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
@@ -5,8 +5,10 @@ import {
 } from "@lumeweb/portal-framework-ui";
 import { useRegister } from "@refinedev/core";
 import React from "react";
+import { useSearchParams } from "react-router";
 
 import { RegisterFormRequest } from "@/dataProviders/auth";
+import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
 import { AuthPage } from "@/ui/components/common/AuthPage";
 import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
 import { getRegisterForm } from "@/ui/forms/register";
@@ -14,6 +16,14 @@ import { getRegisterForm } from "@/ui/forms/register";
 function RegisterIndex() {
   const register = useRegister<RegisterFormRequest>();
   const loginUrl = useLoginUrl();
+  const [searchParams] = useSearchParams();
+
+  const to = searchParams.get("to");
+  const loginUrlWithTo = to
+    ? `${loginUrl}?to=${encodeURIComponent(to)}`
+    : loginUrl;
+
+  useRedirectIfAuthenticated("/dashboard", to);
 
   const onSubmit = async (values: any) => {
     await register.mutateAsync({
@@ -21,6 +31,7 @@ function RegisterIndex() {
       firstName: values.firstName,
       lastName: values.lastName,
       password: values.password,
+      redirectTo: to ?? undefined,
     });
   };
 
@@ -31,7 +42,7 @@ function RegisterIndex() {
       beforeLink={<AuthPageTitle>All Roads Lead to Lume 🎉</AuthPageTitle>}
       linkLabel="Already have an account?"
       linkText="Login here →"
-      linkUrl={loginUrl}
+      linkUrl={loginUrlWithTo}
       variant="register">
       <SchemaForm config={finalRegisterFormConfig} />
     </AuthPage>

--- a/libs/portal-plugin-onboarding/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-onboarding/src/capabilities/refineConfig.ts
@@ -1,0 +1,56 @@
+import type { RefineProps } from "@refinedev/core";
+import {
+  Framework,
+  mergeRefineConfig,
+  RefineConfigCapability,
+  type CapabilityStatus,
+} from "@lumeweb/portal-framework-core";
+
+const DATA_PROVIDER_NAME = "ipfs";
+
+export class Capability implements RefineConfigCapability {
+  readonly id: string = "onboarding:refine-config";
+  status: CapabilityStatus = "active";
+  readonly type = "core:refine-config";
+  version!: string;
+  #apiUrl!: string;
+
+  dependencies = ["ipfs:refine-config"];
+
+  getApiUrl(): string {
+    return this.#apiUrl;
+  }
+
+  async destroy() {
+  }
+
+  getConfig(existing?: Partial<RefineProps>) {
+    const onboardingResources = [
+      {
+        meta: {
+          dataProviderName: DATA_PROVIDER_NAME,
+          template: "/api/websites",
+        },
+        name: "ipfs/websites",
+      },
+    ];
+
+    return mergeRefineConfig(existing, {}, onboardingResources);
+  }
+
+  async initialize(framework: Framework) {
+    const ipfsCapability = await framework.getCapability<
+      RefineConfigCapability & { getApiUrl(): string }
+    >("ipfs:refine-config");
+
+    if (!ipfsCapability) {
+      throw new Error("IPFS refine capability not found");
+    }
+
+    this.#apiUrl = ipfsCapability.getApiUrl();
+
+    if (!this.#apiUrl) {
+      throw new Error("API URL not found in IPFS capability");
+    }
+  }
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Introduce a `useRedirectIfAuthenticated` hook to centralize redirect logic for authenticated users on auth pages, fix `?to=` parameter forwarding across the login, register, and OTP flows so redirect destinations are preserved when navigating between auth pages, and add an onboarding `refineConfig` capability that provides IPFS-backed website resources for the onboarding experience.
<!-- kody-pr-summary:end -->