### PR TITLE
feat/pinner upload retry timeout

### DIFF
--- a/libs/pinner/src/config.ts
+++ b/libs/pinner/src/config.ts
@@ -47,14 +47,30 @@ export interface PinnerConfig {
 
   /**
    * Custom base name for Helia storage.
-   * Passed as the `base` option to both blockstore and datastore storage instances.
+   * Passed as the base option to both blockstore and datastore storage instances.
    * Only used when neither datastore nor storage are provided.
    * @default "pinner-helia-data"
    */
   datastoreName?: string;
+
+  /**
+   * Upload request timeout in milliseconds.
+   * Applied to XHR uploads. TUS does not expose a timeout option.
+   * @default 120_000
+   */
+  timeout?: number;
+
+  /**
+   * Number of retry attempts for failed uploads.
+   * Applied to XHR uploads (TUS uses retryDelays instead).
+   * @default 3
+   */
+  retries?: number;
 }
 
 export const DEFAULT_CONFIG: Partial<PinnerConfig> = {
   endpoint: DEFAULT_ENDPOINT,
   gateway: DEFAULT_GATEWAY,
+  timeout: 120_000,
+  retries: 3,
 };

--- a/libs/pinner/src/upload/xhr-upload.ts
+++ b/libs/pinner/src/upload/xhr-upload.ts
@@ -13,6 +13,8 @@ export class XHRUploadHandler extends BaseUploadHandler {
       headers: {
         Authorization: `Bearer ${this.config.jwt}`,
       },
+      timeout: this.config.timeout,
+      retries: this.config.retries,
     });
   }
 

--- a/libs/uppy-post-upload/src/network/node/retry.ts
+++ b/libs/uppy-post-upload/src/network/node/retry.ts
@@ -15,14 +15,14 @@
 // ky's default retry options (extracted from normalizeRetryOptions)
 export const DEFAULT_RETRY_OPTIONS = {
   limit: 2,
-  methods: ['get', 'put', 'head', 'delete', 'options', 'trace'] as const,
+  methods: ['get', 'post', 'put', 'head', 'delete', 'options', 'trace'] as const,
   statusCodes: [408, 413, 429, 500, 502, 503, 504] as const,
   afterStatusCodes: [413, 429, 503] as const,
   maxRetryAfter: Number.POSITIVE_INFINITY,
   backoffLimit: Number.POSITIVE_INFINITY,
   delay: (attemptCount: number) => 0.3 * (2 ** (attemptCount - 1)) * 1000,
   jitter: undefined,
-  retryOnTimeout: false,
+  retryOnTimeout: true,
 } as const;
 
 export interface RetryOptions {


### PR DESCRIPTION
- **fix(uppy-post-upload): enable retry on timeout and include POST in retry methods**
- **feat(pinner): add timeout and retries config for uploads**

---

<!-- kody-pr-summary:start -->
Add configurable upload timeout and retry settings for the pinner, and enable retries on POST requests and timeouts

This PR introduces timeout and retry configuration options for pinner uploads and updates the default retry behavior to cover upload scenarios:

- **New config options**: Added `timeout` (default: 120,000ms) and `retries` (default: 3) to `PinnerConfig`, which are passed through to XHR uploads.
- **Retry on POST requests**: Added `'post'` to the default retryable HTTP methods, so failed upload requests are automatically retried.
- **Retry on timeout**: Changed `retryOnTimeout` default from `false` to `true`, ensuring timed-out requests are retried rather than immediately failing.
<!-- kody-pr-summary:end -->