### PR TITLE
feat(pinner.xyz): add robots.txt integration, canonical URLs, and trailing slash

### DIFF
--- a/apps/pinner.xyz/astro.config.mjs
+++ b/apps/pinner.xyz/astro.config.mjs
@@ -2,6 +2,7 @@
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import mdx from "@astrojs/mdx";
+import robotsTxt from "astro-robots-txt";
 import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import mdAlternate from "astro-md-alternate";
@@ -10,10 +11,12 @@ import llms from "astro-llms-md";
 // https://astro.build/config
 export default defineConfig({
   site: "https://pinner.xyz",
+  trailingSlash: "always",
   integrations: [
     react(),
     sitemap(),
     mdx(),
+    robotsTxt(),
     mdAlternate({
       collections: [],
     }),

--- a/apps/pinner.xyz/package.json
+++ b/apps/pinner.xyz/package.json
@@ -21,6 +21,7 @@
     "astro": "catalog:",
     "astro-llms-md": "catalog:websites",
     "astro-md-alternate": "catalog:websites",
+    "astro-robots-txt": "catalog:websites",
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",
     "lucide-react": "catalog:",

--- a/apps/pinner.xyz/src/layouts/LegalLayout.astro
+++ b/apps/pinner.xyz/src/layouts/LegalLayout.astro
@@ -7,6 +7,7 @@ import { getGitLastUpdated } from "@/lib/last-updated";
 const { title } = Astro.props;
 const frontmatter = Astro.props.frontmatter || {};
 const lastUpdated = getGitLastUpdated();
+const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? "https://pinner.xyz");
 
 const formattedDate = frontmatter.last_updated
   ? new Date(frontmatter.last_updated).toLocaleDateString("en-US", {
@@ -24,6 +25,7 @@ const formattedDate = frontmatter.last_updated
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
+    <link rel="canonical" href={canonicalURL.href} />
     <title>Pinner - {title}</title>
   </head>
   <body class="bg-white antialiased">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,9 @@ importers:
       astro-md-alternate:
         specifier: catalog:websites
         version: 0.1.0(astro@6.3.2(@types/node@25.9.1)(idb-keyval@6.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.48.0)(yaml@2.9.0))
+      astro-robots-txt:
+        specifier: catalog:websites
+        version: 1.0.0
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1


### PR DESCRIPTION
- Add astro-robots-txt integration to generate robots.txt
- Add canonical link tag in LegalLayout using Astro.site
- Enable trailingSlash: always for consistent URL resolution
- Add astro-robots-txt dependency via catalog:websites

---

<!-- kody-pr-summary:start -->
This pull request adds SEO improvements to the pinner.xyz site, specifically:

- **robots.txt integration**: Adds the `astro-robots-txt` integration to automatically generate a robots.txt file for search engine crawlers.
- **Canonical URLs**: Adds canonical URL `<link>` tags to the Legal layout, constructed from the current pathname and the site URL, to prevent duplicate content issues in search engine indexing.
- **Trailing slash enforcement**: Configures Astro to always append trailing slashes to URLs (`trailingSlash: "always"`), ensuring consistent URL formatting across the site.
<!-- kody-pr-summary:end -->