### PR TITLE
fix: correct folder bundle upload progress % exceeding 100%

### DIFF
--- a/libs/portal-plugin-dashboard/src/features/upload/Manager.ts
+++ b/libs/portal-plugin-dashboard/src/features/upload/Manager.ts
@@ -247,10 +247,10 @@ export class Manager implements IUploadManager {
       // For folder bundles, use the size field
       const meta = file.meta as BundleMetadata;
       if (meta?.isVirtualBundle && meta?.displayAsFolder) {
-        if (file.size) {
-          totalBytes += file.size;
+        const bundleTotal = file.progress.bytesTotal || file.size;
+        if (bundleTotal) {
+          totalBytes += bundleTotal;
         }
-        // Use Uppy's built-in progress tracking
         if (file.progress.bytesUploaded) {
           uploadedBytes += file.progress.bytesUploaded;
         }


### PR DESCRIPTION
Prefer file.progress.bytesTotal (set by TUS after CAR preprocessing) over file.size for virtual folder bundles, so numerator and denominator are in the same units (CAR bytes). Falls back to file.size before TUS has set 

 only the 3-line block inside the if (meta?.isVirtualBundle && meta?.displayAsFolder) branch was modified, replacing file.size as the denominator with file.progress.bytesTotal || file.size to match units with bytesUploaded.

Fixes #521

---

<!-- kody-pr-summary:start -->
## Fix: Folder bundle upload progress percentage exceeding 100%

This PR fixes a bug where the upload progress percentage for folder bundles could exceed 100%.

**Root Cause:** When calculating progress for folder bundles, `uploadedBytes` was tracked using Uppy's built-in `file.progress.bytesUploaded`, but `totalBytes` was calculated using `file.size`. Since these values can differ (with `bytesTotal` potentially being smaller than `file.size`), the uploaded bytes could exceed the reported total, causing progress to go over 100%.

**Fix:** Changed `totalBytes` to prefer `file.progress.bytesTotal` over `file.size`, falling back to `file.size` only when `bytesTotal` is unavailable. This ensures both the numerator (`bytesUploaded`) and denominator (`bytesTotal`) come from the same tracking source, keeping the progress calculation consistent and within the 0–100% range.
<!-- kody-pr-summary:end -->