### PR TITLE
fix(pinner.xyz): reorder homepage sections, improve hero subheadline spacing

### DIFF
--- a/apps/pinner.xyz/src/components/Home/Hero.tsx
+++ b/apps/pinner.xyz/src/components/Home/Hero.tsx
@@ -48,7 +48,7 @@ const Hero = () => {
   return (
     <HeroSection
       headline={<>Your data.<br />Your rules.</>}
-      subheadline={<><a href="/solutions/ipfs-pinning" className="underline hover:text-white transition-colors">Pin files</a>. <a href="/solutions/website-hosting" className="underline hover:text-white transition-colors">Host sites</a>. <a href="/solutions/private-storage" className="underline hover:text-white transition-colors">Store private data</a>.<br />All on one quota. Zero-knowledge encrypted.<br />Pay by card or crypto, no KYC on crypto.</>}
+      subheadline={<><span className="block mb-2"><a href="/solutions/ipfs-pinning" className="underline hover:text-white transition-colors">Pin files</a>. <a href="/solutions/website-hosting" className="underline hover:text-white transition-colors">Host sites</a>. <a href="/solutions/private-storage" className="underline hover:text-white transition-colors">Store private data</a>.</span><span className="block mb-2">All on one quota. Zero-knowledge encrypted.</span><span className="block">Pay by card or crypto, no KYC on crypto.</span></>}
       primaryButtons={[
         { label: "Start Pinning →", url: config.registerUrl("pinning"), buttonStyle: "btn-light" },
         { label: "Host a Website →", url: config.registerUrl("hosting"), buttonStyle: "btn-light" },

--- a/apps/pinner.xyz/src/pages/index.astro
+++ b/apps/pinner.xyz/src/pages/index.astro
@@ -21,6 +21,10 @@ import { ctaCopy } from "@/lib/config";
 <Layout title="Website Hosting, IPFS Pinning & Private Storage. Pinner" variant="home" showNewsletterFooter={false}>
   <Hero client:load />
 
+  <ProblemAgitation client:load />
+
+  <TrustSection client:load variant="dark" />
+
   <ProductCards client:load />
 
   <UseCases client:load />
@@ -32,10 +36,6 @@ import { ctaCopy } from "@/lib/config";
     variant="dark"
     client:load
   />
-
-  <ProblemAgitation client:load />
-
-  <TrustSection client:load variant="dark" />
 
   <Account client:load variant="dark" />
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This PR reorders the homepage sections on pinner.xyz and improves the hero subheadline spacing.

### Changes

1. **Homepage section reordering** (`index.astro`): The `ProblemAgitation` and `TrustSection` components were moved from their previous position (after `UseCases`) to immediately follow the `Hero` section, placing them before `ProductCards`. This shifts the problem/trust narrative earlier in the page flow.

2. **Hero subheadline spacing** (`Hero.tsx`): The subheadline layout was improved by replacing `<br />` line breaks with block-level `<span>` elements that include bottom margin (`mb-2`). This provides more controlled, consistent vertical spacing between the three lines of the subheadline (product links, quota/encryption info, and payment info).
<!-- kody-pr-summary:end -->