### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/heavy-berries-open.md
+++ b/.changeset/heavy-berries-open.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-app-shell: patch
+---
+
+## Fixes
+
+- remove dead deps causing taze errors (events, querystring)

--- a/.changeset/moody-baboons-appear.md
+++ b/.changeset/moody-baboons-appear.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/advanced-rest: patch
+---
+
+## Fixes
+
+- remove dead deps causing taze errors (events, querystring)

--- a/.changeset/neat-taxes-say.md
+++ b/.changeset/neat-taxes-say.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-sdk: patch
+---
+
+## Fixes
+
+- update portal-sdk orval mock config for 8.18.0

--- a/.changeset/short-snakes-swim.md
+++ b/.changeset/short-snakes-swim.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/docs.pinner.xyz: patch
+---
+
+## Fixes
+
+- propagate PATH export to parent shell
+- propagate script exit code through eval

--- a/.changeset/sixty-yaks-wink.md
+++ b/.changeset/sixty-yaks-wink.md
@@ -1,0 +1,9 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- update orval mock config for 8.18.0 (generators array)
+- centralize auth in AuthManager
+- use invalid JwtAuthManager in auth-error tests

--- a/.changeset/tasty-places-march.md
+++ b/.changeset/tasty-places-march.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-core: patch
+---
+
+## Fixes
+
+- migrate pnpm settings to pnpm-workspace.yaml, remove dead esbuild dep


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset files documenting patch-level fixes across multiple packages in the monorepo. The changesets record the following fixes:

- **@lumeweb/portal-app-shell** and **@lumeweb/advanced-rest**: Removed dead dependencies (`events`, `querystring`) that were causing `taze` errors.
- **@lumeweb/portal-sdk**: Updated the orval mock config for version 8.18.0.
- **@lumeweb/docs.pinner.xyz**: Propagated the `PATH` export to the parent shell and propagated the script exit code through `eval`.
- **@lumeweb/pinner**: Updated the orval mock config for 8.18.0 (generators array), centralized authentication in `AuthManager`, and used an invalid `JwtAuthManager` in auth-error tests.
- **@lumeweb/portal-framework-core**: Migrated pnpm settings to `pnpm-workspace.yaml` and removed a dead `esbuild` dependency.
<!-- kody-pr-summary:end -->