### PR TITLE
fix(pinner.xyz): remove duplicate h1 tags from PageHeader component

### DIFF
--- a/apps/pinner.xyz/src/components/PageHeader.tsx
+++ b/apps/pinner.xyz/src/components/PageHeader.tsx
@@ -2,8 +2,7 @@ import { TrackedButton } from "@/components/TrackedButton";
 import BgShape from "@/assets/hero-shape.svg";
 
 interface PageHeaderProps {
-	title?: string;
-	mobileTitle?: string;
+	title: string;
 	description?: string;
 	btnText?: string;
 	url?: string;
@@ -14,7 +13,6 @@ interface PageHeaderProps {
 
 const PageHeader = ({
   title,
-  mobileTitle,
   description,
   btnText,
   url,

--- a/apps/pinner.xyz/src/components/PageHeader.tsx
+++ b/apps/pinner.xyz/src/components/PageHeader.tsx
@@ -31,12 +31,8 @@ const PageHeader = ({
           className="absolute left-0 top-0 max-w-max"
         />
         <div className="text-left md:text-center md:max-w-[810px] mx-auto relative z-10">
-          <h1 className="text-[60px] text-home-text leading-[60px] font-medium hidden md:block">
+          <h1 className="text-[38px] md:text-[60px] text-home-text leading-[48px] md:leading-[60px] font-medium">
             {title}
-          </h1>
-
-          <h1 className="text-[38px] text-home-text leading-[48px] font-medium md:hidden">
-            {mobileTitle}
           </h1>
 
           {description && (

--- a/apps/pinner.xyz/src/pages/about.astro
+++ b/apps/pinner.xyz/src/pages/about.astro
@@ -17,7 +17,6 @@ import AboutHowItWorks from "@/assets/about-how-it-works.jpg";
 <Layout title="Decentralized Storage That Respects Your Data" variant="home" ogImage="/images/og-about.png" description="A small business building storage infrastructure that respects your data. Zero-knowledge encryption, open source, built on the Sia decentralized network.">
   <PageHeader
     title="Why we're building Pinner"
-    mobileTitle="Why we're building Pinner"
     description="A small business building storage infrastructure that respects your data."
     btnText="Start Pinning →"
     url={config.registerUrl()}

--- a/apps/pinner.xyz/src/pages/alternatives/cloudflare-pages/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/cloudflare-pages/index.astro
@@ -53,7 +53,6 @@ const faqs = [
 <Layout title="Cloudflare Pages Alternative for Static Site Hosting | Pinner" description="Static site hosting on the Sia network with crypto payments, no KYC, no file caps, and open-source code. 5 USD/mo, works with any DNS provider.">
   <PageHeader
     title="Static hosting with no file caps and no DNS lock-in"
-    mobileTitle="Cloudflare Pages Alternative"
     description="5 USD/mo for 250 GB bandwidth. Crypto or card, no KYC for crypto. No file count limits, no file size limits, works with any DNS provider."
     btnText="Start Hosting →"
     url={config.registerUrl("hosting")}

--- a/apps/pinner.xyz/src/pages/alternatives/filebase/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/filebase/index.astro
@@ -53,7 +53,6 @@ const faqs = [
 <Layout title="Filebase Sites Alternative for Static Site Hosting | Pinner" description="Static site hosting on the Sia network with crypto payments, no KYC, and open-source code. 5 USD/mo, one product, one price.">
   <PageHeader
     title="Static hosting, one product, one price"
-    mobileTitle="Filebase Alternative"
     description="5 USD/mo for 250 GB bandwidth. Crypto or card, no KYC for crypto. Your data lives on a network of independent hosts, not one company's servers."
     btnText="Start Hosting →"
     url={config.registerUrl("hosting")}

--- a/apps/pinner.xyz/src/pages/alternatives/fleek/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/fleek/index.astro
@@ -57,7 +57,6 @@ const faqs = [
 <Layout title="Fleek Alternative for Static Site Hosting | Pinner" description="Fleek's IPFS hosting shut down in January 2026. Deploy your static site on Pinner. Data stored on the Sia network by independent hosts who are paid to store it.">
   <PageHeader
     title="A host that's built to stick around"
-    mobileTitle="Fleek Alternative"
     description="Fleek's hosting shut down in January 2026 and took sites with it. Your data on Pinner lives on a network of independent hosts paid to keep it, not on our servers. Pay with crypto or card. No KYC for crypto."
     btnText="Start Hosting →"
     url={config.registerUrl("hosting")}

--- a/apps/pinner.xyz/src/pages/alternatives/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/index.astro
@@ -11,7 +11,6 @@ const sorted = alternatives.sort((a, b) => (a.data.featured === b.data.featured 
   <PageHeader
     title="Compare Pinner against other platforms"
     description="A simple index of our comparison pages. If you are weighing Pinner against another hosting, storage, or pinning platform, you can start here."
-    mobileTitle="Compare Pinner"
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/alternatives/netlify/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/netlify/index.astro
@@ -50,7 +50,6 @@ const faqs = [
 <Layout title="Netlify Alternative for Static Site Hosting | Pinner" description={`Flat-rate static site hosting with no per-seat pricing, no overage rates, and permanent links. ${worksWithFrameworks({ andMore: false })}`}>
   <PageHeader
     title="Flat pricing. No credit math. No overages."
-    mobileTitle="Netlify Alternative"
     description={`Pinner skips the credit math. Pay for storage and bandwidth directly with no per-seat charges and no overage rates. ${worksWithFrameworks({ format: "technical" })} Pay with crypto or card. No KYC for crypto.`}
     btnText="Start Hosting →"
     url={config.registerUrl("hosting")}

--- a/apps/pinner.xyz/src/pages/alternatives/pinata/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/pinata/index.astro
@@ -60,7 +60,6 @@ const faqs = [
 <Layout title="Pinata Alternative: IPFS Pinning with Website Hosting & No-KYC Payments | Pinner" description="IPFS pinning with no-KYC crypto payments, website hosting, and private storage on a decentralized network. We help you migrate.">
   <PageHeader
     title="IPFS pinning with website hosting and decentralized storage"
-    mobileTitle="Pinata Alternative"
     description="Pay with crypto (no KYC) or use a card. Host websites from pinned content and store on a decentralized network. Need help migrating? We'll work with you."
     btnText="Start Pinning →"
     url={config.registerUrl("pinning")}

--- a/apps/pinner.xyz/src/pages/alternatives/vercel/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/vercel/index.astro
@@ -56,7 +56,6 @@ const faqs = [
 <Layout title="Vercel Alternative for Static Site Hosting | Pinner" description={`Static site hosting with no per-seat pricing, no overage rates, and permanent links. ${worksWithFrameworks({ andMore: false })}`}>
   <PageHeader
     title="No per-seat pricing. No bandwidth surprises."
-    mobileTitle="Vercel Alternative"
     description={`Hit a bandwidth bill you didn't expect? Pinner hosts static sites with no per-seat charges and no overage rates. ${worksWithFrameworks({ format: "technical" })} Pay with crypto or card. No KYC for crypto.`}
     btnText="Start Hosting →"
     url={config.registerUrl("hosting")}

--- a/apps/pinner.xyz/src/pages/contact.astro
+++ b/apps/pinner.xyz/src/pages/contact.astro
@@ -13,7 +13,6 @@ const ctaClass = "inline-block py-3 md:py-4 px-7 bg-[#E4E0D4] text-[#0D1D1C] fon
   <PageHeader
     title="Connect with the community"
     description="Get help and join the discussion"
-    mobileTitle="Connect with us"
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/how-it-works.astro
+++ b/apps/pinner.xyz/src/pages/how-it-works.astro
@@ -16,7 +16,6 @@ import StorageMobile from "@/assets/how-it-works-mobile-2.png";
   <PageHeader
     title="Simple interface, powerful network"
     description="IPFS pinning, website hosting, and private storage on a decentralized network"
-    mobileTitle="How Pinner Works"
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/partners.astro
+++ b/apps/pinner.xyz/src/pages/partners.astro
@@ -12,7 +12,6 @@ import IPFSImage from "@/assets/partners-ipfs.jpg";
 <Layout title="Revenue Sharing Program for Sia & IPFS Developers" description="Build on Pinner. Revenue sharing for Sia app builders, integration support for IPFS developers, and custom pricing for businesses needing 10TB+.">
   <PageHeader
     title="Build on Pinner"
-    mobileTitle="Partners"
     description="Sia app builders, IPFS developers, and businesses. Let's find what works."
     client:load
   />

--- a/apps/pinner.xyz/src/pages/pricing.astro
+++ b/apps/pinner.xyz/src/pages/pricing.astro
@@ -61,7 +61,6 @@ const pricingFaqs = [
   <PageHeader
     title="Simple pricing. No surprises."
     description="<a href='/solutions/ipfs-pinning' class='underline hover:text-white transition-colors'>IPFS pinning</a> and hosting plans. <a href='/solutions/private-storage' class='underline hover:text-white transition-colors'>Private storage</a> for personal use and developer integrations."
-    mobileTitle="Storage Options"
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/solutions/ipfs-pinning.astro
+++ b/apps/pinner.xyz/src/pages/solutions/ipfs-pinning.astro
@@ -55,7 +55,6 @@ const faqs = [
 <Layout title="IPFS Pinning Service & Decentralized Storage" description="Pin files to IPFS and get a permanent link that stays online as long as it's pinned. Decentralized, content-addressed, no vendor lock-in.">
   <PageHeader
     title="IPFS pinning that stays online"
-    mobileTitle="IPFS Pinning"
     description="Pin files to a peer-to-peer network. Your content gets a permanent link that stays accessible as long as it's pinned."
     btnText="Start Pinning →"
     url={config.registerUrl("pinning")}

--- a/apps/pinner.xyz/src/pages/solutions/private-storage.astro
+++ b/apps/pinner.xyz/src/pages/solutions/private-storage.astro
@@ -12,7 +12,6 @@ import { ctaCopy } from '@/lib/config';
 <Layout title="Private, Encrypted Storage: Coming Soon | Pinner" description="Only you hold the keys. Zero-knowledge encrypted storage on the Sia network. Coming soon.">
   <PageHeader
     title="Private, Encrypted Storage"
-    mobileTitle="Private Storage"
     description="Only you hold the keys. Zero-knowledge encryption on the Sia network."
     client:load
   />

--- a/apps/pinner.xyz/src/pages/solutions/private-storage/developers.astro
+++ b/apps/pinner.xyz/src/pages/solutions/private-storage/developers.astro
@@ -35,7 +35,6 @@ const faqs = [
 <Layout title="Build Apps on Encrypted Storage: Coming Soon | Developer Platform" description="Build applications on encrypted, peer-to-peer storage. S3-compatible API, revenue sharing for app developers, and the Sia SDK for direct access. Coming soon.">
   <PageHeader
     title="Build Apps on Encrypted Storage"
-    mobileTitle="Developer Platform"
     description="Build applications on encrypted, peer-to-peer storage. S3-compatible API for object storage, revenue sharing when your users store data, and the Sia SDK for direct access."
     client:load
   />

--- a/apps/pinner.xyz/src/pages/solutions/private-storage/personal.astro
+++ b/apps/pinner.xyz/src/pages/solutions/private-storage/personal.astro
@@ -42,7 +42,6 @@ const faqs = [
 <Layout title="Private Storage for Your Data: Coming Soon | Pinner" description="Store your files privately with zero-knowledge encryption on the Sia network. Coming soon.">
   <PageHeader
     title="Private Storage for Your Data"
-    mobileTitle="Private Storage"
     description="Store your files privately with zero-knowledge encryption on the Sia network. Your keys, your data. No one can read your files without your key. Not us, not the storage hosts."
     client:load
   />

--- a/apps/pinner.xyz/src/pages/solutions/s3-storage.astro
+++ b/apps/pinner.xyz/src/pages/solutions/s3-storage.astro
@@ -43,7 +43,6 @@ const faqs = [
 <Layout title="S3-Compatible Storage on a Peer-to-Peer Network" description="Drop-in S3-compatible storage on a peer-to-peer network. Use your existing tools: AWS CLI, boto3, rclone, Terraform. Encrypted by default. No vendor lock-in.">
   <PageHeader
     title="S3-Compatible Storage on a Peer-to-Peer Network"
-    mobileTitle="S3 Storage"
     description="Use your existing S3 tools with your self-hosted gateway. Same API, your endpoint. Encrypted by default."
     btnText="Start Storing →"
     url={config.registerUrl("storing")}

--- a/apps/pinner.xyz/src/pages/solutions/website-hosting.astro
+++ b/apps/pinner.xyz/src/pages/solutions/website-hosting.astro
@@ -48,7 +48,6 @@ const faqs = [
 <Layout title="Static Website Hosting: Permanent, No Lock-In | Pinner" description={`Host static websites with permanent links. No vendor lock-in, no surprise bills. ${worksWithFrameworks()}`}>
   <PageHeader
     title="Static site hosting that stays up"
-    mobileTitle="Website Hosting"
     description={`Host static websites with a permanent address. No vendor lock-in, no surprise bills. ${worksWithFrameworks()} Pay with crypto or card. No ID required for crypto.`}
     btnText="Host a Website →"
     url={config.registerUrl("hosting")}


### PR DESCRIPTION
PageHeader.tsx rendered two h1 elements (desktop + mobile) with `hidden`/`md:hidden` for responsive switching. This violates SEO best practice — search engines see two h1 tags per page.

Replaced with a single h1 using Tailwind responsive font sizing (`text-[38px] md:text-[60px]`). The `mobileTitle` prop is no longer used for h1 content — `title` is the canonical heading for both viewports.

Fixes duplicate h1 on 18 pages: pricing, about, contact, all `alternatives/*`, all `solutions/*`, how-it-works, partners.

---

<!-- kody-pr-summary:start -->
Fix duplicate h1 tags in PageHeader component for SEO/accessibility compliance

The PageHeader component previously rendered two separate `<h1>` tags — one visible on desktop (`hidden md:block`) and one visible on mobile (`md:hidden`) — resulting in duplicate h1 elements in the DOM. This change consolidates them into a single `<h1>` tag using responsive Tailwind classes (`text-[38px] md:text-[60px]`, `leading-[48px] md:leading-[60px]`) to handle both viewports, eliminating the duplicate heading issue.
<!-- kody-pr-summary:end -->