### PR TITLE
feat(pinner): barrel-export types and fix TypeDoc visibility

### DIFF
--- a/libs/pinner/src/adapters/pinata/shared/types.ts
+++ b/libs/pinner/src/adapters/pinata/shared/types.ts
@@ -374,7 +374,7 @@ export type KeyListItem = {
 /**
  * Key scopes
  */
-type KeyScopes = {
+export type KeyScopes = {
 	endpoints: {
 		pinning: {
 			pinFileToIPFS: boolean;

--- a/libs/pinner/src/blockstore/index.ts
+++ b/libs/pinner/src/blockstore/index.ts
@@ -1,2 +1,2 @@
 export { createBlockstore, createDatastore, setDriverFactory } from "./unstorage";
-export type { UnstorageBlockstoreOptions } from "./unstorage-base";
+export type { UnstorageBlockstoreOptions, DriverFactory } from "./unstorage-base";

--- a/libs/pinner/src/blockstore/unstorage-base.ts
+++ b/libs/pinner/src/blockstore/unstorage-base.ts
@@ -36,7 +36,7 @@ export interface UnstorageBlockstoreOptions {
  *       This determines where the storage driver stores data.
  */
 
-type DriverFactory = () => Driver | Promise<Driver>;
+export type DriverFactory = () => Driver | Promise<Driver>;
 
 export let driverFactory: DriverFactory | null = null;
 
@@ -172,11 +172,12 @@ export function createUnstorageBlockstore(
       options?: AbortOptions,
     ): AwaitGenerator<BlockstorePair> {
       for await (const cid of source) {
+        const self = this;
         yield {
           cid,
           bytes: (async function* () {
-            yield* await this.get(cid, options);
-          }.call(this)),
+            yield* await self.get(cid, options);
+          })(),
         };
       }
     }

--- a/libs/pinner/src/index.ts
+++ b/libs/pinner/src/index.ts
@@ -12,9 +12,31 @@ export type { PinRequest } from "./api/generated/schemas/pinRequest";
 export type { PinRequestMeta } from "./api/generated/schemas/pinRequestMeta";
 export type { PinResultsResponse } from "./api/generated/schemas/pinResultsResponse";
 export type { ErrorResponse } from "./api/generated/schemas/errorResponse";
+export type { Multiaddr } from "./api/generated/schemas/multiaddr";
 export type { PostUploadResponse } from "./api/generated/schemas/postUploadResponse";
 export type { UploadResultResponse } from "./api/generated/schemas/uploadResultResponse";
 export type { Component } from "./api/generated/schemas/component";
+export type { GatewayWebsiteResponse } from "./api/generated/schemas/gatewayWebsiteResponse";
+export type { GatewayWebsiteStatusResponse } from "./api/generated/schemas/gatewayWebsiteStatusResponse";
+export type { GetBlockMetaBatchRequest } from "./api/generated/schemas/getBlockMetaBatchRequest";
+export type { IPNSKeyRequest } from "./api/generated/schemas/iPNSKeyRequest";
+export type { IPNSKeyListResponseResponse } from "./api/generated/schemas/iPNSKeyListResponseResponse";
+export type { IPNSKeyListResponse } from "./api/generated/schemas/iPNSKeyListResponse";
+export type { IPNSRepublishResponse } from "./api/generated/schemas/iPNSRepublishResponse";
+export type { IPNSKeyResponse } from "./api/generated/schemas/iPNSKeyResponse";
+export type { IPNSPublishRequest } from "./api/generated/schemas/iPNSPublishRequest";
+export type { IPNSPublishResponse } from "./api/generated/schemas/iPNSPublishResponse";
+export type { IPNSResolveResponse } from "./api/generated/schemas/iPNSResolveResponse";
+export type { PostApiUploadBody } from "./api/generated/schemas/postApiUploadBody";
+export type { SSLStatusUpdateRequest } from "./api/generated/schemas/sSLStatusUpdateRequest";
+export type { WebsiteItemResponse } from "./api/generated/schemas/websiteItemResponse";
+export type { WebsiteRequest } from "./api/generated/schemas/websiteRequest";
+export type { WebsiteResponse } from "./api/generated/schemas/websiteResponse";
+export type { WebsiteItem } from "./api/generated/schemas/websiteItem";
+export type { WebsiteUpdateRequest } from "./api/generated/schemas/websiteUpdateRequest";
+export type { WebsiteConfigResponse } from "./api/generated/schemas/websiteConfigResponse";
+export type { SSLStatusInfo } from "./api/generated/schemas/sSLStatusInfo";
+export type { WebsiteValidateResponse } from "./api/generated/schemas/websiteValidateResponse";
 
 // Upload exports
 export type {
@@ -23,8 +45,10 @@ export type {
   UploadProgress,
   UploadOperation,
   UploadInput,
+  PinnerUploadBuilder,
 } from "@/types/upload";
 export { UploadManager } from "./upload/manager";
+export type { UploadMethodAndBuilder, UploadBuilderNamespace } from "./upload/builder";
 export {
   preprocessToCar,
   isCarFile,
@@ -45,7 +69,8 @@ export type {
 // API exports
 export { IpnsClient } from "./api/ipns";
 export { WebsitesClient, WebsiteValidationReason, getValidationReason, isValidationReason } from "./api/websites";
-export type { WebsiteValidationReasonValue } from "./api/websites";
+export type { WebsiteValidationReasonValue, WebsitesClientOptions, WatchOptions, SSLWatcher, SSLCallbacks, SSLError } from "./api/websites";
+export type { IpnsClientOptions } from "./api/ipns";
 
 // Error exports
 export {
@@ -70,7 +95,7 @@ export { MIME_TYPE_CAR, MIME_TYPE_OCTET_STREAM, FILE_EXTENSION_CAR } from "./typ
 
 // Blockstore exports
 export { createBlockstore, createDatastore, setDriverFactory } from "./blockstore";
-export type { UnstorageBlockstoreOptions } from "./blockstore";
+export type { UnstorageBlockstoreOptions, DriverFactory } from "./blockstore";
 
 // Stream utilities
 export {
@@ -90,3 +115,91 @@ export type {
   PinataAdapter,       // v2.x
   PinataLegacyAdapter, // v1.10.1
 } from "./adapters/pinata";
+
+// Pinata adapter types (referenced by adapter method signatures)
+export type {
+  PinataConfig as PinataLegacyConfig,
+  UploadResponse as PinataUploadResponse,
+  UploadOptions as PinataUploadOptions,
+  FileListResponse as PinataFileListResponse,
+  FileListQuery as PinataFileListQuery,
+  FileListItem as PinataFileListItem,
+  PinJobQuery as PinataPinJobQuery,
+  PinJobResponse as PinataPinJobResponse,
+  PinJobItem as PinataPinJobItem,
+  SignedUrlOptions as PinataSignedUrlOptions,
+  AnalyticsQuery as PinataAnalyticsQuery,
+  TopAnalyticsQuery as PinataTopAnalyticsQuery,
+  TopAnalyticsResponse as PinataTopAnalyticsResponse,
+  TopAnalyticsItem as PinataTopAnalyticsItem,
+  TimeIntervalAnalyticsQuery as PinataTimeIntervalAnalyticsQuery,
+  TimeIntervalAnalyticsResponse as PinataTimeIntervalAnalyticsResponse,
+  TimePeriodItem as PinataTimePeriodItem,
+  SwapCidOptions as PinataSwapCidOptions,
+  SwapHistoryOptions as PinataSwapHistoryOptions,
+  SwapCidResponse as PinataSwapCidResponse,
+  ContainsCIDResponse as PinataContainsCIDResponse,
+  KeyScopes as PinataKeyScopes,
+  PinataMetadata as PinataLegacyMetadata,
+  DeleteResponse as PinataDeleteResponse,
+  JsonBody as PinataJsonBody,
+  FileObject as PinataFileObject,
+} from "./adapters/pinata/shared/types";
+
+export type {
+  PinataConfig as PinataV2Config,
+  UploadOptions as PinataV2UploadOptions,
+  UploadResponse as PinataV2UploadResponse,
+  UploadCIDOptions as PinataV2UploadCIDOptions,
+  PinByCIDResponse as PinataPinByCIDResponse,
+  SignedUploadUrlOptions as PinataV2SignedUploadUrlOptions,
+  FileListItem as PinataV2FileListItem,
+  FileListResponse as PinataV2FileListResponse,
+  FileListQuery as PinataV2FileListQuery,
+  UpdateFileOptions as PinataV2UpdateFileOptions,
+  DeleteResponse as PinataV2DeleteResponse,
+  PinQueueItem as PinataPinQueueItem,
+  PinQueueQuery as PinataPinQueueQuery,
+  PinQueueResponse as PinataPinQueueResponse,
+  SwapCidOptions as PinataV2SwapCidOptions,
+  SwapHistoryOptions as PinataV2SwapHistoryOptions,
+  SwapCidResponse as PinataV2SwapCidResponse,
+  AccessLinkOptions as PinataV2AccessLinkOptions,
+  ContentType as PinataV2ContentType,
+  GetCIDResponse as PinataV2GetCIDResponse,
+  GroupOptions as PinataV2GroupOptions,
+  UpdateGroupOptions as PinataV2UpdateGroupOptions,
+  GetGroupOptions as PinataV2GetGroupOptions,
+  GroupResponseItem as PinataV2GroupResponseItem,
+  GroupListResponse as PinataV2GroupListResponse,
+  GroupQueryOptions as PinataV2GroupQueryOptions,
+  GroupCIDOptions as PinataV2GroupCIDOptions,
+  UpdateGroupFilesResponse as PinataV2UpdateGroupFilesResponse,
+  AnalyticsQuery as PinataV2AnalyticsQuery,
+  TopAnalyticsQuery as PinataV2TopAnalyticsQuery,
+  TopAnalyticsResponse as PinataV2TopAnalyticsResponse,
+  TopAnalyticsItem as PinataV2TopAnalyticsItem,
+  TimeIntervalAnalyticsQuery as PinataV2TimeIntervalAnalyticsQuery,
+  TimePeriodItem as PinataV2TimePeriodItem,
+  TimeIntervalAnalyticsResponse as PinataV2TimeIntervalAnalyticsResponse,
+  UserPinnedDataResponse as PinataV2UserPinnedDataResponse,
+  CidVersion as PinataCidVersion,
+  Network as PinataNetwork,
+  PinataMetadata as PinataV2Metadata,
+} from "./adapters/pinata/v2/types";
+
+export type {
+  UploadBuilder as PinataUploadBuilder,
+  FilterFiles as PinataFilterFiles,
+  FilterQueue as PinataFilterQueue,
+  FilterGroups as PinataFilterGroups,
+  PublicUpload as PinataPublicUpload,
+  PrivateUpload as PinataPrivateUpload,
+  PublicFiles as PinataPublicFiles,
+  PrivateFiles as PinataPrivateFiles,
+  PublicGateways as PinataPublicGateways,
+  PrivateGateways as PinataPrivateGateways,
+  PublicGroups as PinataPublicGroups,
+  PrivateGroups as PinataPrivateGroups,
+  Analytics as PinataAnalytics,
+} from "./adapters/pinata/v2/adapter-interface";

--- a/libs/pinner/src/upload/__tests__/test-helpers.ts
+++ b/libs/pinner/src/upload/__tests__/test-helpers.ts
@@ -37,13 +37,13 @@ export async function createTestCarFile(
   const cid = CID.create(1, 0x55, hash);
 
   // Create a CAR writer with the root CID
-  const { writer, out } = CarWriter.create([cid]);
+  const { writer, out } = CarWriter.create([cid as any]);
 
   // Collect all bytes from the async iterable
   const collectPromise = collectAsyncIterable(out);
 
   // Add the block to the CAR
-  await writer.put({ cid, bytes: data });
+  await writer.put({ cid: cid as any, bytes: data });
 
   // Finish the CAR and get the bytes
   await writer.close();
@@ -89,14 +89,14 @@ export async function createMultiBlockCarFile(
   }
 
   // Create a CAR writer with all root CIDs
-  const { writer, out } = CarWriter.create(cids);
+  const { writer, out } = CarWriter.create(cids as any);
 
   // Collect all bytes from the async iterable
   const collectPromise = collectAsyncIterable(out);
 
   // Add all blocks to the CAR
   for (const block of blocks) {
-    await writer.put(block);
+    await writer.put(block as any);
   }
 
   // Finish the CAR and get the bytes

--- a/libs/pinner/src/upload/__tests__/xhr-upload.integration.spec.ts
+++ b/libs/pinner/src/upload/__tests__/xhr-upload.integration.spec.ts
@@ -26,7 +26,7 @@ describe("XHRUploadHandler Integration", () => {
       expect(result.cid).not.toBe("");
 
       const { CID } = await import("multiformats/cid");
-      expect(() => CID.parse(result.cid)).not.toThrow();
+      expect(() => CID.parse(result.cid!)).not.toThrow();
 
       handler.destroy();
     });

--- a/libs/pinner/tsconfig.typedoc.json
+++ b/libs/pinner/tsconfig.typedoc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["es2020", "dom"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.spec.ts", "src/**/*.integration.spec.ts", "node_modules", "dist"]
+}


### PR DESCRIPTION
- Export 20+ missing schema types from index.ts (Website*, IPNS*, SSL*)
- Export DriverFactory and KeyScopes types
- Export PinnerUploadBuilder, UploadMethodAndBuilder, UploadBuilderNamespace
- Fix createUnstorageBlockstore async generator 'this' binding
- Fix test helpers TS strict mode (CID type assertions)
- Add tsconfig.typedoc.json excluding test files from TypeDoc
- Add pinner type-check step to CI build workflow

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR barrel-exports missing types from the pinner package and fixes type errors that were blocking TypeDoc and SDK reference generation.

### Key Changes

**Type Exports (barrel exports in `index.ts`):**
- Added exports for numerous API schema types that were previously not publicly accessible, including IPNS, website, gateway, SSL, and upload-related types
- Added exports for API client configuration types (`IpnsClientOptions`, `WebsitesClientOptions`, `WatchOptions`, `SSLWatcher`, `SSLCallbacks`, `SSLError`)
- Added exports for upload builder types (`PinnerUploadBuilder`, `UploadMethodAndBuilder`, `UploadBuilderNamespace`)
- Added exports for Pinata adapter types (both legacy and v2), with aliased names to avoid naming collisions
- Added exports for Pinata adapter interface types (upload builders, filters, analytics)

**Visibility Fixes:**
- Made `KeyScopes` and `DriverFactory` types exported from their source modules so they can be re-exported

**Type Error Fixes:**
- Fixed a `this` binding issue in `createUnstorageBlockstore` where the async generator used `.call(this)` pattern; replaced with a captured `self` reference and IIFE
- Added type assertions in test helpers to resolve `CarWriter` type incompatibilities
- Added non-null assertion for `result.cid` in integration test

**CI:**
- Added a type-check step (`tsc --noEmit`) for the pinner package in the build workflow that runs before the build, ensuring type errors block TypeDoc and SDK reference generation

### Purpose

Consumers of the pinner SDK now have access to all types referenced by public method signatures and API clients. The added CI type-check step ensures type visibility issues are caught before documentation generation, preventing broken SDK reference docs.
<!-- kody-pr-summary:end -->