### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/goofy-kings-sort.md
+++ b/.changeset/goofy-kings-sort.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-ipfs: patch
+---
+
+## Fixes
+
+- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param

--- a/.changeset/slick-canyons-visit.md
+++ b/.changeset/slick-canyons-visit.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-billing: patch
+---
+
+## Fixes
+
+- extract src-lib for cross-plugin consumption

--- a/libs/portal-plugin-billing/CHANGELOG.md
+++ b/libs/portal-plugin-billing/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 0.1.5 (2026-06-09)
-
-### Fixes
-
-#### Fixes
-
-- extract src-lib for cross-plugin consumption
-
 ## 0.1.2 (2026-06-06)
 
 ### Fixes

--- a/libs/portal-plugin-billing/package.json
+++ b/libs/portal-plugin-billing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/portal-plugin-billing",
-  "version": "0.1.5",
+  "version": "0.1.2",
   "type": "module",
   "files": [
     "lib-dist",
@@ -65,6 +65,10 @@
   "peerDependencies": {
     "react": ">=18.3.1",
     "react-dom": ">=18.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LumeWeb/web"
   },
   "msw": {
     "workerDirectory": [

--- a/libs/portal-plugin-ipfs/CHANGELOG.md
+++ b/libs/portal-plugin-ipfs/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 0.1.6 (2026-06-09)
-
-### Fixes
-
-#### Fixes
-
-- extract src-lib, remove Orval client, switch to @lumeweb/pinner, add usePinsCount enabled param
-
 ## 0.1.3 (2026-06-06)
 
 ### Fixes

--- a/libs/portal-plugin-ipfs/package.json
+++ b/libs/portal-plugin-ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/portal-plugin-ipfs",
-  "version": "0.1.6",
+  "version": "0.1.3",
   "type": "module",
   "files": [
     "lib-dist",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset files to properly document recent fixes for two packages, while removing manually written changelog entries that should instead be auto-generated by the changeset tooling.

Specifically:
- **`@lumeweb/portal-plugin-ipfs`** (patch): Documents fixes including extracting src-lib, removing the Orval client, switching to `@lumeweb/pinner`, and adding a `usePinsCount` enabled param.
- **`@lumeweb/portal-plugin-billing`** (patch): Documents the fix to extract src-lib for cross-plugin consumption.

The corresponding manually maintained changelog entries (versions 0.1.6 and 0.1.5 respectively) are removed from the packages' `CHANGELOG.md` files, as they will be generated by the changeset workflow going forward.
<!-- kody-pr-summary:end -->