### PR TITLE
fix: migrate pnpm settings to pnpm-workspace.yaml, remove dead esbuild dep

### DIFF
--- a/libs/portal-framework-core/package.json
+++ b/libs/portal-framework-core/package.json
@@ -45,7 +45,6 @@
     "@types/express": "^5.0.6",
     "@vitejs/devtools": "^0.1.22",
     "babel-plugin-react-compiler": "^1.0.0",
-    "esbuild-fix-imports-plugin": "^1.0.23",
     "express": "^5.2.1",
     "lucide-react": "catalog:",
     "memoizee": "^0.4.17",

--- a/package.json
+++ b/package.json
@@ -80,33 +80,6 @@
     "vitest-browser-react": "catalog:",
     "wrangler": "^4.90.1"
   },
-  "pnpm": {
-    "overrides": {
-      "@module-federation/enhanced>typescript": "catalog:",
-      "@module-federation/dts-plugin>typescript": "catalog:",
-      "@module-federation/rspack>typescript": "catalog:"
-    },
-    "patchedDependencies": {
-      "object-inspect": "patches/object-inspect.patch",
-      "warn-once": "patches/warn-once.patch",
-      "pluralize": "patches/pluralize.patch",
-      "papaparse": "patches/papaparse.patch",
-      "@uppy/core": "patches/@uppy__core.patch",
-      "better-sse@0.16.1": "patches/better-sse@0.16.1.patch",
-      "@module-federation/vite": "patches/@module-federation__vite.patch",
-      "vocs": "patches/vocs.patch"
-    },
-    "onlyBuiltDependencies": [
-      "@ipshipyard/node-datachannel",
-      "@parcel/watcher",
-      "aws-sdk",
-      "es5-ext",
-      "esbuild",
-      "msw",
-      "sharp",
-      "workerd"
-    ]
-  },
   "packageManager": "pnpm@10.33.4",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,9 +1131,6 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
-      esbuild-fix-imports-plugin:
-        specifier: ^1.0.23
-        version: 1.0.23
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -9859,9 +9856,6 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
-
-  esbuild-fix-imports-plugin@1.0.23:
-    resolution: {integrity: sha512-zDn2Mq3OnW9qNm9FrHDeE0FePgIRIaH9EWpHOGsJZFPfyPSNqzvCK/x9EZJ5eHEEyXe8ZGdb5CjDpzqkyAqcCg==}
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
@@ -24743,8 +24737,6 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
-
-  esbuild-fix-imports-plugin@1.0.23: {}
 
   esbuild@0.25.9:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,6 +99,30 @@ catalogs:
     astro-md-alternate: ^0.1.0
     astro-robots-txt: ^1.0.0
 
+overrides:
+  '@module-federation/enhanced>typescript': 'catalog:'
+  '@module-federation/dts-plugin>typescript': 'catalog:'
+  '@module-federation/rspack>typescript': 'catalog:'
+
+patchedDependencies:
+  object-inspect: patches/object-inspect.patch
+  warn-once: patches/warn-once.patch
+  pluralize: patches/pluralize.patch
+  papaparse: patches/papaparse.patch
+  '@uppy/core': patches/@uppy__core.patch
+  better-sse@0.16.1: patches/better-sse@0.16.1.patch
+  '@module-federation/vite': patches/@module-federation__vite.patch
+  vocs: patches/vocs.patch
+
+onlyBuiltDependencies:
+  - '@ipshipyard/node-datachannel'
+  - '@parcel/watcher'
+  - aws-sdk
+  - es5-ext
+  - msw
+  - sharp
+  - workerd
+
 gitChecks: false
 
 publishBranch: develop

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,6 +119,7 @@ onlyBuiltDependencies:
   - '@parcel/watcher'
   - aws-sdk
   - es5-ext
+  - esbuild
   - msw
   - sharp
   - workerd


### PR DESCRIPTION
## Problem

The Update Dependencies workflow fails with exit code 143 (SIGTERM) during `pnpm install`.

**Root cause:** pnpm v10 no longer reads `pnpm.overrides`, `pnpm.patchedDependencies`, or `pnpm.onlyBuiltDependencies` from `package.json` — these must live in `pnpm-workspace.yaml`. Without `onlyBuiltDependencies`, native deps like `esbuild` were not built, so the `prepare` script (`turbo build` → `tsdown`) hung and was killed after ~3.5 min.

## Changes

1. **Move pnpm settings from `package.json` to `pnpm-workspace.yaml`** — `overrides`, `patchedDependencies`, and `onlyBuiltDependencies` now live where pnpm v10 expects them.

2. **Remove dead `esbuild-fix-imports-plugin`** from `libs/portal-framework-core` — zero references in source code across the entire repo. It was an unused direct dependency (esbuild itself is still pulled transitively by wrangler, orval, storybook, tsx, etc.).

3. **Update `pnpm-lock.yaml`** to reflect the removed dependency.

## Verification

- `onlyBuiltDependencies` is now properly recognized by pnpm v10
- The `prepare` script will no longer hang because the native deps it needs are built correctly