### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/tidy-pugs-dance.md
+++ b/.changeset/tidy-pugs-dance.md
@@ -1,5 +1,5 @@
 ---
-"@lumeweb/portal-plugin-onboarding": patch
+@lumeweb/portal-plugin-onboarding: patch
 ---
 
 # Fixes 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fix changeset package name formatting by removing unnecessary quotes around the package identifier in the changeset frontmatter.
<!-- kody-pr-summary:end -->