### PR TITLE
fix(pinner.xyz): revise site copy and fix CadenceToggle badge colors

### DIFF
--- a/apps/pinner.xyz/src/components/Home/FAQ.tsx
+++ b/apps/pinner.xyz/src/components/Home/FAQ.tsx
@@ -85,12 +85,12 @@ const faqs = [
       {
         question: "Can I try Pinner before paying?",
         answer:
-          "Founding Offer: first 50 accounts get their rate locked for life, a 30-day money-back guarantee, and a deployment promise: create a website and if it isn't live in 5 minutes, we'll deploy it for you. Pay for storage and bandwidth. No hidden fees.",
+          "Founding Offer: first 50 accounts get their rate locked for life, a 30-day money-back guarantee, and a deployment promise: create a website and if it isn't live in 5 minutes, we'll deploy it for you. Pay for storage and bandwidth, priced upfront.",
       },
       {
         question: "How does billing work?",
         answer:
-          "Pay for storage and bandwidth. No hidden fees, no API call charges. Monthly or annual. Card or crypto.",
+          "Pay for storage and bandwidth, priced upfront. No API call charges. Monthly or annual. Card or crypto.",
       },
     ],
   },

--- a/apps/pinner.xyz/src/components/Home/Hero.tsx
+++ b/apps/pinner.xyz/src/components/Home/Hero.tsx
@@ -48,7 +48,7 @@ const Hero = () => {
   return (
     <HeroSection
       headline={<>Your data.<br />Your rules.</>}
-      subheadline={<><a href="/solutions/website-hosting" className="underline hover:text-white transition-colors">Website hosting</a>, <a href="/solutions/ipfs-pinning" className="underline hover:text-white transition-colors">IPFS pinning</a>, and <a href="/solutions/private-storage" className="underline hover:text-white transition-colors">private storage</a>.<br /><br />No one else can read your files, not even us.<br /><br />No vendor lock-in, no hidden fees.</>}
+      subheadline={<><a href="/solutions/website-hosting" className="underline hover:text-white transition-colors">Website hosting</a>, <a href="/solutions/ipfs-pinning" className="underline hover:text-white transition-colors">IPFS pinning</a>, and <a href="/solutions/private-storage" className="underline hover:text-white transition-colors">private storage</a>.<br /><br />No one else can read your files, not even us.<br /><br />No vendor lock-in. Storage and bandwidth, priced upfront.</>}
       primaryButtons={[
         { label: "Start Pinning →", url: config.registerUrl("pinning"), buttonStyle: "btn-light" },
         { label: "Host a Website →", url: config.registerUrl("hosting"), buttonStyle: "btn-light" },

--- a/apps/pinner.xyz/src/components/Home/TrustSection.tsx
+++ b/apps/pinner.xyz/src/components/Home/TrustSection.tsx
@@ -12,9 +12,9 @@ const principles = [
     "Zero-knowledge encryption means even we don't have the keys. That's not a promise. It's the architecture.",
 	},
 	{
-		title: "We keep our word",
+		title: "What you see is what you pay",
 		description:
-			"Uptime we commit to, pricing you can understand. No hidden fees, no bait-and-switch tiers.",
+			"Storage and bandwidth, priced upfront. No tiers to climb, no surprise line items. The pricing page is the pricing page.",
 	},
 	{
 		title: "You can leave",

--- a/apps/pinner.xyz/src/components/Home/UseCases.tsx
+++ b/apps/pinner.xyz/src/components/Home/UseCases.tsx
@@ -12,7 +12,7 @@ const useCases: UseCaseCardProps[] = [
   {
     title: "Private AI & RAG Pipelines",
     description:
-      "Store embeddings, vector databases, and knowledge bases with zero-knowledge encryption. Your AI data stays fully private, even from us.",
+      "Store embeddings, vector databases, and knowledge bases with zero-knowledge encryption. Your data is encrypted before it leaves your device. Even we can't read it.",
     cta: "Store Privately →",
     href: "/solutions/private-storage",
   },

--- a/apps/pinner.xyz/src/components/MissionSection.tsx
+++ b/apps/pinner.xyz/src/components/MissionSection.tsx
@@ -19,7 +19,7 @@ const beliefs = [
   {
     icon: Wallet,
     title: "Pricing should be boring",
-    description: "Pay for what you store and transfer. Transparent pricing, no hidden fees",
+    description: "Pay for what you store and transfer. Priced upfront, no tiers to climb",
   },
 ];
 

--- a/apps/pinner.xyz/src/components/pricing/CadenceToggle.tsx
+++ b/apps/pinner.xyz/src/components/pricing/CadenceToggle.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import { themeStyles } from "./theme";
-import type { Cadence } from "./utils";
+import { Cadence } from "./utils";
 
 interface CadenceToggleProps {
   cadence: Cadence;
@@ -18,6 +18,8 @@ export function CadenceToggle({
   return (
     <div className="flex justify-center mb-10 md:mb-16">
       <div
+        role="radiogroup"
+        aria-label="Billing cadence"
         className={cn(
           theme.toggleBg,
           "inline-flex rounded-full p-1 border",
@@ -27,28 +29,33 @@ export function CadenceToggle({
         )}
       >
         <button
-          onClick={() => { onChange("monthly"); window.posthog?.capture("pricing_cadence_toggled", { cadence: "monthly" }); }}
+          role="radio"
+          aria-pressed={cadence === Cadence.Monthly}
+          aria-checked={cadence === Cadence.Monthly}
+          onClick={() => { onChange(Cadence.Monthly); window.posthog?.capture("pricing_cadence_toggled", { cadence: Cadence.Monthly }); }}
           className={cn(
             "px-5 py-2 rounded-full text-sm font-medium transition-all duration-200",
-            cadence === "monthly" ? theme.toggleActive : theme.toggleInactive
+            cadence === Cadence.Monthly ? theme.toggleActive : theme.toggleInactive
           )}
         >
           Monthly
         </button>
         <button
-          onClick={() => { onChange("yearly"); window.posthog?.capture("pricing_cadence_toggled", { cadence: "yearly" }); }}
+          role="radio"
+          aria-pressed={cadence === Cadence.Yearly}
+          aria-checked={cadence === Cadence.Yearly}
+          onClick={() => { onChange(Cadence.Yearly); window.posthog?.capture("pricing_cadence_toggled", { cadence: Cadence.Yearly }); }}
           className={cn(
             "px-5 py-2 rounded-full text-sm font-medium transition-all duration-200",
-            cadence === "yearly" ? theme.toggleActive : theme.toggleInactive
+            cadence === Cadence.Yearly ? theme.toggleActive : theme.toggleInactive
           )}
         >
-          Yearly
+          <span>Yearly</span>
           <span
+            aria-label="2 months free"
             className={cn(
               "ml-1.5 inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold leading-none",
-              variant === "dark"
-                ? "bg-white/15 text-home-text"
-                : "bg-content-text/10 text-content-text"
+              cadence === Cadence.Yearly ? theme.badgeActive : theme.badgeInactive
             )}
           >
             2 months free

--- a/apps/pinner.xyz/src/components/pricing/PlanCard.tsx
+++ b/apps/pinner.xyz/src/components/pricing/PlanCard.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 import { TrackedButton } from "@/components/TrackedButton";
 import type { BillingPlan } from "@/lib/api";
 import { themeStyles } from "./theme";
-import type { Cadence } from "./utils";
+import { Cadence } from "./utils";
 import {
   getPriceDisplay,
   getCTA,

--- a/apps/pinner.xyz/src/components/pricing/PricingPlans.tsx
+++ b/apps/pinner.xyz/src/components/pricing/PricingPlans.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import type { BillingPlan, BillingPlansResponse } from "@/lib/api";
 import { themeStyles } from "./theme";
 import { getPlansApiUrl, fetcher } from "./utils";
-import type { Cadence } from "./utils";
+import { Cadence } from "./utils";
 import { CadenceToggle } from "./CadenceToggle";
 import { PlanCard } from "./PlanCard";
 import { SkeletonCard } from "./SkeletonCard";
@@ -31,7 +31,7 @@ const PricingPlans = ({
   variant = "dark",
   showToggle = true,
 }: PricingPlansProps) => {
-  const [cadence, setCadence] = useState<Cadence>("monthly");
+  const [cadence, setCadence] = useState<Cadence>(Cadence.Monthly);
   const theme = themeStyles[variant];
 
   const { data, error, isLoading } = useSWR<BillingPlansResponse>(

--- a/apps/pinner.xyz/src/components/pricing/theme.ts
+++ b/apps/pinner.xyz/src/components/pricing/theme.ts
@@ -10,6 +10,8 @@ export const themeStyles = {
     toggleInactive: "text-home-text-muted",
     skeleton: "bg-home-card-bg/60",
     errorText: "text-home-text-muted",
+    badgeActive: "bg-content-text/10 text-content-text",
+    badgeInactive: "bg-white/15 text-home-text",
   },
   light: {
     card: "bg-content-section-gray border-content-section-gray",
@@ -22,6 +24,8 @@ export const themeStyles = {
     toggleInactive: "text-content-text-muted",
     skeleton: "bg-content-section-gray/60",
     errorText: "text-content-text-muted",
+    badgeActive: "bg-white/20 text-white",
+    badgeInactive: "bg-content-text/10 text-content-text",
   },
 } as const;
 

--- a/apps/pinner.xyz/src/components/pricing/utils.ts
+++ b/apps/pinner.xyz/src/components/pricing/utils.ts
@@ -1,7 +1,10 @@
 import type { BillingPlan } from "@/lib/api";
 import { config } from "@/lib/config";
 
-export type Cadence = "monthly" | "yearly";
+export enum Cadence {
+  Monthly = "monthly",
+  Yearly = "yearly",
+}
 
 export function getPlansApiUrl(): string {
   return `${config.portalApiUrl}/api/billing/plans`;
@@ -23,7 +26,7 @@ export function getPriceDisplay(plan: BillingPlan, cadence: Cadence) {
     if (!fallback) return { price: "Custom", sub: "" };
     return { price: `$${fallback.price_usd}`, sub: `/${fallback.cadence}` };
   }
-  if (cadence === "yearly") {
+  if (cadence === Cadence.Yearly) {
     const perMonth = period.price_usd / 12;
     return {
       price: perMonth % 1 === 0 ? `$${perMonth}` : `$${perMonth.toFixed(2)}`,

--- a/apps/pinner.xyz/src/lib/api.ts
+++ b/apps/pinner.xyz/src/lib/api.ts
@@ -1,6 +1,8 @@
+import type { Cadence } from "@/components/pricing/utils";
+
 export interface PricingPeriod {
   id: number;
-  cadence: "monthly" | "yearly";
+  cadence: Cadence;
   price_usd: number;
   quota_plan_id: number;
 }

--- a/apps/pinner.xyz/src/lib/config.ts
+++ b/apps/pinner.xyz/src/lib/config.ts
@@ -42,7 +42,7 @@ export const ctaCopy = {
   },
   privateStorage: {
     heading: "Your data is yours.",
-    subheading: "Private storage. Zero-knowledge encryption. No data mining.",
+    subheading: "Private storage. Zero-knowledge encryption. Data mining impossible.",
   },
   privateStoragePersonal: {
     heading: "Your data is yours.",
@@ -58,7 +58,7 @@ export const ctaCopy = {
   },
   about: {
     heading: "Your data is yours.",
-    subheading: "We don't look at it. We don't sell it. Open source, no data mining.",
+    subheading: "We can't look at it. We can't sell it. Open source; verify the architecture yourself.",
   },
   howItWorks: {
     heading: "Pin, host, or store your data on a network.",

--- a/apps/pinner.xyz/src/pages/about.astro
+++ b/apps/pinner.xyz/src/pages/about.astro
@@ -32,7 +32,7 @@ import AboutHowItWorks from "@/assets/about-how-it-works.jpg";
   <AboutSection
     title="Pinner is your storage service."
     subtitle="What is Pinner?"
-    description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. All on a decentralized network. No middlemen. No data mining. No AI training. No headaches."
+    description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. All on a decentralized network. No middlemen. No data mining possible. No AI training possible. No headaches."
     imageUrl={AboutWhatIsPinner}
     theme="white"
     client:load
@@ -41,7 +41,7 @@ import AboutHowItWorks from "@/assets/about-how-it-works.jpg";
   <AboutSection
     title="Your data is yours."
     subtitle="What We Stand For"
-    description="We don't look at it. We don't sell it, we don't use it to train models.<br/><br/>We keep our word. Uptime we commit to, pricing you can understand.<br/><br/>No roadblocks: we may use automation to scale, but if you need a human, you will get one.<br/><br/>Real SMB: founder-owned LLC, no investors, no exit strategy.<br/><br/>Open by default: fully open source, public GitHub."
+    description="We can't look at it. Zero-knowledge encryption means the keys never leave your device. We can't sell it. We can't train models on it. Not because we chose not to, but because the architecture makes it impossible.<br/><br/>Uptime is a contract, not a promise. Hosts only get paid when they prove your data is there. Pricing is storage and bandwidth, upfront. No tiers to climb.<br/><br/>No roadblocks: we may use automation to scale, but if you need a human, you will get one.<br/><br/>Real SMB: founder-owned LLC, no investors, no exit strategy.<br/><br/>Open by default: fully open source, public GitHub. Don't take our word for it. Read the code."
     imageUrl={AboutValues}
     theme="gray"
     client:load


### PR DESCRIPTION
- Clarify pricing language across Hero, FAQ, TrustSection, MissionSection
- Update About page copy
- Add Cadence enum, replace string literals
- Fix badge color contrast on active toggle state
- Add a11y roles to cadence toggle

---

<!-- kody-pr-summary:start -->
## Summary

This PR revises the marketing copy across the pinner.xyz website and fixes the `CadenceToggle` badge colors, along with related refactoring and accessibility improvements.

### Copy Revisions

Across multiple pages (Hero, FAQ, TrustSection, UseCases, MissionSection, About, and config), the messaging was updated to:

- **Pricing language**: Shifted from "no hidden fees" to "priced upfront" and "no tiers to climb," emphasizing transparent, upfront pricing rather than the absence of hidden fees.
- **Privacy language**: Changed from "we don't look at it / we don't sell it" to "we can't look at it / we can't sell it," framing privacy as an architectural impossibility (zero-knowledge encryption) rather than a promise or choice.
- **Data mining**: Updated from "no data mining" to "data mining impossible" to reinforce the same architectural framing.

### CadenceToggle Fixes

- **Badge colors**: The "2 months free" badge now uses theme-based `badgeActive`/`badgeInactive` classes (added to `theme.ts`) instead of the previous variant-based logic, ensuring correct color contrast when the yearly option is selected vs. not.
- **Accessibility**: Added `role="radiogroup"`, `role="radio"`, `aria-pressed`, `aria-checked`, and `aria-label` attributes to the billing cadence toggle.

### Cadence Enum Refactor

- Converted `Cadence` from a string union type (`"monthly" | "yearly"`) to an enum (`Cadence.Monthly`, `Cadence.Yearly`), updating all usages across `CadenceToggle`, `PlanCard`, `PricingPlans`, `utils`, and `api.ts`.
<!-- kody-pr-summary:end -->