### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/tidy-pugs-dance.md
+++ b/.changeset/tidy-pugs-dance.md
@@ -1,0 +1,7 @@
+---
+"@lumeweb/portal-plugin-onboarding": patch
+---
+
+# Fixes 
+
+Remove unused Tailwind/PostCSS config and CSS import that caused style conflicts on login/register screens


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Remove unused Tailwind/PostCSS configuration and CSS import that was causing style conflicts on the login and register screens in the portal onboarding plugin.
<!-- kody-pr-summary:end -->