### PR TITLE
fix(onboarding): remove unused tailwind/postcss config and CSS import

### DIFF
--- a/libs/portal-plugin-onboarding/postcss.config.cjs
+++ b/libs/portal-plugin-onboarding/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};

--- a/libs/portal-plugin-onboarding/src/ui/widgets/onboarding/checklist.tsx
+++ b/libs/portal-plugin-onboarding/src/ui/widgets/onboarding/checklist.tsx
@@ -1,4 +1,3 @@
-import "@lumeweb/portal-framework-ui-core/tailwind-plugin.css";
 import { OnboardingChecklist } from "@/ui/components/OnboardingChecklist";
 
 export default function OnboardingChecklistWidget() {

--- a/libs/portal-plugin-onboarding/tailwind.config.ts
+++ b/libs/portal-plugin-onboarding/tailwind.config.ts
@@ -1,9 +1,0 @@
-import type { Config } from "tailwindcss";
-
-export default {
-  content: ["./src/**/*.{js,ts,jsx,tsx}"],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-} satisfies Config;


### PR DESCRIPTION
The generated Tailwind CSS was unnecessary and caused style conflicts
on the login/register screens. Remove postcss.config.cjs,
tailwind.config.ts, and the tailwind-plugin.css import from the
onboarding checklist widget.

---

<!-- kody-pr-summary:start -->
Remove unused Tailwind CSS import from onboarding checklist widget

This PR removes the unused `@lumeweb/portal-framework-ui-core/tailwind-plugin.css` import from the onboarding checklist widget, cleaning up unnecessary Tailwind/PostCSS configuration that was not being utilized.
<!-- kody-pr-summary:end -->