### PR TITLE
fix(ci): filter sitemap XML URLs from IndexNow submissions

### DIFF
--- a/.github/actions/indexnow/action.yml
+++ b/.github/actions/indexnow/action.yml
@@ -39,7 +39,7 @@ runs:
           yq '.. | select(has("loc")) | .loc' -o=props "$xml_file" >> "$URL_LIST" || true
         done
 
-        SORTED_URLS=$(sort -u "$URL_LIST" | sed '/^[[:space:]]*$/d')
+        SORTED_URLS=$(sort -u "$URL_LIST" | sed '/^[[:space:]]*$/d' | sed '/\.xml$/d')
 
         if [ -z "$SORTED_URLS" ]; then
           echo "::warning::No URLs found in sitemaps under ${BUILD_PATH}"
@@ -48,12 +48,6 @@ runs:
         fi
 
         URL_COUNT=$(echo "$SORTED_URLS" | wc -l | tr -d ' ')
-
-        if [ "$URL_COUNT" -eq 0 ]; then
-          echo "::warning::No URLs found in sitemaps under ${BUILD_PATH}"
-          rm -f "$URL_LIST"
-          exit 0
-        fi
 
         echo "Found ${URL_COUNT} URLs to submit"
         echo "$SORTED_URLS"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Filter out sitemap XML URLs from IndexNow submissions

The IndexNow action was incorrectly including sitemap XML file URLs (e.g., `sitemap.xml`) in the list of URLs submitted to search engines. Sitemap files are index files for discovering content URLs, not content pages themselves, so submitting them to IndexNow is unnecessary and incorrect. This fix adds a `sed` filter to remove any URLs ending in `.xml` from the sorted URL list. Additionally, a redundant zero-URL-count check was removed since the empty-string check above already handles that case.
<!-- kody-pr-summary:end -->