### PR TITLE
chore/go 1.26 and onboarding pkg

### DIFF
--- a/go/portal-abuse-report/go.mod
+++ b/go/portal-abuse-report/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-abuse-report
 
-go 1.23
+go 1.26

--- a/go/portal-admin/go.mod
+++ b/go/portal-admin/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-admin
 
-go 1.23
+go 1.26

--- a/go/portal-dashboard/go.mod
+++ b/go/portal-dashboard/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-dashboard
 
-go 1.23
+go 1.26

--- a/go/portal-frontend/go.mod
+++ b/go/portal-frontend/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-frontend
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-abuse-report/go.mod
+++ b/go/portal-plugin-abuse-report/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-abuse-report
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-abuse/go.mod
+++ b/go/portal-plugin-abuse/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-abuse
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-admin/go.mod
+++ b/go/portal-plugin-admin/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-admin
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-billing/go.mod
+++ b/go/portal-plugin-billing/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-billing
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-core/go.mod
+++ b/go/portal-plugin-core/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-core
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-dashboard/go.mod
+++ b/go/portal-plugin-dashboard/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-dashboard
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-ipfs/go.mod
+++ b/go/portal-plugin-ipfs/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-ipfs
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-lbry/go.mod
+++ b/go/portal-plugin-lbry/go.mod
@@ -1,3 +1,3 @@
 module go.lumeweb.com/web/go/portal-plugin-lbry
 
-go 1.23
+go 1.26

--- a/go/portal-plugin-onboarding/go.mod
+++ b/go/portal-plugin-onboarding/go.mod
@@ -1,0 +1,3 @@
+module go.lumeweb.com/web/go/portal-plugin-onboarding
+
+go 1.26

--- a/go/portal-plugin-onboarding/handler.go
+++ b/go/portal-plugin-onboarding/handler.go
@@ -1,0 +1,15 @@
+package portal_plugin_onboarding
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:build/*
+var appFs embed.FS
+
+func GetFS() fs.FS {
+	appFiles, _ := fs.Sub(appFs, "build")
+
+	return appFiles
+}


### PR DESCRIPTION
- **chore: update Go modules to 1.26**
- **feat: add portal-plugin-onboarding Go package**

---

<!-- kody-pr-summary:start -->
Add onboarding plugin package with embedded filesystem support

This PR introduces a new `portal-plugin-onboarding` Go package that embeds and serves static frontend assets from a `build` directory. The package provides a `GetFS()` function that returns an `fs.FS` interface for the embedded build artifacts, enabling the onboarding UI to be distributed as part of the compiled binary.
<!-- kody-pr-summary:end -->