### PR TITLE
ci: integrate IndexNow actions into pinner.xyz deploy

### DIFF
--- a/.github/workflows/deploy-pinner.xyz.yml
+++ b/.github/workflows/deploy-pinner.xyz.yml
@@ -33,6 +33,11 @@ jobs:
           directory: apps/pinner.xyz
       - name: Build
         run: pnpm build:pinner.xyz
+      - name: Write IndexNow key file
+        uses: ./.github/actions/indexnow-write-key
+        with:
+          public-path: apps/pinner.xyz/dist
+          key: ${{ vars.INDEXNOW_KEY_PINNER }}
       - name: Deploy to IPFS via Pinner
         id: deploy_pinner
         uses: lumeweb/pinner-deploy-action@v0
@@ -41,3 +46,9 @@ jobs:
           path: apps/pinner.xyz/dist
           domain: pinner.xyz
           remove-previous: true
+      - name: Submit URLs to IndexNow
+        uses: ./.github/actions/indexnow
+        with:
+          build-path: apps/pinner.xyz/dist
+          site: pinner.xyz
+          key: ${{ vars.INDEXNOW_KEY_PINNER }}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request integrates IndexNow support into the pinner.xyz deployment workflow. It adds two new steps to the CI pipeline:

1. **Write IndexNow key file** — Before deployment, the IndexNow verification key file is written into the build output directory so it gets deployed alongside the site content.
2. **Submit URLs to IndexNow** — After deployment, the site's URLs are submitted to the IndexNow protocol to notify search engines of content updates, enabling faster indexing of the pinner.xyz site.

Both steps use the `INDEXNOW_KEY_PINNER` repository variable for authentication.
<!-- kody-pr-summary:end -->