### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/goofy-kings-sort.md
+++ b/.changeset/goofy-kings-sort.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-ipfs: patch
+---
+
+## Fixes
+
+- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param

--- a/.changeset/slick-canyons-visit.md
+++ b/.changeset/slick-canyons-visit.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-billing: patch
+---
+
+## Fixes
+
+- extract src-lib for cross-plugin consumption

--- a/libs/portal-plugin-billing/CHANGELOG.md
+++ b/libs/portal-plugin-billing/CHANGELOG.md
@@ -1,19 +1,3 @@
-## 0.1.4 (2026-06-09)
-
-### Fixes
-
-#### Fixes
-
-- extract src-lib for cross-plugin consumption
-
-## 0.1.3 (2026-06-09)
-
-### Fixes
-
-#### Fixes
-
-- extract src-lib for cross-plugin consumption
-
 ## 0.1.2 (2026-06-06)
 
 ### Fixes

--- a/libs/portal-plugin-billing/package.json
+++ b/libs/portal-plugin-billing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/portal-plugin-billing",
-  "version": "0.1.4",
+  "version": "0.1.2",
   "type": "module",
   "files": [
     "lib-dist",

--- a/libs/portal-plugin-ipfs/CHANGELOG.md
+++ b/libs/portal-plugin-ipfs/CHANGELOG.md
@@ -1,19 +1,3 @@
-## 0.1.5 (2026-06-09)
-
-### Fixes
-
-#### Fixes
-
-- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param
-
-## 0.1.4 (2026-06-09)
-
-### Fixes
-
-#### Fixes
-
-- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param
-
 ## 0.1.3 (2026-06-06)
 
 ### Fixes

--- a/libs/portal-plugin-ipfs/package.json
+++ b/libs/portal-plugin-ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/portal-plugin-ipfs",
-  "version": "0.1.5",
+  "version": "0.1.3",
   "type": "module",
   "files": [
     "lib-dist",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset entries for two portal plugins and cleans up duplicate changelog entries.

**Changes:**

- **Added changeset files** for tracking version bumps:
  - `@lumeweb/portal-plugin-ipfs` (patch): Extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param
  - `@lumeweb/portal-plugin-billing` (patch): Extract src-lib for cross-plugin consumption

- **Cleaned up CHANGELOG.md files** by removing duplicate version entries:
  - `portal-plugin-billing`: Removed duplicate entries for versions 0.1.4 and 0.1.3
  - `portal-plugin-ipfs`: Removed duplicate entries for versions 0.1.5 and 0.1.4
<!-- kody-pr-summary:end -->