### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/cold-doors-show.md
+++ b/.changeset/cold-doors-show.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-ui: minor
+---
+
+## Features
+
+- add VITE_PORTAL_BRAND env var for brand configurability

--- a/.changeset/fiery-baths-end.md
+++ b/.changeset/fiery-baths-end.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param

--- a/.changeset/goofy-kings-sort.md
+++ b/.changeset/goofy-kings-sort.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-ipfs: patch
+---
+
+## Fixes
+
+- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param

--- a/.changeset/huge-falcons-see.md
+++ b/.changeset/huge-falcons-see.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-dashboard: minor
+---
+
+## Features
+
+- add VITE_PORTAL_BRAND env var for brand configurability

--- a/.changeset/neat-keys-matter.md
+++ b/.changeset/neat-keys-matter.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/portal-framework-auth: minor
+---
+
+## Features
+
+- useRedirectIfAuthenticated hook, fix ?to= param forwarding, add onboarding refineConfig capability
+- add VITE_PORTAL_BRAND env var for brand configurability
+
+## Fixes
+
+- sanitize redirect URL in useRedirectIfAuthenticated to prevent open redirect

--- a/.changeset/plain-impalas-like.md
+++ b/.changeset/plain-impalas-like.md
@@ -1,0 +1,16 @@
+---
+@lumeweb/portal-framework-core: minor
+---
+
+## Features
+
+- modularize Vite plugin with schema validation and full test coverage
+- replace custom plugin with local flag and preserve local plugins in upstream merge
+- add unstorage-based query param persistence with plugin-owned config
+- add VITE_PORTAL_BRAND env var for brand configurability
+
+## Fixes
+
+- address PR review bugs with regression tests
+- coerce VITE_PORTAL_DOMAIN_IS_ROOT to boolean for zod schema
+- prevent query param persistence failure from aborting initialization

--- a/.changeset/slick-canyons-visit.md
+++ b/.changeset/slick-canyons-visit.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-billing: patch
+---
+
+## Fixes
+
+- extract src-lib for cross-plugin consumption

--- a/.changeset/thin-radios-write.md
+++ b/.changeset/thin-radios-write.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-app-shell: minor
+---
+
+## Features
+
+- add unstorage-based query param persistence with plugin-owned config
+- add VITE_PORTAL_BRAND env var for brand configurability

--- a/.changeset/whole-breads-heal.md
+++ b/.changeset/whole-breads-heal.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/advanced-rest: patch
+---
+
+## Fixes
+
+- add X-Total-Count header fallback


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changesets to document and version recent features and fixes across the LumeWeb portal ecosystem. The recorded changes include new brand configurability options, authentication and routing improvements, and various bug fixes and refactors.

### Features
*   **Brand Configurability:** Introduces the `VITE_PORTAL_BRAND` environment variable across the portal framework (UI, dashboard, auth, core, and app shell) to allow for brand customization.
*   **Authentication & Routing:** Adds a `useRedirectIfAuthenticated` hook, fixes `?to=` parameter forwarding, and adds onboarding `refineConfig` capability.
*   **Query Param Persistence:** Implements unstorage-based query param persistence with plugin-owned config in the core framework and app shell.
*   **Vite Plugin:** Modularizes the Vite plugin with schema validation and test coverage, and replaces a custom plugin with a local flag while preserving local plugins during upstream merges.

### Fixes
*   **Security:** Sanitizes redirect URLs in `useRedirectIfAuthenticated` to prevent open redirect vulnerabilities.
*   **Resilience:** Prevents query param persistence failure from aborting initialization in the core framework.
*   **Configuration:** Coerces `VITE_PORTAL_DOMAIN_IS_ROOT` to a boolean for the zod schema.
*   **IPFS/Pinner:** Extracts `src-lib`, removes the Orval client, switches to `@lumeweb/pinner`, and adds an `enabled` parameter to `usePinsCount`.
*   **Billing:** Extracts `src-lib` in the billing plugin for cross-plugin consumption.
*   **API:** Adds an `X-Total-Count` header fallback in the advanced-rest package.
<!-- kody-pr-summary:end -->