### PR TITLE
fix(pinner): centralize auth in AuthManager

### DIFF
--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -8,10 +8,11 @@
     "build": "pnpm generate && vocs build",
     "preview": "vocs preview",
     "generate": "pnpm generate:cli-ref && pnpm generate:cli && pnpm generate:sdk",
-    "generate:cli-ref": "mkdir -p reference-sources && pinner generate-docs json > reference-sources/cli-ref.json",
+    "generate:cli-ref": "pnpm setup:pinner && mkdir -p reference-sources && pinner generate-docs json > reference-sources/cli-ref.json",
     "generate:typedoc": "typedoc",
     "generate:cli": "tsx scripts/generate-cli-ref.ts",
-    "generate:sdk": "pnpm generate:typedoc && tsx scripts/generate-sdk-ref.ts"
+    "generate:sdk": "pnpm generate:typedoc && tsx scripts/generate-sdk-ref.ts",
+    "setup:pinner": "bash ../../scripts/setup-pinner-cli.sh"
   },
   "dependencies": {
     "@fontsource/inter": "catalog:websites",

--- a/libs/pinner/src/api/__tests__/ipns.spec.ts
+++ b/libs/pinner/src/api/__tests__/ipns.spec.ts
@@ -73,7 +73,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.listKeys()).rejects.toThrow(AuthenticationError);
     });
 
@@ -169,7 +169,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       const request: IPNSKeyRequest = {
         name: "test-key",
       };
@@ -198,7 +198,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.deleteKey(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -244,7 +244,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       const request: IPNSPublishRequest = {
         key_id: 1,
         cid: "QmTestCID",
@@ -269,7 +269,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.republish(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -295,7 +295,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.resolve("k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e")).rejects.toThrow(AuthenticationError);
     });
   });

--- a/libs/pinner/src/api/__tests__/ipns.spec.ts
+++ b/libs/pinner/src/api/__tests__/ipns.spec.ts
@@ -25,6 +25,7 @@ import {
   createNotFoundHandler,
 } from "@/__tests__/msw";
 import { testConfig } from "@/__tests__/setup";
+import { JwtAuthManager } from "@/auth";
 
 const websiteStore = new WebsiteStore();
 const ipnsStore = new IPNSStore();
@@ -44,6 +45,8 @@ describe("IpnsClient", () => {
     endpoint: "https://test.pinner.xyz",
   };
 
+const mockAuth = new JwtAuthManager(mockConfig.jwt!);
+
   beforeEach(() => {
     // Reset mock data state before each test to ensure isolation
     resetWebsitesIPNSState(websiteStore, ipnsStore);
@@ -52,7 +55,7 @@ describe("IpnsClient", () => {
   describe("listKeys", () => {
     it("should list all IPNS keys", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const result = await client.listKeys();
 
@@ -70,8 +73,7 @@ describe("IpnsClient", () => {
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.listKeys()).rejects.toThrow(AuthenticationError);
     });
 
@@ -88,7 +90,7 @@ describe("IpnsClient", () => {
       );
 
       // For now, just test normal case
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
       const result = await client.listKeys();
       expect(result).toBeDefined();
     });
@@ -97,7 +99,7 @@ describe("IpnsClient", () => {
   describe("getKey", () => {
     it("should get a specific IPNS key", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const key = await client.getKey(1);
 
@@ -111,7 +113,7 @@ describe("IpnsClient", () => {
 
     it("should throw NotFoundError for non-existent key", async ({ worker }) => {
       worker.use(ipnsNotFoundHandler);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       await expect(client.getKey(999)).rejects.toThrow(NotFoundError);
     });
@@ -120,7 +122,7 @@ describe("IpnsClient", () => {
   describe("createKey", () => {
     it("should create a new IPNS key", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const request: IPNSKeyRequest = {
         name: "new-key",
@@ -137,11 +139,11 @@ describe("IpnsClient", () => {
 
     it("should import an existing IPNS key", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const request: IPNSKeyRequest = {
         name: "imported-key",
-        key: "-----BEGIN PRIVATE KEY-----\ntest-key-data\n-----END PRIVATE KEY-----",
+        key: "[REDACTED PRIVATE KEY]",
       };
 
       const key = await client.createKey(request);
@@ -152,7 +154,7 @@ describe("IpnsClient", () => {
 
     it("should handle validation errors", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const request: IPNSKeyRequest = {
         name: "",
@@ -167,8 +169,7 @@ describe("IpnsClient", () => {
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       const request: IPNSKeyRequest = {
         name: "test-key",
       };
@@ -180,14 +181,14 @@ describe("IpnsClient", () => {
   describe("deleteKey", () => {
     it("should delete an IPNS key", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       await expect(client.deleteKey(1)).resolves.not.toThrow();
     });
 
     it("should throw NotFoundError for non-existent key", async ({ worker }) => {
       worker.use(ipnsNotFoundHandler);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       await expect(client.deleteKey(999)).rejects.toThrow(NotFoundError);
     });
@@ -197,8 +198,7 @@ describe("IpnsClient", () => {
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.deleteKey(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -206,7 +206,7 @@ describe("IpnsClient", () => {
   describe("publish", () => {
     it("should publish CID to IPNS key", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const request: IPNSPublishRequest = {
         key_id: 1,
@@ -226,7 +226,7 @@ describe("IpnsClient", () => {
 
     it("should handle validation errors", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const request: IPNSPublishRequest = {
         key_id: 1,
@@ -244,8 +244,7 @@ describe("IpnsClient", () => {
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       const request: IPNSPublishRequest = {
         key_id: 1,
         cid: "QmTestCID",
@@ -258,7 +257,7 @@ describe("IpnsClient", () => {
   describe("republish", () => {
     it("should republish an IPNS key by ID", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const result = await client.republish(1);
       expect(result).toHaveProperty("count");
@@ -270,8 +269,7 @@ describe("IpnsClient", () => {
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.republish(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -279,7 +277,7 @@ describe("IpnsClient", () => {
   describe("resolve", () => {
     it("should resolve IPNS name to CID", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       const ipnsName = "k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e";
       const result: IPNSResolveResponse = await client.resolve(ipnsName);
@@ -297,8 +295,7 @@ describe("IpnsClient", () => {
       const client = new IpnsClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.resolve("k51qzi5uqu5dj14p8d8q8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e8y4e")).rejects.toThrow(AuthenticationError);
     });
   });
@@ -310,7 +307,7 @@ describe("IpnsClient", () => {
         endpoint: "https://test.com",
       };
 
-      const minimalClient = new IpnsClient(minimalConfig);
+      const minimalClient = new IpnsClient(minimalConfig, mockAuth);
       expect(minimalClient).toBeInstanceOf(IpnsClient);
     });
 
@@ -320,7 +317,7 @@ describe("IpnsClient", () => {
         endpoint: "https://custom.api.com",
       };
 
-      const customClient = new IpnsClient(customConfig);
+      const customClient = new IpnsClient(customConfig, mockAuth);
       expect(customClient).toBeInstanceOf(IpnsClient);
     });
 
@@ -330,18 +327,18 @@ describe("IpnsClient", () => {
         endpoint: "https://test.com",
       } as PinnerConfig;
 
-      expect(() => new IpnsClient(invalidConfig)).toThrow(ConfigurationError);
+      expect(() => new IpnsClient(invalidConfig, new JwtAuthManager(invalidConfig.jwt))).toThrow(ConfigurationError);
     });
 
     it("should throw ConfigurationError with missing config", () => {
-      expect(() => new IpnsClient({} as PinnerConfig)).toThrow(ConfigurationError);
+      expect(() => new IpnsClient({} as PinnerConfig, new JwtAuthManager(undefined as unknown as string))).toThrow(ConfigurationError);
     });
   });
 
   describe("error handling", () => {
     it("should handle network errors gracefully", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       // Test normal operation
       const result = await client.listKeys();
@@ -350,7 +347,7 @@ describe("IpnsClient", () => {
 
     it("should handle malformed responses", async ({ worker }) => {
       worker.use(...ipnsHandlers);
-      const client = new IpnsClient(mockConfig);
+      const client = new IpnsClient(mockConfig, mockAuth);
 
       // Test normal operation
       const result = await client.listKeys();

--- a/libs/pinner/src/api/__tests__/websites.integration.spec.ts
+++ b/libs/pinner/src/api/__tests__/websites.integration.spec.ts
@@ -5,12 +5,12 @@ import type { PinnerConfig } from "@/config";
 import type { SSLStatusInfo } from "../generated/schemas/index";
 import { SSLStatus } from "../websites";
 import {
-import { JwtAuthManager } from "@/auth";
   WebsiteStore,
   IPNSStore,
   createWebsiteHandlers,
   resetWebsitesIPNSState,
 } from "@/__tests__/msw";
+import { JwtAuthManager } from "@/auth";
 
 const websiteStore = new WebsiteStore();
 const ipnsStore = new IPNSStore();

--- a/libs/pinner/src/api/__tests__/websites.integration.spec.ts
+++ b/libs/pinner/src/api/__tests__/websites.integration.spec.ts
@@ -5,6 +5,7 @@ import type { PinnerConfig } from "@/config";
 import type { SSLStatusInfo } from "../generated/schemas/index";
 import { SSLStatus } from "../websites";
 import {
+import { JwtAuthManager } from "@/auth";
   WebsiteStore,
   IPNSStore,
   createWebsiteHandlers,
@@ -23,6 +24,8 @@ describe("WebsitesClient SSL Integration Tests", () => {
     endpoint: "https://test.pinner.xyz",
   };
 
+const mockAuth = new JwtAuthManager(mockConfig.jwt!);
+
   beforeEach(() => {
     // Reset mock data state before each test to ensure isolation
     resetWebsitesIPNSState(websiteStore, ipnsStore);
@@ -32,7 +35,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
   describe("SSL Status Monitoring Integration", () => {
     it("should monitor SSL status from pending to ready", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       // Start with pending status
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
@@ -67,7 +70,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle SSL provisioning failure", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -98,7 +101,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should timeout if SSL never becomes ready", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -124,7 +127,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle multiple status transitions", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -159,7 +162,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should allow stopping and restarting the watcher", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -199,7 +202,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle concurrent watchers", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -232,7 +235,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should support abort signal for SSL status check", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.VALID);
 
@@ -246,7 +249,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle rapid status updates", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -280,7 +283,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle error responses from API", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       // Test with a domain that might not exist — use a short timeout
       const watcher = client.watchSSL("nonexistent.example.com", { interval: 100, timeout: 500 });
@@ -302,7 +305,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
   describe("SSL Status Fetch", () => {
     it("should fetch current SSL status", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", "valid", undefined);
 
@@ -314,7 +317,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should fetch SSL status with error detail", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", "failed", "DNS record not found");
 
@@ -326,7 +329,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle different SSL states", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const states = [
         SSLStatus.PENDING,
@@ -347,7 +350,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
   describe("SSL Watcher Lifecycle", () => {
     it("should allow multiple start/stop cycles", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -373,7 +376,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle stop before start", ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const watcher = client.watchSSL("example.com");
 
@@ -384,7 +387,7 @@ describe("WebsitesClient SSL Integration Tests", () => {
 
     it("should handle multiple stop calls", async ({ worker }) => {
       worker.use(...createWebsiteHandlers(websiteStore, ipnsStore));
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 

--- a/libs/pinner/src/api/__tests__/websites.spec.ts
+++ b/libs/pinner/src/api/__tests__/websites.spec.ts
@@ -26,6 +26,7 @@ import {
   createNotFoundHandler,
 } from "@/__tests__/msw";
 import { testConfig } from "@/__tests__/setup";
+import { JwtAuthManager } from "@/auth";
 
 const websiteStore = new WebsiteStore();
 const ipnsStore = new IPNSStore();
@@ -44,6 +45,8 @@ describe("WebsitesClient", () => {
     endpoint: "https://test.pinner.xyz",
   };
 
+const mockAuth = new JwtAuthManager(mockConfig.jwt!);
+
   beforeEach(() => {
     // Reset mock data state before each test to ensure isolation
     resetWebsitesIPNSState(websiteStore, ipnsStore);
@@ -53,7 +56,7 @@ describe("WebsitesClient", () => {
   describe("list", () => {
     it("should list all websites", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const websites = await client.listWebsites();
 
@@ -75,14 +78,13 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.listWebsites()).rejects.toThrow(AuthenticationError);
     });
 
     it("should handle network errors", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       // Test normal operation
       const websites = await client.listWebsites();
@@ -93,7 +95,7 @@ describe("WebsitesClient", () => {
   describe("get", () => {
     it("should get website details", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const website: WebsiteResponse = await client.getWebsite(1);
 
@@ -110,7 +112,7 @@ describe("WebsitesClient", () => {
 
     it("should throw NotFoundError for non-existent website", async ({ worker }) => {
       worker.use(websiteNotFoundHandler);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       await expect(client.getWebsite(999)).rejects.toThrow(NotFoundError);
     });
@@ -120,8 +122,7 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.getWebsite(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -129,7 +130,7 @@ describe("WebsitesClient", () => {
   describe("create", () => {
     it("should create a new website", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const request: WebsiteRequest = {
         domain: "test.example.com",
@@ -148,7 +149,7 @@ describe("WebsitesClient", () => {
 
     it("should create a website with IPNS target", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const request: WebsiteRequest = {
         domain: "test.example.com",
@@ -164,7 +165,7 @@ describe("WebsitesClient", () => {
 
     it("should handle validation errors", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const request: WebsiteRequest = {
         domain: "", // Invalid: empty domain
@@ -183,8 +184,7 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       const request: WebsiteRequest = {
         domain: "test.example.com",
         target_type: "ipfs",
@@ -198,7 +198,7 @@ describe("WebsitesClient", () => {
   describe("update", () => {
     it("should update an existing website", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
@@ -216,7 +216,7 @@ describe("WebsitesClient", () => {
 
     it("should update partial fields on a website", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const request: WebsiteUpdateRequest = {
         target_hash: "QmUpdatedOnlyCID",
@@ -230,7 +230,7 @@ describe("WebsitesClient", () => {
 
     it("should throw NotFoundError for non-existent website", async ({ worker }) => {
       worker.use(websiteNotFoundHandler);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
@@ -246,8 +246,7 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
         target_type: "ipfs",
@@ -261,14 +260,14 @@ describe("WebsitesClient", () => {
   describe("delete", () => {
     it("should delete a website", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       await expect(client.deleteWebsite(1)).resolves.not.toThrow();
     });
 
     it("should throw NotFoundError for non-existent website", async ({ worker }) => {
       worker.use(websiteNotFoundHandler);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       await expect(client.deleteWebsite(999)).rejects.toThrow(NotFoundError);
     });
@@ -278,8 +277,7 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.deleteWebsite(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -287,7 +285,7 @@ describe("WebsitesClient", () => {
   describe("validate", () => {
     it("should validate website DNS", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const result: WebsiteValidateResponse = await client.validateWebsite(1);
 
@@ -303,7 +301,7 @@ describe("WebsitesClient", () => {
 
     it("should throw NotFoundError for non-existent website", async ({ worker }) => {
       worker.use(websiteNotFoundHandler);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       await expect(client.validateWebsite(999)).rejects.toThrow(NotFoundError);
     });
@@ -313,14 +311,13 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.validateWebsite(1)).rejects.toThrow(AuthenticationError);
     });
 
     it("should return reason field from validation response", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const result = await client.validateWebsite(1);
 
@@ -360,7 +357,7 @@ describe("WebsitesClient", () => {
   describe("getSSLStatus", () => {
     it("should get SSL status for a domain", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.VALID);
 
@@ -372,7 +369,7 @@ describe("WebsitesClient", () => {
 
     it("should get SSL status with error", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.FAILED, "DNS validation failed");
 
@@ -384,7 +381,7 @@ describe("WebsitesClient", () => {
 
     it("should support abort signal", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const controller = new AbortController();
       controller.abort();
@@ -398,7 +395,7 @@ describe("WebsitesClient", () => {
   describe("getWebsiteConfig", () => {
     it("should get website hosting configuration", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       const config = await client.getWebsiteConfig();
 
@@ -420,8 +417,7 @@ describe("WebsitesClient", () => {
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      });
-
+      }, mockAuth);
       await expect(client.getWebsiteConfig()).rejects.toThrow(AuthenticationError);
     });
   });
@@ -429,7 +425,7 @@ describe("WebsitesClient", () => {
   describe("watchSSL", () => {
     it("should watch SSL status and emit ready when SSL is valid", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -453,7 +449,7 @@ describe("WebsitesClient", () => {
 
     it("should watch SSL status and emit error when SSL fails", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -476,7 +472,7 @@ describe("WebsitesClient", () => {
 
     it("should emit status updates", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -505,7 +501,7 @@ describe("WebsitesClient", () => {
 
     it("should timeout if SSL never becomes ready", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -524,7 +520,7 @@ describe("WebsitesClient", () => {
 
     it("should stop watching", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       websiteStore.setSSLStatus("example.com", SSLStatus.PENDING);
 
@@ -550,7 +546,7 @@ describe("WebsitesClient", () => {
 
     it("should handle network errors", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       // This test would need MSW to return network errors
       // For now, we just verify the structure exists
@@ -569,7 +565,7 @@ describe("WebsitesClient", () => {
         endpoint: "https://test.com",
       };
 
-      const minimalClient = new WebsitesClient(minimalConfig);
+      const minimalClient = new WebsitesClient(minimalConfig, mockAuth);
       expect(minimalClient).toBeInstanceOf(WebsitesClient);
     });
 
@@ -579,7 +575,7 @@ describe("WebsitesClient", () => {
         endpoint: "https://custom.api.com",
       };
 
-      const customClient = new WebsitesClient(customConfig);
+      const customClient = new WebsitesClient(customConfig, mockAuth);
       expect(customClient).toBeInstanceOf(WebsitesClient);
     });
 
@@ -589,18 +585,18 @@ describe("WebsitesClient", () => {
         endpoint: "https://test.com",
       } as PinnerConfig;
 
-      expect(() => new WebsitesClient(invalidConfig)).toThrow(ConfigurationError);
+      expect(() => new WebsitesClient(invalidConfig, new JwtAuthManager(invalidConfig.jwt))).toThrow(ConfigurationError);
     });
 
     it("should throw ConfigurationError with missing config", () => {
-      expect(() => new WebsitesClient({} as PinnerConfig)).toThrow(ConfigurationError);
+      expect(() => new WebsitesClient({} as PinnerConfig, new JwtAuthManager(undefined as unknown as string))).toThrow(ConfigurationError);
     });
   });
 
   describe("error handling", () => {
     it("should handle network errors gracefully", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       // Test normal operation
       const websites = await client.listWebsites();
@@ -609,7 +605,7 @@ describe("WebsitesClient", () => {
 
     it("should handle malformed responses", async ({ worker }) => {
       worker.use(...websiteHandlers);
-      const client = new WebsitesClient(mockConfig);
+      const client = new WebsitesClient(mockConfig, mockAuth);
 
       // Test normal operation
       const websites = await client.listWebsites();

--- a/libs/pinner/src/api/__tests__/websites.spec.ts
+++ b/libs/pinner/src/api/__tests__/websites.spec.ts
@@ -78,7 +78,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.listWebsites()).rejects.toThrow(AuthenticationError);
     });
 
@@ -122,7 +122,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.getWebsite(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -184,7 +184,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       const request: WebsiteRequest = {
         domain: "test.example.com",
         target_type: "ipfs",
@@ -246,7 +246,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       const request: WebsiteUpdateRequest = {
         domain: "updated.example.com",
         target_type: "ipfs",
@@ -277,7 +277,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.deleteWebsite(1)).rejects.toThrow(AuthenticationError);
     });
   });
@@ -311,7 +311,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.validateWebsite(1)).rejects.toThrow(AuthenticationError);
     });
 
@@ -417,7 +417,7 @@ const mockAuth = new JwtAuthManager(mockConfig.jwt!);
       const client = new WebsitesClient({
         jwt: "invalid-jwt",
         endpoint: "https://test.pinner.xyz",
-      }, mockAuth);
+      }, new JwtAuthManager("invalid-jwt"));
       await expect(client.getWebsiteConfig()).rejects.toThrow(AuthenticationError);
     });
   });

--- a/libs/pinner/src/api/client.ts
+++ b/libs/pinner/src/api/client.ts
@@ -1,0 +1,82 @@
+import ky, { HTTPError } from "ky";
+import type { AuthManager } from "@/auth";
+import {
+  AuthenticationError,
+  NotFoundError,
+  NetworkError,
+  ValidationError,
+} from "@/errors";
+
+/**
+ * Shared base class for API clients that use ky with Bearer auth.
+ *
+ * Replaces the duplicated request() + error handling in IpnsClient and WebsitesClient.
+ * Auth headers come from AuthManager — one source of truth.
+ */
+export abstract class ApiClient {
+  protected readonly auth: AuthManager;
+  protected readonly endpoint: string;
+
+  constructor(auth: AuthManager, endpoint: string) {
+    this.auth = auth;
+    this.endpoint = endpoint;
+  }
+
+  protected async request<T>(
+    path: string,
+    options?: RequestInit & { signal?: AbortSignal },
+  ): Promise<T> {
+    try {
+      const response = await ky(path, {
+        prefix: this.endpoint,
+        headers: {
+          ...this.auth.getAuthHeaders(),
+          "Content-Type": "application/json",
+        },
+        ...options,
+      });
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const text = await response.text();
+      if (!text) {
+        return undefined as T;
+      }
+
+      return JSON.parse(text) as T;
+    } catch (error) {
+      throw await this.mapError(error);
+    }
+  }
+
+  protected async mapError(error: unknown): Promise<Error> {
+    if (error instanceof HTTPError) {
+      const status = error.response.status;
+      const body = await error.response.json().catch(() => ({}));
+      const message = (body as any).error || (body as any).message;
+
+      if (status === 401 || status === 403) {
+        return new AuthenticationError(message || "Authentication failed");
+      }
+      if (status === 404) {
+        return new NotFoundError(message || "Resource not found");
+      }
+      if (status === 400) {
+        return new ValidationError(message || "Invalid request");
+      }
+      if (status === 410) {
+        return new ValidationError(message || "Target is broken or gone");
+      }
+
+      return new NetworkError(message || `HTTP error: ${status}`);
+    }
+
+    if (error instanceof Error) {
+      return new NetworkError(error.message);
+    }
+
+    return new NetworkError("Unknown error occurred");
+  }
+}

--- a/libs/pinner/src/api/ipns.ts
+++ b/libs/pinner/src/api/ipns.ts
@@ -1,5 +1,6 @@
-import ky, { HTTPError } from "ky";
 import type { PinnerConfig } from "../config";
+import type { AuthManager } from "@/auth";
+import { ApiClient } from "./client";
 import type {
   IPNSKeyListResponseResponse,
   IPNSKeyRequest,
@@ -9,13 +10,6 @@ import type {
   IPNSRepublishResponse,
   IPNSResolveResponse,
 } from "./generated/schemas/index";
-import {
-  ConfigurationError,
-  AuthenticationError,
-  NotFoundError,
-  NetworkError,
-  ValidationError,
-} from "@/errors";
 
 export interface IpnsClientOptions {
   signal?: AbortSignal;
@@ -24,86 +18,14 @@ export interface IpnsClientOptions {
 /**
  * Client for managing IPNS keys and publishing content to IPNS names.
  */
-export class IpnsClient {
-  private config: PinnerConfig;
-
+export class IpnsClient extends ApiClient {
   /**
    * Create a new IpnsClient.
    * @param config SDK configuration
+   * @param auth AuthManager for authentication
    */
-  constructor(config: PinnerConfig) {
-    if (!config.jwt) {
-      throw new ConfigurationError("JWT token is required");
-    }
-    this.config = config;
-  }
-
-  private getEndpoint(): string {
-    return this.config.endpoint ?? "https://ipfs.pinner.xyz";
-  }
-
-  private async request<T>(
-    path: string,
-    options?: RequestInit & { signal?: AbortSignal },
-  ): Promise<T> {
-    if (!this.config.jwt) {
-      throw new ConfigurationError("JWT token is required");
-    }
-
-    try {
-      const response = await ky(path, {
-        prefix: this.getEndpoint(),
-        headers: {
-          Authorization: `Bearer ${this.config.jwt}`,
-          "Content-Type": "application/json",
-        },
-        ...options,
-      });
-
-      if (response.status === 204) {
-        return undefined as T;
-      }
-
-      const text = await response.text();
-      if (!text) {
-        return undefined as T;
-      }
-
-      return JSON.parse(text) as T;
-    } catch (error) {
-      if (error instanceof HTTPError) {
-        const status = error.response.status;
-        const body = await error.response.json().catch(() => ({}));
-
-        if (status === 401) {
-          throw new AuthenticationError(
-            body.error || "Authentication failed",
-          );
-        }
-        if (status === 403) {
-          throw new AuthenticationError(
-            body.error || "Access forbidden",
-          );
-        }
-        if (status === 404) {
-          throw new NotFoundError(body.error || "Resource not found");
-        }
-        if (status === 400) {
-          throw new ValidationError(body.error || "Invalid request");
-        }
-
-        throw new NetworkError(
-          body.error || `HTTP error: ${status}`,
-          status,
-        );
-      }
-
-      if (error instanceof Error) {
-        throw new NetworkError(error.message);
-      }
-
-      throw new NetworkError("Unknown error occurred");
-    }
+  constructor(config: PinnerConfig, auth: AuthManager) {
+    super(auth, config.endpoint ?? "https://ipfs.pinner.xyz");
   }
 
   /**

--- a/libs/pinner/src/api/websites.ts
+++ b/libs/pinner/src/api/websites.ts
@@ -1,6 +1,7 @@
-import ky, { HTTPError } from "ky";
 import { createNanoEvents } from "nanoevents";
 import type { PinnerConfig } from "../config";
+import type { AuthManager } from "@/auth";
+import { ApiClient } from "./client";
 import type {
   WebsiteItemResponse,
   WebsiteRequest,
@@ -53,13 +54,6 @@ export function isValidationReason(response: WebsiteValidateResponse | null | un
   }
   return response.reason === reason;
 }
-import {
-  ConfigurationError,
-  AuthenticationError,
-  NotFoundError,
-  NetworkError,
-  ValidationError,
-} from "@/errors";
 
 export interface WebsitesClientOptions {
   signal?: AbortSignal;
@@ -68,88 +62,14 @@ export interface WebsitesClientOptions {
 /**
  * Client for managing websites hosted on IPFS with custom domains and SSL.
  */
-export class WebsitesClient {
-  private config: PinnerConfig;
-
+export class WebsitesClient extends ApiClient {
   /**
    * Create a new WebsitesClient.
    * @param config SDK configuration
+   * @param auth AuthManager for authentication
    */
-  constructor(config: PinnerConfig) {
-    if (!config.jwt) {
-      throw new ConfigurationError("JWT token is required");
-    }
-    this.config = config;
-  }
-
-  private getEndpoint(): string {
-    return this.config.endpoint ?? "https://ipfs.pinner.xyz";
-  }
-
-  private async request<T>(
-    path: string,
-    options?: RequestInit & { signal?: AbortSignal },
-  ): Promise<T> {
-    if (!this.config.jwt) {
-      throw new ConfigurationError("JWT token is required");
-    }
-
-    try {
-      const response = await ky(path, {
-        prefix: this.getEndpoint(),
-        headers: {
-          Authorization: `Bearer ${this.config.jwt}`,
-          "Content-Type": "application/json",
-        },
-        ...options,
-      });
-
-      if (response.status === 204) {
-        return undefined as T;
-      }
-
-      const text = await response.text();
-      if (!text) {
-        return undefined as T;
-      }
-
-      return JSON.parse(text) as T;
-    } catch (error) {
-      if (error instanceof HTTPError) {
-        const status = error.response.status;
-        const body = await error.response.json().catch(() => ({}));
-
-        if (status === 401) {
-          throw new AuthenticationError(
-            body.error || "Authentication failed",
-          );
-        }
-        if (status === 403) {
-          throw new AuthenticationError(
-            body.error || "Access forbidden",
-          );
-        }
-        if (status === 404) {
-          throw new NotFoundError(body.error || "Resource not found");
-        }
-        if (status === 400) {
-          throw new ValidationError(body.error || "Invalid request");
-        }
-        if (status === 410) {
-          throw new ValidationError(body.error || "Target is broken or gone");
-        }
-
-        throw new NetworkError(
-          body.error || `HTTP error: ${status}`,
-        );
-      }
-
-      if (error instanceof Error) {
-        throw new NetworkError(error.message);
-      }
-
-      throw new NetworkError("Unknown error occurred");
-    }
+  constructor(config: PinnerConfig, auth: AuthManager) {
+    super(auth, config.endpoint ?? "https://ipfs.pinner.xyz");
   }
 
   /**

--- a/libs/pinner/src/auth/__tests__/manager.spec.ts
+++ b/libs/pinner/src/auth/__tests__/manager.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { JwtAuthManager } from "../manager";
+import { ConfigurationError } from "@/errors";
+
+describe("JwtAuthManager", () => {
+  describe("constructor", () => {
+    it("should accept a valid JWT token", () => {
+      const manager = new JwtAuthManager("my-jwt-token");
+      expect(manager).toBeDefined();
+    });
+
+    it("should throw ConfigurationError for empty string", () => {
+      expect(() => new JwtAuthManager("")).toThrow(ConfigurationError);
+    });
+
+    it("should throw ConfigurationError for null/undefined", () => {
+      expect(() => new JwtAuthManager(null as unknown as string)).toThrow(
+        ConfigurationError,
+      );
+      expect(() => new JwtAuthManager(undefined as unknown as string)).toThrow(
+        ConfigurationError,
+      );
+    });
+
+    it("should throw ConfigurationError with descriptive message", () => {
+      try {
+        new JwtAuthManager("");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConfigurationError);
+        expect((e as Error).message).toBe("JWT token is required");
+      }
+    });
+  });
+
+  describe("getAuthToken", () => {
+    it("should return the token string", () => {
+      const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+      const manager = new JwtAuthManager(token);
+      expect(manager.getAuthToken()).toBe(token);
+    });
+  });
+
+  describe("getAuthHeaders", () => {
+    it("should return Authorization Bearer header", () => {
+      const token = "my-jwt-token";
+      const manager = new JwtAuthManager(token);
+      expect(manager.getAuthHeaders()).toEqual({
+        Authorization: `Bearer ${token}`,
+      });
+    });
+
+    it("should return a new object each call (not cached)", () => {
+      const manager = new JwtAuthManager("token");
+      const h1 = manager.getAuthHeaders();
+      const h2 = manager.getAuthHeaders();
+      expect(h1).toEqual(h2);
+      expect(h1).not.toBe(h2);
+    });
+  });
+
+  describe("getAccessToken", () => {
+    it("should return the raw token for pinning-service-client", () => {
+      const token = "raw-token-123";
+      const manager = new JwtAuthManager(token);
+      expect(manager.getAccessToken()).toBe(token);
+    });
+  });
+
+  describe("interface compliance", () => {
+    it("should satisfy the AuthManager interface", () => {
+      const manager: import("../manager").AuthManager = new JwtAuthManager(
+        "token",
+      );
+      expect(manager.getAuthToken()).toBe("token");
+      expect(manager.getAuthHeaders()).toHaveProperty("Authorization");
+      expect(manager.getAccessToken()).toBe("token");
+    });
+  });
+});

--- a/libs/pinner/src/auth/index.ts
+++ b/libs/pinner/src/auth/index.ts
@@ -1,0 +1,1 @@
+export { type AuthManager, JwtAuthManager } from "./manager";

--- a/libs/pinner/src/auth/manager.ts
+++ b/libs/pinner/src/auth/manager.ts
@@ -1,0 +1,59 @@
+import { ConfigurationError } from "@/errors";
+
+/**
+ * Interface for authentication management.
+ * Provides auth tokens and headers for API requests.
+ *
+ * This is the single source of truth for auth in the Pinner SDK.
+ * All clients receive an AuthManager instance and call getAuthHeaders()
+ * or getAuthToken() — never touch config.jwt directly.
+ */
+export interface AuthManager {
+  /**
+   * Get the raw auth token string.
+   * Throw ConfigurationError if no token is configured.
+   */
+  getAuthToken(): string;
+
+  /**
+   * Get the Authorization header object for use in fetch/ky requests.
+   * Example: { Authorization: "Bearer eyJ..." }
+   */
+  getAuthHeaders(): Record<string, string>;
+
+  /**
+   * Get the auth token for use with libraries that expect an accessToken field
+   * (e.g. @ipfs-shipyard/pinning-service-client Configuration).
+   */
+  getAccessToken(): string;
+}
+
+/**
+ * Default AuthManager implementation that holds a JWT token.
+ *
+ * Mirrors the Go SDK's approach: token is set once at construction time
+ * and used for all subsequent requests. If token exchange (API key → login JWT)
+ * is needed in the future, it goes here — one place, not scattered across clients.
+ */
+export class JwtAuthManager implements AuthManager {
+  private readonly token: string;
+
+  constructor(jwt: string) {
+    if (!jwt) {
+      throw new ConfigurationError("JWT token is required");
+    }
+    this.token = jwt;
+  }
+
+  getAuthToken(): string {
+    return this.token;
+  }
+
+  getAuthHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${this.token}` };
+  }
+
+  getAccessToken(): string {
+    return this.token;
+  }
+}

--- a/libs/pinner/src/pin/client.ts
+++ b/libs/pinner/src/pin/client.ts
@@ -5,6 +5,7 @@ import {
   RemotePinningServiceClient,
 } from "@ipfs-shipyard/pinning-service-client";
 import type { PinnerConfig } from "../config";
+import type { AuthManager } from "@/auth";
 import type {
   AbortOptions,
   RemoteAddOptions,
@@ -18,9 +19,11 @@ import { ConfigurationError, NotFoundError } from "@/errors";
 export class PinClient implements RemotePins {
   private client: RemotePinningServiceClient | null = null;
   private config: PinnerConfig;
+  private readonly auth: AuthManager;
 
-  constructor(config: PinnerConfig) {
+  constructor(config: PinnerConfig, auth: AuthManager) {
     this.config = config;
+    this.auth = auth;
   }
 
   protected getClient(): RemotePinningServiceClient {
@@ -28,17 +31,13 @@ export class PinClient implements RemotePins {
       return this.client;
     }
 
-    if (!this.config.jwt) {
-      throw new ConfigurationError("JWT token is required");
-    }
-
-    const configuration = new Configuration({
-      endpointUrl: this.config.endpoint,
-      accessToken: this.config.jwt,
-      fetchApi: this.config.fetch ?? fetch,
-    });
-
-    this.client = new RemotePinningServiceClient(configuration);
+    this.client = new RemotePinningServiceClient(
+      new Configuration({
+        endpointUrl: this.config.endpoint,
+        accessToken: this.auth.getAccessToken(),
+        fetchApi: this.config.fetch ?? fetch,
+      }),
+    );
     return this.client;
   }
 

--- a/libs/pinner/src/pinner.ts
+++ b/libs/pinner/src/pinner.ts
@@ -3,6 +3,7 @@ import { UploadManager } from "./upload";
 import { PinClient } from "./pin";
 import { IpnsClient } from "./api/ipns";
 import { WebsitesClient } from "./api/websites";
+import { JwtAuthManager, type AuthManager } from "@/auth";
 import type { UploadMethodAndBuilder } from "@/upload/builder";
 import { createUploadBuilderNamespace } from "@/upload/builder";
 import type {
@@ -26,16 +27,18 @@ export class Pinner {
   private _ipns: IpnsClient;
   private _websites: WebsitesClient;
   private _upload?: UploadMethodAndBuilder;
+  private readonly auth: AuthManager;
 
   /**
    * Create a new Pinner SDK instance.
    * @param config SDK configuration object
    */
   constructor(config: PinnerConfig) {
-    this.uploadManager = new UploadManager(config);
-    this._pins = new PinClient(config);
-    this._ipns = new IpnsClient(config);
-    this._websites = new WebsitesClient(config);
+    this.auth = new JwtAuthManager(config.jwt);
+    this.uploadManager = new UploadManager(config, this.auth);
+    this._pins = new PinClient(config, this.auth);
+    this._ipns = new IpnsClient(config, this.auth);
+    this._websites = new WebsitesClient(config, this.auth);
   }
 
   /**

--- a/libs/pinner/src/upload/__tests__/manager.integration.spec.ts
+++ b/libs/pinner/src/upload/__tests__/manager.integration.spec.ts
@@ -12,6 +12,7 @@ import { test as it } from "./int-test";
 import { DEFAULT_UPLOAD_LIMIT, MOCK_CONFIG } from "./test-constants";
 import { assertUploadOperationStructure } from "./test-assertions";
 import { importUploadManager } from "./test-fixtures";
+import { JwtAuthManager } from "@/auth";
 
 describe("UploadManager Integration Tests", () => {
   let manager: any;
@@ -20,7 +21,7 @@ describe("UploadManager Integration Tests", () => {
     vi.clearAllMocks();
 
     const UploadManager = await importUploadManager();
-    manager = new UploadManager(MOCK_CONFIG);
+    manager = new UploadManager(MOCK_CONFIG, mockAuth);
   });
 
   afterEach(() => {

--- a/libs/pinner/src/upload/base-upload.ts
+++ b/libs/pinner/src/upload/base-upload.ts
@@ -3,6 +3,7 @@ import { default as defer } from "p-defer";
 import type { Readable } from "stream";
 
 import type { PinnerConfig } from "../config";
+import type { AuthManager } from "@/auth";
 import type {
   UploadInput,
   UploadOperation,
@@ -25,9 +26,11 @@ type NodeStreamWithSize = Readable & { size: number | null };
 
 export abstract class BaseUploadHandler {
   protected config: Required<PinnerConfig>;
+  protected readonly auth: AuthManager;
 
-  constructor(config: PinnerConfig) {
+  constructor(config: PinnerConfig, auth: AuthManager) {
     this.config = config as Required<PinnerConfig>;
+    this.auth = auth;
   }
 
   async upload(

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -10,6 +10,7 @@ import { createEqFilter } from "@lumeweb/query-builder";
 import type { UploadResultResponse } from "@/api/generated/schemas";
 
 import type { PinnerConfig } from "../config";
+import type { AuthManager } from "@/auth";
 import type {
   UploadInput,
   UploadOperation,
@@ -41,6 +42,7 @@ import { type UploadInputObject } from "./normalize";
  */
 export class UploadManager {
   private config: PinnerConfig;
+  private readonly auth: AuthManager;
   private xhrHandler: XHRUploadHandler;
   private tusHandler: TUSUploadHandler;
   private portalSdk: Sdk;
@@ -50,12 +52,15 @@ export class UploadManager {
   /**
    * Create a new UploadManager.
    * @param config SDK configuration
+   * @param auth AuthManager for authentication
    */
-  constructor(config: PinnerConfig) {
+  constructor(config: PinnerConfig, auth: AuthManager) {
     this.config = config;
-    this.xhrHandler = new XHRUploadHandler(config);
-    this.tusHandler = new TUSUploadHandler(config);
+    this.auth = auth;
+    this.xhrHandler = new XHRUploadHandler(config, auth);
+    this.tusHandler = new TUSUploadHandler(config, auth);
     this.portalSdk = new Sdk(config.endpoint || DEFAULT_ENDPOINT);
+    this.portalSdk.setAuthToken(auth.getAuthToken());
     configureCar({
       datastoreName: config.datastoreName,
       datastore: config.datastore,
@@ -313,7 +318,7 @@ export class UploadManager {
 
     const baseUrl = this.config.endpoint || DEFAULT_ENDPOINT;
     const fetchUrl = `${baseUrl}/api/upload/result/${encodeURIComponent(uploadId)}`;
-    const headers = { Authorization: `Bearer ${this.config.jwt}` };
+    const headers = this.auth.getAuthHeaders();
 
     const result = await poll<UploadResultResponse>(
       async () => {

--- a/libs/pinner/src/upload/tus-upload.ts
+++ b/libs/pinner/src/upload/tus-upload.ts
@@ -3,18 +3,17 @@ import TusPlugin from "@uppy/tus";
 import type { UploadResult } from "@/types/upload";
 import { BaseUploadHandler } from "./base-upload";
 import type { PinnerConfig } from "@/config";
+import type { AuthManager } from "@/auth";
 import { UPLOAD_SOURCE_TUS } from "./constants";
 
 export class TUSUploadHandler extends BaseUploadHandler {
-  constructor(config: PinnerConfig) {
-    super(config);
+  constructor(config: PinnerConfig, auth: AuthManager) {
+    super(config, auth);
   }
   protected configurePlugin(uppy: Uppy): void {
     uppy.use(TusPlugin, {
       endpoint: `${this.config.endpoint}/api/upload/tus`,
-      headers: {
-        Authorization: `Bearer ${this.config.jwt}`,
-      },
+      headers: this.auth.getAuthHeaders(),
       chunkSize: 10 * 1024 * 1024,
       retryDelays: [0, 1000, 3000, 5000],
     });

--- a/libs/pinner/src/upload/xhr-upload.ts
+++ b/libs/pinner/src/upload/xhr-upload.ts
@@ -10,9 +10,7 @@ export class XHRUploadHandler extends BaseUploadHandler {
       endpoint: `${this.config.endpoint}/api/upload`,
       fieldName: "file",
       formData: true,
-      headers: {
-        Authorization: `Bearer ${this.config.jwt}`,
-      },
+      headers: this.auth.getAuthHeaders(),
       timeout: this.config.timeout,
       retries: this.config.retries,
     });

--- a/libs/pinner/vitest.config.ts
+++ b/libs/pinner/vitest.config.ts
@@ -341,9 +341,17 @@ function createBaseUploadProjects(
   ];
 }
 
+function createAuthProjects() {
+  return [
+    createNodeProject("node-auth", ["src/auth/__tests__/**/*.spec.ts"]),
+  ];
+}
+
 export default defineConfig({
   test: {
     projects: [
+      // Auth tests - pure logic, node only
+      ...createAuthProjects(),
       // Upload integration tests - no mocks, real implementations
       ...createUploadProjects(TEST_TYPE_INTEGRATION),
       // Upload unit tests - with mocks

--- a/scripts/setup-pinner-cli.sh
+++ b/scripts/setup-pinner-cli.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Setup pinner-cli binary for local development.
+#
+# If `pinner` is already on PATH, does nothing.
+# Otherwise, installs it via `go install go.lumeweb.com/pinner-cli/cmd/pinner@latest`
+# and ensures the GOPATH/bin directory is on PATH.
+#
+# This mirrors the CI composite action at .github/actions/setup-pinner-cli/action.yml.
+#
+set -euo pipefail
+
+if command -v pinner &>/dev/null; then
+  exit 0
+fi
+
+if ! command -v go &>/dev/null; then
+  echo "error: 'go' is not installed and 'pinner' binary not found on PATH." >&2
+  echo "       Install Go or place the pinner binary on PATH manually." >&2
+  exit 1
+fi
+
+VERSION="${PINNER_CLI_VERSION:-latest}"
+echo "Installing pinner-cli@${VERSION} via go install..."
+GOTOOLCHAIN="${GOTOOLCHAIN:-auto}" go install go.lumeweb.com/pinner-cli/cmd/pinner@"${VERSION}"
+
+GOPATH_BIN="$(go env GOPATH)/bin"
+if [[ ":${PATH}:" != *":${GOPATH_BIN}:"* ]]; then
+  echo "export PATH=\"${GOPATH_BIN}:\${PATH}\""
+  export PATH="${GOPATH_BIN}:${PATH}"
+fi
+
+echo "pinner-cli installed to ${GOPATH_BIN}/pinner"
+pinner version

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,9 @@
     },
     "build-storybook": {
       "dependsOn": ["@lumeweb/tsdown-config#build:config", "^build"]
+    },
+    "setup:pinner": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## What

Replaces scattered JWT handling across 6 clients with a single `AuthManager` interface. All clients now receive `AuthManager` instead of reading `config.jwt` directly.

## Why

Auth was duplicated in 6 places — each client independently constructed `Authorization: Bearer` headers from `config.jwt`, validated the token separately, and (in IpnsClient/WebsitesClient) copy-pasted ~35 lines of identical request/error handling. The `setAuthToken` call in `UploadManager` was also being missed by some code paths, causing unauthenticated API calls that surfaced as the "Failed to find operation with CID" deploy failures.

The Go SDK handles auth in one spot at client construction. This mirrors that approach.

## Changes

- **`auth/manager.ts`** — `AuthManager` interface + `JwtAuthManager` implementation (token validation, `getAuthToken()`, `getAuthHeaders()`, `getAccessToken()`)
- **`api/client.ts`** — `ApiClient` base class with shared `request()` method and error mapping
- **`pinner.ts`** — Creates `JwtAuthManager` once, injects into all clients
- **`upload/`** — `UploadManager`, `XHRUploadHandler`, `TUSUploadHandler`, `BaseUploadHandler` use `auth.getAuthHeaders()`
- **`api/ipns.ts` + `api/websites.ts`** — Extend `ApiClient`, removed duplicated `request()` and `if (!config.jwt)` checks
- **`pin/client.ts`** — Uses `auth.getAccessToken()`
- **Tests** — 9 AuthManager unit tests; all existing test files updated for new constructor signatures

---

<!-- kody-pr-summary:start -->
## Description

This PR centralizes authentication handling in the Pinner SDK by introducing an `AuthManager` abstraction, replacing the previous pattern where each client directly accessed `config.jwt` and manually constructed `Authorization: Bearer` headers.

### Key Changes

**New `AuthManager` interface and `JwtAuthManager` implementation** (`libs/pinner/src/auth/`):
- Defines a single source of truth for authentication with methods `getAuthToken()`, `getAuthHeaders()`, and `getAccessToken()`
- `JwtAuthManager` holds a JWT token and provides Bearer auth headers, with validation that throws `ConfigurationError` if no token is provided

**New `ApiClient` base class** (`libs/pinner/src/api/client.ts`):
- Extracts the duplicated HTTP request logic and error mapping (previously copy-pasted in both `IpnsClient` and `WebsitesClient`) into a shared abstract base class
- Auth headers are sourced from `AuthManager` rather than `config.jwt` directly

**Client refactoring**:
- `IpnsClient` and `WebsitesClient` now extend `ApiClient` and accept an `AuthManager` in their constructors, eliminating duplicated request/error-handling code
- `PinClient` uses `auth.getAccessToken()` instead of `config.jwt` for the pinning service client configuration
- `UploadManager` and all upload handlers (`XHRUploadHandler`, `TUSUploadHandler`, `BaseUploadHandler`) now receive and use `AuthManager` for auth headers and tokens

**`Pinner` entry point**:
- Creates a single `JwtAuthManager` instance from `config.jwt` and injects it into all sub-clients, ensuring consistent auth across the entire SDK

**Tests**:
- All existing tests updated to pass a `mockAuth` (`JwtAuthManager`) instance to client constructors
- New unit tests added for `JwtAuthManager` covering construction validation, token retrieval, and interface compliance
- Vitest configuration updated to include a dedicated auth test project
<!-- kody-pr-summary:end -->