### PR TITLE
chore: add setup-pinner-cli script for local dev

### DIFF
--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -12,7 +12,7 @@
     "generate:typedoc": "typedoc",
     "generate:cli": "tsx scripts/generate-cli-ref.ts",
     "generate:sdk": "pnpm generate:typedoc && tsx scripts/generate-sdk-ref.ts",
-    "setup:pinner": "eval \"$(bash ../../scripts/setup-pinner-cli.sh)\""
+    "setup:pinner": "out=$(bash ../../scripts/setup-pinner-cli.sh) && eval \"$out\""
   },
   "dependencies": {
     "@fontsource/inter": "catalog:websites",

--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -8,10 +8,11 @@
     "build": "pnpm generate && vocs build",
     "preview": "vocs preview",
     "generate": "pnpm generate:cli-ref && pnpm generate:cli && pnpm generate:sdk",
-    "generate:cli-ref": "mkdir -p reference-sources && pinner generate-docs json > reference-sources/cli-ref.json",
+    "generate:cli-ref": "pnpm setup:pinner && mkdir -p reference-sources && pinner generate-docs json > reference-sources/cli-ref.json",
     "generate:typedoc": "typedoc",
     "generate:cli": "tsx scripts/generate-cli-ref.ts",
-    "generate:sdk": "pnpm generate:typedoc && tsx scripts/generate-sdk-ref.ts"
+    "generate:sdk": "pnpm generate:typedoc && tsx scripts/generate-sdk-ref.ts",
+    "setup:pinner": "bash ../../scripts/setup-pinner-cli.sh"
   },
   "dependencies": {
     "@fontsource/inter": "catalog:websites",

--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -12,7 +12,7 @@
     "generate:typedoc": "typedoc",
     "generate:cli": "tsx scripts/generate-cli-ref.ts",
     "generate:sdk": "pnpm generate:typedoc && tsx scripts/generate-sdk-ref.ts",
-    "setup:pinner": "bash ../../scripts/setup-pinner-cli.sh"
+    "setup:pinner": "eval \"$(bash ../../scripts/setup-pinner-cli.sh)\""
   },
   "dependencies": {
     "@fontsource/inter": "catalog:websites",

--- a/scripts/setup-pinner-cli.sh
+++ b/scripts/setup-pinner-cli.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Setup pinner-cli binary for local development.
+#
+# If `pinner` is already on PATH, does nothing.
+# Otherwise, installs it via `go install go.lumeweb.com/pinner-cli/cmd/pinner@latest`
+# and ensures the GOPATH/bin directory is on PATH.
+#
+# This mirrors the CI composite action at .github/actions/setup-pinner-cli/action.yml.
+#
+set -euo pipefail
+
+if command -v pinner &>/dev/null; then
+  exit 0
+fi
+
+if ! command -v go &>/dev/null; then
+  echo "error: 'go' is not installed and 'pinner' binary not found on PATH." >&2
+  echo "       Install Go or place the pinner binary on PATH manually." >&2
+  exit 1
+fi
+
+VERSION="${PINNER_CLI_VERSION:-latest}"
+echo "Installing pinner-cli@${VERSION} via go install..."
+GOTOOLCHAIN="${GOTOOLCHAIN:-auto}" go install go.lumeweb.com/pinner-cli/cmd/pinner@"${VERSION}"
+
+GOPATH_BIN="$(go env GOPATH)/bin"
+if [[ ":${PATH}:" != *":${GOPATH_BIN}:"* ]]; then
+  echo "export PATH=\"${GOPATH_BIN}:\${PATH}\""
+  export PATH="${GOPATH_BIN}:${PATH}"
+fi
+
+echo "pinner-cli installed to ${GOPATH_BIN}/pinner"
+pinner version

--- a/scripts/setup-pinner-cli.sh
+++ b/scripts/setup-pinner-cli.sh
@@ -4,12 +4,16 @@
 #
 # If `pinner` is already on PATH, does nothing.
 # Otherwise, installs it via `go install go.lumeweb.com/pinner-cli/cmd/pinner@latest`
-# and ensures the GOPATH/bin directory is on PATH.
+# and emits a PATH export for the caller to eval.
+#
+# Usage in package.json scripts:
+#   "setup:pinner": "eval \"$(bash ../../scripts/setup-pinner-cli.sh)\""
 #
 # This mirrors the CI composite action at .github/actions/setup-pinner-cli/action.yml.
 #
 set -euo pipefail
 
+# If pinner is already on PATH, nothing to do.
 if command -v pinner &>/dev/null; then
   exit 0
 fi
@@ -21,14 +25,15 @@ if ! command -v go &>/dev/null; then
 fi
 
 VERSION="${PINNER_CLI_VERSION:-latest}"
-echo "Installing pinner-cli@${VERSION} via go install..."
-GOTOOLCHAIN="${GOTOOLCHAIN:-auto}" go install go.lumeweb.com/pinner-cli/cmd/pinner@"${VERSION}"
+echo "Installing pinner-cli@${VERSION} via go install..." >&2
+GOTOOLCHAIN="${GOTOOLCHAIN:-auto}" go install go.lumeweb.com/pinner-cli/cmd/pinner@"${VERSION}" >&2
 
 GOPATH_BIN="$(go env GOPATH)/bin"
 if [[ ":${PATH}:" != *":${GOPATH_BIN}:"* ]]; then
+  # Emit the PATH export to stdout so `eval "$(...)"` in the caller picks it up.
   echo "export PATH=\"${GOPATH_BIN}:\${PATH}\""
   export PATH="${GOPATH_BIN}:${PATH}"
 fi
 
-echo "pinner-cli installed to ${GOPATH_BIN}/pinner"
-pinner version
+echo "pinner-cli installed to ${GOPATH_BIN}/pinner" >&2
+pinner version >&2

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,9 @@
     },
     "build-storybook": {
       "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"]
+    },
+    "setup:pinner": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## What

Adds a `scripts/setup-pinner-cli.sh` helper that mirrors the CI composite action — if `pinner` is not already on PATH, it installs via `go install go.lumeweb.com/pinner-cli/cmd/pinner@latest`.

## Why

Running `pnpm build` locally fails for `@lumeweb/docs.pinner.xyz` because the `pinner` binary isn't installed. CI handles this via `.github/actions/setup-pinner-cli`, but there's no equivalent for local dev.

## Changes

- **`scripts/setup-pinner-cli.sh`** — no-ops if `pinner` is on PATH; otherwise `go install`s it
- **`apps/docs.pinner.xyz/package.json`** — `generate:cli-ref` now runs `pnpm setup:pinner` first
- **`turbo.json`** — adds uncached `setup:pinner` task

---

<!-- kody-pr-summary:start -->
This pull request adds a new shell script (`scripts/setup-pinner-cli.sh`) to automate the installation and setup of the `pinner-cli` binary for local development. 

The script checks if `pinner` is already available on the system's PATH. If not, it verifies that Go is installed, installs the `pinner-cli` tool via `go install`, and ensures the Go bin directory is added to the PATH. This provides a convenient way for developers to set up the `pinner` tool locally, mirroring the existing CI setup process.
<!-- kody-pr-summary:end -->