### PR TITLE
fix: remove dead deps causing taze errors (events, querystring)

### DIFF
--- a/apps/portal-app-shell/package.json
+++ b/apps/portal-app-shell/package.json
@@ -26,7 +26,6 @@
     "@lumeweb/portal-sdk": "workspace:*",
     "@t3-oss/env-core": "catalog:",
     "@tanstack/react-query": "catalog:",
-    "events": "^3.3.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-hook-form": "catalog:",

--- a/libs/advanced-rest/package.json
+++ b/libs/advanced-rest/package.json
@@ -7,8 +7,7 @@
     "@lumeweb/query-builder": "workspace:*",
     "@refinedev/core": "catalog:",
     "ky": "catalog:",
-    "pupa": "^3.3.0",
-    "querystring": "^0.2.1"
+    "pupa": "^3.3.0"
   },
   "private": true,
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,9 +696,6 @@ importers:
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.100.10(react@19.2.6)
-      events:
-        specifier: ^3.3.0
-        version: 3.3.0
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -819,9 +816,6 @@ importers:
       pupa:
         specifier: ^3.3.0
         version: 3.3.0
-      querystring:
-        specifier: ^0.2.1
-        version: 0.2.1
     devDependencies:
       '@lumeweb/tsdown-config':
         specifier: workspace:*
@@ -13029,11 +13023,6 @@ packages:
 
   querystring@0.2.0:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
-    engines: {node: '>=0.4.x'}
-    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
-
-  querystring@0.2.1:
-    resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
@@ -28864,8 +28853,6 @@ snapshots:
   quansync@1.0.0: {}
 
   querystring@0.2.0: {}
-
-  querystring@0.2.1: {}
 
   querystringify@2.2.0: {}
 


### PR DESCRIPTION
## Problem

`taze` fails with `Invalid package name "events"` and `Invalid package name "querystring"` errors during the Update Dependencies workflow.

## Root Cause

Both `events` and `querystring` are declared as direct dependencies but have zero imports in source code:
- `events` (`apps/portal-app-shell`) — Node.js built-in polyfill, never imported
- `querystring` (`libs/advanced-rest`) — deprecated npm package, never imported

taze tries to resolve them from the npm registry and fails because they share names with Node.js built-in modules.

## Changes

1. Remove `events` from `apps/portal-app-shell/package.json`
2. Remove `querystring` from `libs/advanced-rest/package.json`
3. Update `pnpm-lock.yaml`

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR removes two unused dependencies — `events` and `querystring` — from the project's dependency tree. These dead dependencies were causing errors when running `taze` (a dependency update tool). By removing them from the lockfile, the `taze` tool can run without encountering issues related to these legacy/unused packages.
<!-- kody-pr-summary:end -->