### PR TITLE
ci: add IndexNow actions and integrate into lumeweb.com deploy

### DIFF
--- a/.github/actions/indexnow-write-key/action.yml
+++ b/.github/actions/indexnow-write-key/action.yml
@@ -1,0 +1,20 @@
+name: "IndexNow Write Key"
+description: "Write the IndexNow verification key file into the Astro public/ folder before build"
+inputs:
+  public-path:
+    description: "Path to the build output directory (e.g. apps/lumeweb.com/dist)"
+    required: true
+  key:
+    description: "IndexNow API key to write into the verification file"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Write key file
+      shell: bash
+      env:
+        PUBLIC_PATH: ${{ inputs.public-path }}
+        KEY: ${{ inputs.key }}
+      run: |
+        printf '%s' "${KEY}" > "${PUBLIC_PATH}/${KEY}.txt"
+        echo "Wrote ${PUBLIC_PATH}/${KEY}.txt"

--- a/.github/actions/indexnow/action.yml
+++ b/.github/actions/indexnow/action.yml
@@ -1,0 +1,85 @@
+name: "IndexNow Submit"
+description: "Extract URLs from Astro sitemap XML and submit to IndexNow (Bing, Yandex, etc.)"
+inputs:
+  build-path:
+    description: "Path to the Astro build output directory (containing sitemap XML files)"
+    required: true
+  site:
+    description: "Site hostname (e.g. lumeweb.com)"
+    required: true
+  key:
+    description: "IndexNow API key (min 8 hex chars, must match the key file hosted at root)"
+    required: true
+  search-engine:
+    description: "IndexNow endpoint search engine host (default: api.indexnow.org)"
+    required: false
+    default: "api.indexnow.org"
+runs:
+  using: "composite"
+  steps:
+    - name: Install yq
+      uses: mikefarah/yq@v4
+
+    - name: Extract URLs and submit to IndexNow
+      shell: bash
+      env:
+        BUILD_PATH: ${{ inputs.build-path }}
+        SITE: ${{ inputs.site }}
+        KEY: ${{ inputs.key }}
+        SEARCH_ENGINE: ${{ inputs.search-engine }}
+      run: |
+        set -euo pipefail
+
+        echo "::group::Extracting URLs from sitemaps"
+
+        URL_LIST=$(mktemp)
+
+        for xml_file in "${BUILD_PATH}"/sitemap*.xml; do
+          [ -f "$xml_file" ] || continue
+          yq '.. | select(has("loc")) | .loc' -o=props "$xml_file" >> "$URL_LIST" || true
+        done
+
+        SORTED_URLS=$(sort -u "$URL_LIST" | sed '/^[[:space:]]*$/d')
+        URL_COUNT=$(echo "$SORTED_URLS" | wc -l | tr -d ' ')
+
+        if [ "$URL_COUNT" -eq 0 ]; then
+          echo "::warning::No URLs found in sitemaps under ${BUILD_PATH}"
+          rm -f "$URL_LIST"
+          exit 0
+        fi
+
+        echo "Found ${URL_COUNT} URLs to submit"
+        echo "$SORTED_URLS"
+        echo "::endgroup::"
+
+        URL_JSON=$(echo "$SORTED_URLS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+        PAYLOAD=$(jq -n \
+          --arg host "${SITE}" \
+          --arg key "${KEY}" \
+          --argjson urlList "$URL_JSON" \
+          '{host: $host, key: $key, urlList: $urlList}')
+
+        echo "::group::Submitting to IndexNow"
+        echo "POST https://${SEARCH_ENGINE}/indexnow"
+
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+          -X POST "https://${SEARCH_ENGINE}/indexnow" \
+          -H "Content-Type: application/json; charset=utf-8" \
+          -d "$PAYLOAD")
+
+        echo "IndexNow response: HTTP ${HTTP_CODE}"
+
+        if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 202 ]; then
+          echo "✅ IndexNow submission successful"
+        elif [ "$HTTP_CODE" -eq 403 ]; then
+          echo "::error::IndexNow 403 — key file not found or key mismatch at https://${SITE}/${KEY}.txt"
+          exit 1
+        elif [ "$HTTP_CODE" -eq 429 ]; then
+          echo "::warning::IndexNow 429 — rate limited, try again later"
+        else
+          echo "::warning::IndexNow returned HTTP ${HTTP_CODE} (expected 200/202)"
+        fi
+        echo "::endgroup::"
+
+        rm -f "$URL_LIST"

--- a/.github/actions/indexnow/action.yml
+++ b/.github/actions/indexnow/action.yml
@@ -40,6 +40,13 @@ runs:
         done
 
         SORTED_URLS=$(sort -u "$URL_LIST" | sed '/^[[:space:]]*$/d')
+
+        if [ -z "$SORTED_URLS" ]; then
+          echo "::warning::No URLs found in sitemaps under ${BUILD_PATH}"
+          rm -f "$URL_LIST"
+          exit 0
+        fi
+
         URL_COUNT=$(echo "$SORTED_URLS" | wc -l | tr -d ' ')
 
         if [ "$URL_COUNT" -eq 0 ]; then

--- a/.github/workflows/deploy-lumeweb.com.yml
+++ b/.github/workflows/deploy-lumeweb.com.yml
@@ -24,6 +24,11 @@ jobs:
         uses: LumeWeb/workflows/.github/actions/setup-all@develop
       - name: Build
         run: pnpm build:lumeweb.com
+      - name: Write IndexNow key file
+        uses: ./.github/actions/indexnow-write-key
+        with:
+          public-path: apps/lumeweb.com/dist
+          key: ${{ vars.INDEXNOW_KEY_LUMEWEB }}
       - name: Deploy to IPFS via Pinner
         id: deploy_pinner
         uses: lumeweb/pinner-deploy-action@v0
@@ -32,3 +37,9 @@ jobs:
           path: apps/lumeweb.com/dist
           domain: lumeweb.com
           remove-previous: true
+      - name: Submit URLs to IndexNow
+        uses: ./.github/actions/indexnow
+        with:
+          build-path: apps/lumeweb.com/dist
+          site: lumeweb.com
+          key: ${{ vars.INDEXNOW_KEY_LUMEWEB }}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add IndexNow integration to the lumeweb.com deployment pipeline, enabling automatic submission of sitemap URLs to search engines (Bing, Yandex, etc.) after each deploy.

Two new reusable composite actions are introduced:

- **`indexnow-write-key`**: Writes the IndexNow verification key file into the build output directory so it gets deployed alongside the site, satisfying the protocol's key verification requirement.
- **`indexnow`**: Extracts URLs from sitemap XML files in the build output, constructs the IndexNow API payload, and submits it to the IndexNow endpoint. Handles success (200/202), key mismatch (403), and rate limiting (429) responses.

The `deploy-lumeweb.com.yml` workflow is updated to call these actions in sequence: the key file is written after build (before deploy) so it's hosted at the site root, and URL submission occurs after deployment to ensure all submitted URLs are live.
<!-- kody-pr-summary:end -->