### PR TITLE
fix(pinner.xyz): fix pricing API URL defaulting to root domain instead of account subdomain

### DIFF
--- a/apps/pinner.xyz/.env.example
+++ b/apps/pinner.xyz/.env.example
@@ -1,5 +1,5 @@
 # Portal API base URL (used by pricing plans, etc.)
-PUBLIC_PORTAL_API_URL=https://pinner.xyz
+PUBLIC_PORTAL_API_URL=https://account.pinner.xyz
 
 # Listmonk newsletter (derived from portal domain as list.<domain> if unset)
 PUBLIC_LISTMONK_URL=

--- a/apps/pinner.xyz/src/lib/config.ts
+++ b/apps/pinner.xyz/src/lib/config.ts
@@ -6,7 +6,10 @@
 const portalApiUrl =
   import.meta.env.PUBLIC_PORTAL_API_URL || "https://account.pinner.xyz";
 
-const portalDomain = new URL(portalApiUrl).hostname;
+const portalHost = new URL(portalApiUrl).hostname;
+const portalDomain = portalHost.split(".").length > 2
+  ? portalHost.split(".").slice(1).join(".")
+  : portalHost;
 
 const accountBaseUrl = portalApiUrl;
 

--- a/apps/pinner.xyz/src/lib/config.ts
+++ b/apps/pinner.xyz/src/lib/config.ts
@@ -4,11 +4,11 @@
  * to avoid hydration mismatches.
  */
 const portalApiUrl =
-  import.meta.env.PUBLIC_PORTAL_API_URL || "https://pinner.xyz";
+  import.meta.env.PUBLIC_PORTAL_API_URL || "https://account.pinner.xyz";
 
 const portalDomain = new URL(portalApiUrl).hostname;
 
-const accountBaseUrl = `https://account.${portalDomain}`;
+const accountBaseUrl = portalApiUrl;
 
 type RegisterIntent = "pinning" | "hosting" | "storing";
 


### PR DESCRIPTION
- Change PUBLIC_PORTAL_API_URL fallback from https://pinner.xyz to https://account.pinner.xyz
- Set accountBaseUrl to portalApiUrl directly instead of prepending account. to an already-qualified hostname
- Fix .env.example default to match production account subdomain

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR fixes an issue in the pinner.xyz application where the pricing API URL was incorrectly defaulting to the root domain instead of the account subdomain.

### Changes Made

In `apps/pinner.xyz/src/lib/config.ts`:

1. **Updated the default `portalApiUrl`**: Changed from `"https://pinner.xyz"` to `"https://account.pinner.xyz"` to correctly point to the account subdomain by default.

2. **Simplified `accountBaseUrl` assignment**: Instead of reconstructing the account URL by prepending `account.` to the extracted hostname (which could produce incorrect URLs when a custom `PUBLIC_PORTAL_API_URL` was provided), the code now directly uses the `portalApiUrl` value as the `accountBaseUrl`.

### Functional Impact

Previously, when the `PUBLIC_PORTAL_API_URL` environment variable was set to a custom URL (e.g., a staging environment), the code would extract the hostname and prepend `account.` to it, potentially resulting in malformed or incorrect URLs (e.g., `https://account.staging.account.pinner.xyz`). 

This fix ensures the account base URL always uses the configured API URL directly, making the configuration more reliable across different environments and preventing pricing API requests from being sent to the wrong endpoint.
<!-- kody-pr-summary:end -->