### PR TITLE
fix(pinner.xyz): replace 'decentralized' with 'verifiable' in marketing copy

### DIFF
--- a/apps/pinner.xyz/src/components/Home/AccountSlider.tsx
+++ b/apps/pinner.xyz/src/components/Home/AccountSlider.tsx
@@ -21,15 +21,15 @@ interface SliderContent {
 const sliderContent: SliderContent[] = [
   {
     title: "Create an account",
-    description: "Get started with decentralized storage in minutes",
+    description: "Get started with verifiable storage in minutes",
   },
   {
     title: "Upload",
-    description: "Simple upload to the decentralized network",
+    description: "Simple upload to the verifiable storage network",
   },
   {
     title: "Secure",
-    description: "A decentralized network stores files redundantly",
+    description: "A verifiable network stores files redundantly",
   },
 ];
 

--- a/apps/pinner.xyz/src/components/HowItWorks/ThreeSteps.tsx
+++ b/apps/pinner.xyz/src/components/HowItWorks/ThreeSteps.tsx
@@ -8,7 +8,7 @@ const steps = [
     number: "2",
     title: "Distribute",
     description:
-      "Files are copied across the decentralized network. Your files stay online even if individual servers go down.",
+      "Files are copied across the network. Your files stay online even if individual servers go down.",
   },
   {
     number: "3",

--- a/apps/pinner.xyz/src/components/pricing/featureCopy.ts
+++ b/apps/pinner.xyz/src/components/pricing/featureCopy.ts
@@ -5,7 +5,7 @@
 const featureMap: Record<string, string> = {
   // IPFS / Public storage
   "IPFS Pinning": "IPFS Pinning. your content stays online as long as it's pinned",
-  "IPFS Hosting": "IPFS Hosting. serve static sites from a decentralized network",
+  "IPFS Hosting": "IPFS Hosting. serve static sites from a verifiable storage network",
   "Website Hosting": "Website Hosting. deploy static sites without a server",
 
   // Private storage

--- a/apps/pinner.xyz/src/data/alternatives/pinata.json
+++ b/apps/pinner.xyz/src/data/alternatives/pinata.json
@@ -1,7 +1,7 @@
 {
   "name": "Pinata",
   "slug": "pinata",
-  "tagline": "IPFS pinning with website hosting and decentralized storage.",
+  "tagline": "IPFS pinning with website hosting and verifiable storage.",
   "description": "Compare Pinner vs Pinata on IPFS pinning, website hosting, storage model, payments, and open-source licensing.",
   "category": "pinning",
   "featured": true

--- a/apps/pinner.xyz/src/pages/about.astro
+++ b/apps/pinner.xyz/src/pages/about.astro
@@ -14,7 +14,7 @@ import AboutValues from "@/assets/about-values.jpg";
 import AboutHowItWorks from "@/assets/about-how-it-works.jpg";
 ---
 
-<Layout title="Decentralized Storage That Respects Your Data" variant="home" ogImage="/images/og-about.png" description="A small business building storage infrastructure that respects your data. Zero-knowledge encryption, open source, built on the Sia decentralized network.">
+<Layout title="Verifiable Storage That Respects Your Data" variant="home" ogImage="/images/og-about.png" description="A small business building storage infrastructure that respects your data. Zero-knowledge encryption, open source, built on the Sia network.">
   <PageHeader
     title="Why we're building Pinner"
     description="A small business building storage infrastructure that respects your data."
@@ -32,7 +32,7 @@ import AboutHowItWorks from "@/assets/about-how-it-works.jpg";
   <AboutSection
     title="Pinner is your storage service."
     subtitle="What is Pinner?"
-    description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. All on a decentralized network. No middlemen. No data mining possible. No AI training possible. No headaches."
+    description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. All on a verifiable storage network. No middlemen. No data mining possible. No AI training possible. No headaches."
     imageUrl={AboutWhatIsPinner}
     theme="white"
     client:load

--- a/apps/pinner.xyz/src/pages/alternatives/netlify/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/netlify/index.astro
@@ -42,7 +42,7 @@ const faqs = [
   },
   {
     question: "How does the peer-to-peer storage work?",
-    answer: "Your static files are stored on the Sia network, where independent storage providers host your data. Providers only get paid when they cryptographically prove they're storing your files. The storage layer is decentralized, not locked to a single provider. The serving layer uses standard HTTP gateways."
+    answer: "Your static files are stored on the Sia network, where independent storage providers host your data. Providers only get paid when they cryptographically prove they're storing your files. The storage layer is verifiable and portable, not locked to a single provider. The serving layer uses standard HTTP gateways."
   }
 ];
 ---

--- a/apps/pinner.xyz/src/pages/alternatives/pinata/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/pinata/index.astro
@@ -32,7 +32,7 @@ const faqs = [
   },
   {
     question: "What makes Pinner different from other IPFS pinning services?",
-    answer: "Crypto payments with no KYC, website hosting from the same pinned content, and storage on the Sia decentralized network. Pinner is also fully open source."
+    answer: "Crypto payments with no KYC, website hosting from the same pinned content, and storage on the Sia network. Pinner is also fully open source."
   },
   {
     question: "What doesn't Pinner offer?",
@@ -57,10 +57,10 @@ const faqs = [
 ];
 ---
 
-<Layout title="Pinata Alternative: IPFS Pinning with Website Hosting & No-KYC Payments | Pinner" description="IPFS pinning with no-KYC crypto payments, website hosting, and private storage on a decentralized network. We help you migrate.">
+<Layout title="Pinata Alternative: IPFS Pinning with Website Hosting & No-KYC Payments | Pinner" description="IPFS pinning with no-KYC crypto payments, website hosting, and private storage on a verifiable storage network. We help you migrate.">
   <PageHeader
-    title="IPFS pinning with website hosting and decentralized storage"
-    description="Pay with crypto (no KYC) or use a card. Host websites from pinned content and store on a decentralized network. Need help migrating? We'll work with you."
+    title="IPFS pinning with website hosting and verifiable storage"
+    description="Pay with crypto (no KYC) or use a card. Host websites from pinned content and store on a verifiable network. Need help migrating? We'll work with you."
     btnText="Start Pinning →"
     url={config.registerUrl("pinning")}
     secondaryBtnText="See Pricing →"
@@ -70,8 +70,8 @@ const faqs = [
 
   <AboutSection
     subtitle="Why Pinner"
-    title="IPFS pinning, plus website hosting and decentralized storage"
-    description="You already know how IPFS pinning works: content addresses, CIDs, pinning to keep data online. Pinner adds website hosting from the same pinned content, storage on a decentralized provider network, and flexible payments including crypto with no KYC or card. Same content addressing you're used to, with a different approach underneath."
+    title="IPFS pinning, plus website hosting and verifiable storage"
+    description="You already know how IPFS pinning works: content addresses, CIDs, pinning to keep data online. Pinner adds website hosting from the same pinned content, storage on a verifiable provider network, and flexible payments including crypto with no KYC or card. Same content addressing you're used to, with a different approach underneath."
     theme="white"
     imageUrl={AboutWhatIsPinner}
     client:load
@@ -79,7 +79,7 @@ const faqs = [
 
   <AboutSection
     subtitle="How It Works"
-    title="Decentralized hosting, no-KYC payments, and more"
+    title="Verifiable hosting, no-KYC payments, and more"
     description="Pay with crypto or card. No KYC for crypto. Your pins live across independent storage providers instead of centralized infrastructure. Host static websites from the same pinned content. Fully open source, no black box."
     theme="gray"
     imagePosition="right"

--- a/apps/pinner.xyz/src/pages/alternatives/vercel/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/vercel/index.astro
@@ -48,7 +48,7 @@ const faqs = [
   },
   {
     question: "How does the peer-to-peer storage work?",
-    answer: "Your static files are stored on the Sia network, where independent storage providers host your data. Providers only get paid when they cryptographically prove they're storing your files. The storage layer is decentralized, not locked to a single provider. The serving layer uses standard HTTP gateways."
+    answer: "Your static files are stored on the Sia network, where independent storage providers host your data. Providers only get paid when they cryptographically prove they're storing your files. The storage layer is verifiable and portable, not locked to a single provider. The serving layer uses standard HTTP gateways."
   }
 ];
 ---

--- a/apps/pinner.xyz/src/pages/how-it-works.astro
+++ b/apps/pinner.xyz/src/pages/how-it-works.astro
@@ -15,7 +15,7 @@ import StorageMobile from "@/assets/how-it-works-mobile-2.png";
 <Layout title="How Pinner Works. IPFS Pinning & Storage" description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. Three steps: pin, distribute, access anywhere.">
   <PageHeader
     title="Simple interface, powerful network"
-    description="IPFS pinning, website hosting, and private storage on a decentralized network"
+    description="IPFS pinning, website hosting, and private storage on a verifiable storage network"
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/solutions/ipfs-pinning.astro
+++ b/apps/pinner.xyz/src/pages/solutions/ipfs-pinning.astro
@@ -23,7 +23,7 @@ const faqs = [
   },
   {
     question: "How is this different from regular cloud storage?",
-    answer: "Traditional cloud storage puts your files on one company's servers. IPFS pinning distributes your content across a decentralized network of independent providers. Your file gets a content address: a unique, verifiable link that doesn't depend on any single provider staying online."
+    answer: "Traditional cloud storage puts your files on one company's servers. IPFS pinning distributes your content across a network of independent providers. Your file gets a content address: a unique, verifiable link that doesn't depend on any single provider staying online."
   },
   {
     question: "Is my data permanent?",
@@ -52,7 +52,7 @@ const faqs = [
 ];
 ---
 
-<Layout title="IPFS Pinning Service & Decentralized Storage" description="Pin files to IPFS and get a permanent link that stays online as long as it's pinned. Decentralized, content-addressed, no vendor lock-in.">
+<Layout title="IPFS Pinning Service & Verifiable Storage" description="Pin files to IPFS and get a permanent link that stays online as long as it's pinned. Content-addressed, verifiable, no vendor lock-in.">
   <PageHeader
     title="IPFS pinning that stays online"
     description="Pin files to a peer-to-peer network. Your content gets a permanent link that stays accessible as long as it's pinned."
@@ -64,7 +64,7 @@ const faqs = [
   <AboutSection
     subtitle="Content Addressing"
     title="Your file gets a permanent link"
-    description="Upload any file and it's pinned to IPFS on a decentralized network. Your content receives a content address: a unique, verifiable link that points to your data regardless of where it's stored. Links stay valid as long as your content is pinned. No short URLs, no broken links, no platform dependencies."
+    description="Upload any file and it's pinned to IPFS on a verifiable storage network. Your content receives a content address: a unique, verifiable link that points to your data regardless of where it's stored. Links stay valid as long as your content is pinned. No short URLs, no broken links, no platform dependencies."
     theme="white"
     imageUrl={HowItWorksImage}
     imgageMobileUrl={HowItWorksMobile}
@@ -72,7 +72,7 @@ const faqs = [
   />
 
   <AboutSection
-    subtitle="Decentralized Network"
+    subtitle="Verifiable Network"
     title="A network, not a data center"
     description="Your files are distributed across independent storage providers, not sitting in one company's servers. If individual hosts go down, your data stays online. Hosts only get paid when they prove your data is there. Crypto payments available for those who prefer them."
     theme="gray"
@@ -85,7 +85,7 @@ const faqs = [
   <AboutSection
     subtitle="Use Cases"
     title="From NFT metadata to dApp assets"
-    description="IPFS pinning powers a range of decentralized use cases: NFT metadata and asset storage, dApp frontend hosting, scientific data publishing with verifiable hashes, archival content that needs to stay link-stable, and any data that benefits from content addressing. If you need a link that points to the same data forever, IPFS pinning is the answer."
+    description="IPFS pinning powers a range of use cases: NFT metadata and asset storage, dApp frontend hosting, scientific data publishing with verifiable hashes, archival content that needs to stay link-stable, and any data that benefits from content addressing. If you need a link that points to the same data forever, IPFS pinning is the answer."
     theme="white"
     imageUrl={UseCasesImage}
     client:load


### PR DESCRIPTION
- About page: meta title, intro, and descriptions
- How-it-works page: description
- IPFS pinning solution page: title, descriptions, FAQ
- Vercel and Netlify alternative pages: storage layer FAQ
- Pinata alternative page: tagline, descriptions, section titles
- AccountSlider: onboarding copy
- ThreeSteps: distribute step description
- Pricing feature copy: IPFS hosting description
- Pinata.json: tagline data

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR updates the marketing copy across the pinner.xyz website to replace the term "decentralized" with "verifiable" (or remove it where appropriate) as part of a repositioning effort.

### Changes Made

The following files were updated to reflect the new terminology:

1. **AccountSlider.tsx** - Updated slider descriptions to use "verifiable storage" and "verifiable storage network" instead of "decentralized"

2. **ThreeSteps.tsx** - Simplified "decentralized network" to just "network" in the distribution step description

3. **featureCopy.ts** - Changed IPFS Hosting description from "decentralized network" to "verifiable storage network"

4. **about.astro** - Updated page title, meta description, and section descriptions to use "verifiable storage" terminology; also removed "decentralized" from the Sia network reference

5. **netlify/index.astro** & **vercel/index.astro** - Updated FAQ answers to describe storage as "verifiable and portable" rather than "decentralized"

6. **pinata/index.astro** - Updated multiple marketing sections including page header, about sections, and meta descriptions to use "verifiable storage" terminology

7. **how-it-works.astro** - Updated page header description to reference "verifiable storage network"

8. **ipfs-pinning.astro** - Updated page title, meta description, section subtitles, and descriptions to replace "decentralized" with "verifiable" or remove it where redundant

### Purpose

This is a terminology/positioning change to move away from the "decentralized" label in favor of "verifiable" when describing the storage network and services. The change affects user-facing marketing copy, SEO metadata, and FAQ content across multiple pages of the pinner.xyz website.
<!-- kody-pr-summary:end -->