### PR TITLE
fix(pinner.xyz): brand heading on trust section

### DIFF
--- a/apps/pinner.xyz/src/components/Home/TrustSection.tsx
+++ b/apps/pinner.xyz/src/components/Home/TrustSection.tsx
@@ -27,7 +27,7 @@ const TrustSection = ({ variant = "default" }: TrustSectionProps) => {
 	return (
 		<Section variant={variant} padding="md">
 			<div className="xl:container px-6">
-				<Heading title="What we do better" />
+				<Heading title="What Pinner Does Better" />
 
 				<div className="mx-auto max-w-[1000px] grid grid-cols-1 gap-4 md:grid-cols-3 lg:gap-6">
 					{principles.map((p, i) => (


### PR DESCRIPTION
## What changed

Changed the trust section heading from "What we do better" to "What Pinner Does Better" on the homepage.

## Why

Uses the brand name in the section heading instead of generic "we".

---

<!-- kody-pr-summary:start -->
This pull request updates the heading text in the Trust Section of the Pinner.xyz home page. The generic title "What we do better" has been changed to the brand-specific title "What Pinner Does Better".
<!-- kody-pr-summary:end -->