### PR TITLE
chore: update knope

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -73,6 +73,11 @@ changelog = "libs/portal-plugin-billing/CHANGELOG.md"
 versioned_files = ["libs/portal-plugin-ipfs/package.json"]
 changelog = "libs/portal-plugin-ipfs/CHANGELOG.md"
 
+[packages."@lumeweb/portal-plugin-onboarding"]
+versioned_files = ["libs/portal-plugin-onboarding/package.json"]
+changelog = "libs/portal-plugin-onboarding/CHANGELOG.md"
+
+
 [packages."@lumeweb/portal-sdk"]
 versioned_files = ["libs/portal-sdk/package.json"]
 changelog = "libs/portal-sdk/CHANGELOG.md"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add Knope configuration for the `@lumeweb/portal-plugin-onboarding` package

This PR registers the `@lumeweb/portal-plugin-onboarding` package in `knope.toml`, enabling automated versioning and changelog generation for it. The configuration follows the same pattern as existing portal plugin packages, pointing to the package's `package.json` for version tracking and its `CHANGELOG.md` for changelog output.
<!-- kody-pr-summary:end -->