### PR TITLE
fix: shell quote leak in release-go workflow target passing

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -63,37 +63,31 @@ jobs:
       - name: Release
         id: release
         run: |
-          args=""
+          ARGS=()
           
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ inputs.targets }}" != "all" ]; then
-              args="$args --targets '${{ inputs.targets }}'"
+              ARGS+=("--targets" "${{ inputs.targets }}")
             fi
             if [ "${{ inputs.force }}" = "true" ]; then
-              args="$args --force"
+              ARGS+=("--force")
             fi
             if [ "${{ inputs.no_push }}" = "true" ]; then
-              args="$args --no-push"
+              ARGS+=("--no-push")
             fi
             if [ "${{ inputs.verbose }}" = "true" ]; then
-              args="$args --verbose"
+              ARGS+=("--verbose")
             fi
             if [ "${{ inputs.dry_run }}" = "true" ]; then
-              args="$args --dry-run"
+              ARGS+=("--dry-run")
             fi
             if [ "${{ inputs.validate_only }}" = "true" ]; then
-              args="$args --validate-only"
-            fi
-            if [ "${{ inputs.force }}" = "true" ]; then
-              args="$args --force"
-            fi
-            if [ "${{ inputs.no_push }}" = "true" ]; then
-              args="$args --no-push"
+              ARGS+=("--validate-only")
             fi
           fi
           
-          echo "Running: python scripts/release-go.py $args"
-          python scripts/release-go.py $args
+          echo "Running: python scripts/release-go.py ${ARGS[*]}"
+          python scripts/release-go.py "${ARGS[@]}"
 
       - name: Get modified apps info
         id: get_modified_apps

--- a/scripts/release-go.py
+++ b/scripts/release-go.py
@@ -878,7 +878,7 @@ def filter_targets(registry: BuildRegistry, target_filter: str) -> List[BuildTar
         logger.info(f"Available targets: {sorted(registry.targets.keys())}")
         return list(registry.targets.values())
     
-    requested_targets = [t.strip() for t in target_filter.split(",")]
+    requested_targets = [t.strip().strip('\'"') for t in target_filter.split(",")]
     filtered_targets = []
     
     for target_name in requested_targets:


### PR DESCRIPTION
The workflow built args via string concatenation with literal single
quotes inside: args="$args --targets '${{ inputs.targets }}'".
Since $args was unquoted on invocation, bash didn't re-process the
quotes — they passed through as literal characters to argparse,
making the target name 'onboarding' (with quotes) instead of
onboarding.

Switch to bash array (ARGS+=) with proper "${ARGS[@]}" expansion
so values pass through cleanly. Also strip quote characters in the
Python filter_targets() as defense-in-depth, and remove duplicate
--force/--no-push checks in the workflow.

---

<!-- kody-pr-summary:start -->
Fix shell quote leaking in release-go workflow target passing

The release-go workflow had a shell quoting issue where single quotes around the `--targets` input value were being passed literally to the Python script instead of being interpreted as shell quoting. This caused target names to include stray quotes (e.g., `'target1,target2'`), leading to target matching failures.

Changes:
- **`.github/workflows/release-go.yml`**: Replaced string concatenation (`args="$args ..."`) with proper bash arrays (`ARGS+=()`) and array expansion (`"${ARGS[@]}"`), which correctly handles argument boundaries without quote leaking. Also removed duplicate `--force` and `--no-push` flag checks that were present in the original code.
- **`scripts/release-go.py`**: Added defensive `.strip('\'"')` when parsing the targets filter, stripping any leading/trailing single or double quotes from target names as a safety measure against quote leakage from any invocation method.
<!-- kody-pr-summary:end -->