### PR TITLE
feat(dashboard): add VITE_PORTAL_BRAND env var for brand configurability

### DIFF
--- a/apps/portal-app-shell/index.html
+++ b/apps/portal-app-shell/index.html
@@ -15,7 +15,7 @@
     </div>
     <div class="flex flex-col items-center justify-center min-h-screen p-8">
       <div class="mb-8">
-        <div class="w-28 h-28 bg-primary rounded-2xl flex items-center justify-center">
+        <div data-loader-logo class="w-28 h-28 bg-primary rounded-2xl flex items-center justify-center">
           <svg viewBox="0 0 339.18999 339.19" fill="none" xmlns="http://www.w3.org/2000/svg">
             <g
               id="g14"

--- a/libs/portal-framework-auth/package.json
+++ b/libs/portal-framework-auth/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@lumeweb/tsdown-config": "workspace:*",
+    "@types/react": "catalog:",
     "tsdown": "catalog:"
   },
   "peerDependencies": {

--- a/libs/portal-framework-auth/src/ui/components/common/AuthFooter.tsx
+++ b/libs/portal-framework-auth/src/ui/components/common/AuthFooter.tsx
@@ -4,28 +4,51 @@ import {
 } from "@lumeweb/portal-framework-ui/images";
 import React from "react";
 
+import type { BrandConfig } from "@lumeweb/portal-framework-core";
+
 interface AuthFooterButtonProps {
   children: React.ReactNode;
   href: string;
   icon: React.ReactNode;
 }
 
-export function AuthFooter() {
+interface AuthFooterProps {
+  brand?: BrandConfig;
+}
+
+export function AuthFooter({ brand }: AuthFooterProps) {
+  const social = brand?.social;
+
   return (
     <footer className="my-5">
       <ul className="flex flex-row">
-        <AuthFooterButton
-          href="https://discord.lumeweb.com"
-          icon={
-            <img alt="Discord Logo" className="h-5" src={discordLogoPng} />
-          }>
-          Connect with us
-        </AuthFooterButton>
-        <AuthFooterButton
-          href="https://lumeweb.com"
-          icon={<img alt="Lume Logo" className="h-5" src={lumeColorLogoPng} />}>
-          Connect with us
-        </AuthFooterButton>
+        {social?.discord && (
+          <AuthFooterButton
+            href={social.discord}
+            icon={
+              <img alt="Discord Logo" className="h-5" src={discordLogoPng} />
+            }>
+            Connect with us
+          </AuthFooterButton>
+        )}
+        {social?.github && (
+          <AuthFooterButton
+            href={social.github}
+            icon={
+              <img alt="Logo" className="h-5" src={brand?.logoUrl || lumeColorLogoPng} />
+            }>
+            View on GitHub
+          </AuthFooterButton>
+        )}
+        {social?.twitter && (
+          <AuthFooterButton
+            href={social.twitter}
+            icon={
+              <img alt="Logo" className="h-5" src={brand?.logoUrl || lumeColorLogoPng} />
+            }>
+            Follow us
+          </AuthFooterButton>
+        )}
       </ul>
     </footer>
   );

--- a/libs/portal-framework-auth/src/ui/components/common/AuthPage.tsx
+++ b/libs/portal-framework-auth/src/ui/components/common/AuthPage.tsx
@@ -1,12 +1,15 @@
 import { InlineAuthLinkBanner, LumeLogo } from "@lumeweb/portal-framework-ui";
 import React, { ReactNode } from "react";
 
+import type { BrandConfig } from "@lumeweb/portal-framework-core";
+
 import { AuthFooter } from "./AuthFooter";
 import { BackgroundImage } from "./BackgroundImage";
 import { BackgroundVariant } from "./types";
 
 interface AuthPageProps {
   beforeLink?: ReactNode;
+  brand?: BrandConfig;
   children: ReactNode;
   linkLabel?: string;
   linkText?: string;
@@ -16,6 +19,7 @@ interface AuthPageProps {
 
 export function AuthPage({
   beforeLink,
+  brand,
   children,
   linkLabel,
   linkText,
@@ -28,7 +32,7 @@ export function AuthPage({
     <div className="relative h-screen sm:overflow-hidden">
       <div className="flex h-full w-full flex-col items-center justify-center sm:flex-row-reverse">
         <header className="absolute left-4 top-4 sm:left-8">
-          <LumeLogo />
+          <LumeLogo src={brand?.logoUrl} />
         </header>
         <BackgroundImage variant={variant} />
         <div
@@ -49,7 +53,7 @@ export function AuthPage({
               </div>
             )}
             {children}
-            <AuthFooter />
+            <AuthFooter brand={brand} />
           </div>
         </div>
       </div>

--- a/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/LoginIndex.tsx
@@ -6,6 +6,7 @@ import {
 import React from "react";
 import { useSearchParams } from "react-router";
 
+import { useBrand } from "@lumeweb/portal-framework-core";
 import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
 import { AuthPage } from "@/ui/components/common/AuthPage";
 import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
@@ -17,6 +18,7 @@ function LoginIndex() {
   const socialLoginEnabled = useFeatureFlag("social_login");
   const registerUrl = useRegisterUrl();
   const [searchParams] = useSearchParams();
+  const brand = useBrand();
 
   const to = searchParams.get("to");
   const registerUrlWithTo = to
@@ -27,7 +29,8 @@ function LoginIndex() {
 
   return (
     <AuthPage
-      beforeLink={<AuthPageTitle>Welcome back 👋</AuthPageTitle>}
+      beforeLink={<AuthPageTitle>Welcome back!</AuthPageTitle>}
+      brand={brand}
       linkLabel="New user?"
       linkText="Create an account →"
       linkUrl={registerUrlWithTo}

--- a/libs/portal-framework-auth/src/ui/components/login/OtpForm.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/OtpForm.tsx
@@ -6,6 +6,7 @@ import {
 import { useLogin, useParsed } from "@refinedev/core";
 import React from "react";
 
+import { useBrand } from "@lumeweb/portal-framework-core";
 import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
 import { AuthPage } from "@/ui/components/common/AuthPage";
 import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
@@ -20,6 +21,7 @@ function OtpForm(): JSX.Element {
   const parsed = useParsed<OtpParams>();
   const login = useLogin();
   const resetPasswordUrl = useResetPasswordUrl();
+  const brand = useBrand();
 
   useRedirectIfAuthenticated("/dashboard", parsed.params?.to, "push");
 
@@ -31,6 +33,7 @@ function OtpForm(): JSX.Element {
   return (
     <AuthPage
       beforeLink={<AuthPageTitle>Two-Factor Authentication</AuthPageTitle>}
+      brand={brand}
       linkLabel="Forgot your password?"
       linkText="Reset password →"
       linkUrl={resetPasswordUrl}

--- a/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/register/RegisterIndex.tsx
@@ -4,9 +4,9 @@ import {
   withTheme,
 } from "@lumeweb/portal-framework-ui";
 import { useRegister } from "@refinedev/core";
-import React from "react";
 import { useSearchParams } from "react-router";
 
+import { useBrand } from "@lumeweb/portal-framework-core";
 import { RegisterFormRequest } from "@/dataProviders/auth";
 import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
 import { AuthPage } from "@/ui/components/common/AuthPage";
@@ -17,6 +17,7 @@ function RegisterIndex() {
   const register = useRegister<RegisterFormRequest>();
   const loginUrl = useLoginUrl();
   const [searchParams] = useSearchParams();
+  const brand = useBrand();
 
   const to = searchParams.get("to");
   const loginUrlWithTo = to
@@ -35,11 +36,12 @@ function RegisterIndex() {
     });
   };
 
-  const finalRegisterFormConfig = getRegisterForm(onSubmit);
+  const finalRegisterFormConfig = getRegisterForm(onSubmit, brand);
 
   return (
     <AuthPage
-      beforeLink={<AuthPageTitle>All Roads Lead to Lume 🎉</AuthPageTitle>}
+      beforeLink={<AuthPageTitle>{brand.tagline}</AuthPageTitle>}
+      brand={brand}
       linkLabel="Already have an account?"
       linkText="Login here →"
       linkUrl={loginUrlWithTo}

--- a/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordLayout.tsx
+++ b/libs/portal-framework-auth/src/ui/components/reset-password/ResetPasswordLayout.tsx
@@ -2,6 +2,7 @@ import { useLoginUrl, withTheme } from "@lumeweb/portal-framework-ui";
 import React from "react";
 import { Outlet, useLocation, useMatches } from "react-router";
 
+import { useBrand } from "@lumeweb/portal-framework-core";
 import { AuthPage } from "@/ui/components/common/AuthPage";
 import { AuthPageTitle } from "@/ui/components/common/AuthPageTitle";
 
@@ -21,6 +22,7 @@ const PAGE_CONFIG = {
 function ResetPasswordLayout() {
   const loginUrl = useLoginUrl();
   const location = useLocation();
+  const brand = useBrand();
   const matches = useMatches().filter(
     (item) => item.pathname === location.pathname,
   );
@@ -32,6 +34,7 @@ function ResetPasswordLayout() {
   return (
     <AuthPage
       beforeLink={<AuthPageTitle>{title}</AuthPageTitle>}
+      brand={brand}
       linkLabel={linkLabel}
       linkText={linkText}
       linkUrl={loginUrl}

--- a/libs/portal-framework-auth/src/ui/forms/register.tsx
+++ b/libs/portal-framework-auth/src/ui/forms/register.tsx
@@ -5,89 +5,98 @@ import {
   GroupOrder,
 } from "@lumeweb/portal-framework-ui";
 
+import type { BrandConfig } from "@lumeweb/portal-framework-core";
+
 import { schema } from "./register.schema";
 
 export const getRegisterForm = (
   onSubmit: (values: any) => Promise<void>,
-): FormConfig => ({
-  actionButtons: [
-    {
-      className: "w-full h-14",
-      label: "Create Account",
-      type: ActionItemType.SUBMIT,
-    },
-  ],
-  fields: [
-    {
-      autocomplete: "given-name",
-      className: "space-y-2",
-      group: "name",
-      inputClassName: "h-14",
-      itemClassName: "flex-1",
-      label: "First Name",
-      name: "firstName",
-      type: FormFieldType.TEXT,
-    },
-    {
-      autocomplete: "family-name",
-      className: "space-y-2",
-      group: "name",
-      inputClassName: "h-14",
-      itemClassName: "flex-1",
-      label: "Last Name",
-      name: "lastName",
-      type: FormFieldType.TEXT,
-    },
-    {
-      autocomplete: "email",
-      inputClassName: "h-14",
-      label: "Email",
-      name: "email",
-      type: FormFieldType.EMAIL,
-    },
-    {
-      autocomplete: "new-password",
-      inputClassName: "h-14",
-      label: "Password",
-      name: "password",
-      type: FormFieldType.PASSWORD,
-    },
-    {
-      autocomplete: "new-password",
-      inputClassName: "h-14",
-      label: "Confirm Password",
-      name: "confirmPassword",
-      type: FormFieldType.PASSWORD,
-    },
-    {
-      label: (
-        <span className="pl-2 text-sm">
-          I agree to the
-          <a
-            className="text-foreground mx-1 underline"
-            href="/terms-of-service">
-            Terms of Service
-          </a>
-          and
-          <a className="text-foreground mx-1 underline" href="/privacy-policy">
-            Privacy Policy
-          </a>
-        </span>
-      ),
-      name: "termsOfService",
-      type: FormFieldType.CHECKBOX,
-    },
-  ],
-  footerClassName: "",
-  formClassName: "w-full m-auto",
-  groupOrder: GroupOrder.GROUPS_FIRST,
-  groups: [
-    {
-      className: "flex gap-4",
-      id: "name",
-    },
-  ],
-  layout: "vertical",
-  onSubmit: onSubmit,
-  validationSchema: schema,
-});
+  brand?: BrandConfig,
+): FormConfig => {
+  const siteUrl = brand?.siteUrl;
+
+  return {
+    actionButtons: [
+      {
+        className: "w-full h-14",
+        label: "Create Account",
+        type: ActionItemType.SUBMIT,
+      },
+    ],
+    fields: [
+      {
+        autocomplete: "given-name",
+        className: "space-y-2",
+        group: "name",
+        inputClassName: "h-14",
+        itemClassName: "flex-1",
+        label: "First Name",
+        name: "firstName",
+        type: FormFieldType.TEXT,
+      },
+      {
+        autocomplete: "family-name",
+        className: "space-y-2",
+        group: "name",
+        inputClassName: "h-14",
+        itemClassName: "flex-1",
+        label: "Last Name",
+        name: "lastName",
+        type: FormFieldType.TEXT,
+      },
+      {
+        autocomplete: "email",
+        inputClassName: "h-14",
+        label: "Email",
+        name: "email",
+        type: FormFieldType.EMAIL,
+      },
+      {
+        autocomplete: "new-password",
+        inputClassName: "h-14",
+        label: "Password",
+        name: "password",
+        type: FormFieldType.PASSWORD,
+      },
+      {
+        autocomplete: "new-password",
+        inputClassName: "h-14",
+        label: "Confirm Password",
+        name: "confirmPassword",
+        type: FormFieldType.PASSWORD,
+      },
+      {
+        label: (
+          <span className="pl-2 text-sm">
+            I agree to the
+            <a
+              className="text-foreground mx-1 underline"
+              href={siteUrl ? `${siteUrl}/terms-of-service` : "/terms-of-service"}>
+              Terms of Service
+            </a>
+            and
+            <a
+              className="text-foreground mx-1 underline"
+              href={siteUrl ? `${siteUrl}/privacy-policy` : "/privacy-policy"}>
+              Privacy Policy
+            </a>
+          </span>
+        ),
+        name: "termsOfService",
+        type: FormFieldType.CHECKBOX,
+      },
+    ],
+    footerClassName: "",
+    formClassName: "w-full m-auto",
+    groupOrder: GroupOrder.GROUPS_FIRST,
+    groups: [
+      {
+        className: "flex gap-4",
+        id: "name",
+      },
+    ],
+    layout: "vertical",
+    onSubmit: onSubmit,
+    validationSchema: schema,
+  };
+};

--- a/libs/portal-framework-core/src/env.ts
+++ b/libs/portal-framework-core/src/env.ts
@@ -1,9 +1,34 @@
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
+const brandSchema = z.object({
+  logoUrl: z.string().optional(),
+  tagline: z.string().optional(),
+  siteUrl: z.string().url().optional(),
+  social: z
+    .object({
+      twitter: z.string().optional(),
+      discord: z.string().optional(),
+      github: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type BrandConfig = z.infer<typeof brandSchema>;
+
+export const DEFAULT_BRAND: BrandConfig = {
+  tagline: "Your data. Your Rules.",
+};
+
+const brandSchemaWithDefault = z.preprocess(
+  (val) => (typeof val === "string" ? JSON.parse(val) : val),
+  brandSchema,
+);
+
 export const env = createEnv({
   client: {
     VITE_PORTAL_ALLOW_LOCALHOST: z.boolean().optional(),
+    VITE_PORTAL_BRAND: brandSchemaWithDefault.optional().default(() => DEFAULT_BRAND),
     VITE_PORTAL_DOMAIN: z.string().includes(".").optional(),
     VITE_PORTAL_DOMAIN_IS_ROOT: z.boolean().optional(),
   },

--- a/libs/portal-framework-core/src/hooks/useBrand.ts
+++ b/libs/portal-framework-core/src/hooks/useBrand.ts
@@ -1,0 +1,10 @@
+import { DEFAULT_BRAND, env, type BrandConfig } from "../env";
+
+export function useBrand(): BrandConfig {
+  const brand = env.VITE_PORTAL_BRAND;
+  if (!brand) return DEFAULT_BRAND;
+  return {
+    ...DEFAULT_BRAND,
+    ...brand,
+  };
+}

--- a/libs/portal-framework-core/src/index.ts
+++ b/libs/portal-framework-core/src/index.ts
@@ -22,7 +22,11 @@ export {
 } from "./contexts/framework";
 
 // Environment
-export { env } from "./env";
+export { DEFAULT_BRAND, env } from "./env";
+export type { BrandConfig } from "./env";
+
+// Hooks
+export { useBrand } from "./hooks/useBrand";
 
 // Plugin Management
 export { PluginManager } from "./plugins/manager";

--- a/libs/portal-framework-core/src/vite/localhost-plugin.ts
+++ b/libs/portal-framework-core/src/vite/localhost-plugin.ts
@@ -3,11 +3,11 @@ import type { HtmlTagDescriptor, Plugin } from "vite";
 export function localhostAccessPlugin(): Plugin {
   return {
     name: "localhost-access-plugin",
-    transformIndexHtml() {
-      const scripts: HtmlTagDescriptor[] = [];
+    transformIndexHtml(html) {
+      const tags: HtmlTagDescriptor[] = [];
 
       if (process.env.VITE_PORTAL_ALLOW_LOCALHOST) {
-        scripts.push({
+        tags.push({
           attrs: { type: "text/javascript" },
           children: `window.VITE_PORTAL_ALLOW_LOCALHOST = true;`,
           injectTo: "head-prepend",
@@ -17,7 +17,7 @@ export function localhostAccessPlugin(): Plugin {
 
       if (process.env.VITE_PORTAL_DOMAIN_IS_ROOT) {
         const isRoot = process.env.VITE_PORTAL_DOMAIN_IS_ROOT === "true";
-        scripts.push({
+        tags.push({
           attrs: { type: "text/javascript" },
           children: `window.VITE_PORTAL_DOMAIN_IS_ROOT = ${JSON.stringify(isRoot)};`,
           injectTo: "head-prepend",
@@ -25,7 +25,29 @@ export function localhostAccessPlugin(): Plugin {
         });
       }
 
-      return scripts;
+      if (process.env.VITE_PORTAL_BRAND) {
+        tags.push({
+          attrs: { type: "text/javascript" },
+          children: `window.VITE_PORTAL_BRAND = ${JSON.stringify(process.env.VITE_PORTAL_BRAND)};`,
+          injectTo: "head-prepend",
+          tag: "script",
+        });
+
+        const brand =
+          typeof process.env.VITE_PORTAL_BRAND === "string"
+            ? JSON.parse(process.env.VITE_PORTAL_BRAND)
+            : process.env.VITE_PORTAL_BRAND;
+
+        if (brand?.logoUrl) {
+          const updatedHtml = html.replace(
+            /(<div\s+data-loader-logo\s+[^>]*>)([\s\S]*?)(<\/div>)/,
+            `$1<img alt="Logo" src="${brand.logoUrl}" />$3`,
+          );
+          return { html: updatedHtml, tags };
+        }
+      }
+
+      return tags;
     },
   };
 }

--- a/libs/portal-framework-ui/src/components/LumeLogo.tsx
+++ b/libs/portal-framework-ui/src/components/LumeLogo.tsx
@@ -8,15 +8,16 @@ import { logoPng } from "@/images";
 interface LumeLogoProps {
   className?: string;
   imageClassName?: string;
+  src?: string;
 }
 
-export function LumeLogo({ className, imageClassName }: LumeLogoProps) {
+export function LumeLogo({ className, imageClassName, src }: LumeLogoProps) {
   return (
     <Link className={cn("flex items-center space-x-2", className)} to="/">
       <img
-        alt="Lume logo"
+        alt="Logo"
         className={cn("h-10", imageClassName)}
-        src={logoPng}
+        src={src || logoPng}
       />
     </Link>
   );

--- a/libs/portal-framework-ui/src/components/layout/DesktopSidebar.tsx
+++ b/libs/portal-framework-ui/src/components/layout/DesktopSidebar.tsx
@@ -1,4 +1,4 @@
-import { FlexWidgetArea } from "@lumeweb/portal-framework-core";
+import { FlexWidgetArea, useBrand } from "@lumeweb/portal-framework-core";
 import { Button, cn } from "@lumeweb/portal-framework-ui-core";
 import React from "react";
 
@@ -9,6 +9,7 @@ import { SidebarToggle } from "./SidebarToggle";
 
 function DesktopSidebar() {
   const { isCollapsed, toggleCollapsed } = useSidebarContext();
+  const brand = useBrand();
 
   return (
     <aside
@@ -31,6 +32,7 @@ function DesktopSidebar() {
             )}
             variant="link">
             <LumeLogo
+              src={brand.logoUrl}
               imageClassName={cn("transition transition-all", {
                 "h-5": isCollapsed,
               })}

--- a/libs/portal-plugin-dashboard/src/ui/routes/account.verify.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/account.verify.tsx
@@ -1,7 +1,7 @@
-import { type Identity } from "@lumeweb/portal-framework-core";
+import { type Identity, useBrand } from "@lumeweb/portal-framework-core";
 import { useSdk, withTheme } from "@lumeweb/portal-framework-ui";
 import { Button } from "@lumeweb/portal-framework-ui-core";
-import { logoPng, lumeBgPng } from "@lumeweb/portal-framework-ui/images";
+import { lumeBgPng, logoPng } from "@lumeweb/portal-framework-ui/images";
 import { useGetIdentity, useGo, useIsAuthenticated } from "@refinedev/core";
 import { useQuery } from "@tanstack/react-query";
 import React, { useEffect, useState } from "react";
@@ -177,7 +177,9 @@ function AccountVerify() {
   const token = searchParams.get("token");
   const email = searchParams.get("email");
   const sdk = useSdk()!;
+  const brand = useBrand();
   const user = useGetIdentity<Identity>();
+  const logoUrl = brand.logoUrl;
   const [isVerified, setIsVerified] = useState(false);
   const [alreadyVerified, setAlreadyVerified] = useState(false);
   const {
@@ -248,7 +250,7 @@ function AccountVerify() {
     return (
       <div className="relative h-screen p-10">
         <header>
-          <img alt="Lume logo" className="h-10" src={logoPng} />
+          <img alt="Logo" className="h-10" src={logoUrl || logoPng} />
         </header>
         <main className="flex h-full flex-col items-center justify-center">
           <MissingParametersError
@@ -259,7 +261,7 @@ function AccountVerify() {
         </main>
         <div className="fixed inset-0 -z-10 overflow-clip">
           <img
-            alt="Lume background"
+            alt="Background"
             className="absolute left-0 right-0 top-0 z-[-1] object-cover"
             src={lumeBgPng}
           />
@@ -270,9 +272,9 @@ function AccountVerify() {
 
   return (
     <div className="relative h-screen p-10">
-      <header>
-        <img alt="Lume logo" className="h-10" src={logoPng} />
-      </header>
+        <header>
+          <img alt="Logo" className="h-10" src={logoUrl || logoPng} />
+        </header>
       <main className="flex h-full flex-col items-center justify-center">
         <VerificationStatus
           alreadyVerified={alreadyVerified}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1003,6 +1003,9 @@ importers:
       '@lumeweb/tsdown-config':
         specifier: workspace:*
         version: link:../tsdown-config
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
@@ -20514,7 +20517,7 @@ snapshots:
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      vite: 8.0.16(@types/node@25.9.1)(@vitejs/devtools@0.1.22)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.7.0)(@vitejs/devtools@0.1.22)(esbuild@0.27.7)(jiti@1.21.7)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.48.0)(yaml@2.9.0)
 
   '@rolldown/plugin-node-polyfills@1.0.3': {}
 


### PR DESCRIPTION
Add single VITE_PORTAL_BRAND JSON env var (Zod-validated) to configure
tagline, logo URL, social links, and ToS/Privacy link domain across the
portal dashboard.

- Add BrandConfig schema, DEFAULT_BRAND constant, useBrand() hook
- Update all auth pages to consume brand config (tagline, logo, socials)
- LumeLogo supports src prop override for branded logos
- DesktopSidebar uses useBrand() for logo
- AuthFooter renders social links from brand config with brand logo
- ToS/Privacy links resolve to brand.siteUrl (root domain)
- Loader data-loader-logo attribute for pre-JS logo replacement
- Vite plugin injects window.VITE_PORTAL_BRAND + replaces loader logo
- Add @types/react devDependency to portal-framework-auth

---

<!-- kody-pr-summary:start -->
Add `VITE_PORTAL_BRAND` environment variable to allow portal brand customization including logo, tagline, site URL, and social links

This PR introduces a new `VITE_PORTAL_BRAND` environment variable that enables configuring the portal's branding without modifying source code. The brand config supports a custom `logoUrl`, `tagline`, `siteUrl`, and social links (`discord`, `github`, `twitter`).

Key changes:
- **Brand config schema and defaults**: Added `BrandConfig` type with a default tagline of "Your data. Your Rules." and a `useBrand()` hook that merges provided config with defaults
- **Vite plugin injection**: The `VITE_PORTAL_BRAND` value is injected at build time into the HTML, and if a custom `logoUrl` is provided, the loading screen SVG is replaced with the custom logo image
- **Auth pages**: All auth pages (login, register, OTP, reset password) now use the brand config for the logo, tagline, and social footer links. Social links in the footer are conditionally rendered based on what's configured
- **Register form**: Terms of Service and Privacy Policy links now prefix with `brand.siteUrl` when configured
- **Dashboard sidebar and account verification**: Use the brand's `logoUrl` for the logo display
- **Hardcoded Lume branding removed**: Replaced "All Roads Lead to Lume 🎉" with the configurable `brand.tagline`, changed "Welcome back 👋" to "Welcome back!", and updated alt text from "Lume logo" to generic "Logo"
<!-- kody-pr-summary:end -->