### PR TITLE
fix(pinner): implement API key exchange for JWT auth

### DIFF
--- a/libs/pinner/package.json
+++ b/libs/pinner/package.json
@@ -66,6 +66,7 @@
     "interface-datastore": "^10.0.1",
     "interface-store": "^8.0.0",
     "ipaddr.js": "^2.4.0",
+    "jwt-decode": "^4.0.0",
     "ky": "catalog:",
     "multiformats": "catalog:",
     "nanoevents": "catalog:",

--- a/libs/pinner/src/api/client.ts
+++ b/libs/pinner/src/api/client.ts
@@ -30,7 +30,7 @@ export abstract class ApiClient {
       const response = await ky(path, {
         prefix: this.endpoint,
         headers: {
-          ...this.auth.getAuthHeaders(),
+          ...await this.auth.getAuthHeaders(),
           "Content-Type": "application/json",
         },
         ...options,

--- a/libs/pinner/src/auth/__tests__/manager.spec.ts
+++ b/libs/pinner/src/auth/__tests__/manager.spec.ts
@@ -33,47 +33,48 @@ describe("JwtAuthManager", () => {
   });
 
   describe("getAuthToken", () => {
-    it("should return the token string", () => {
-      const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+    it("should return the token string", async () => {
+      const token = "eyJhbG...VCJ9";
       const manager = new JwtAuthManager(token);
-      expect(manager.getAuthToken()).toBe(token);
+      expect(await manager.getAuthToken()).toBe(token);
     });
   });
 
   describe("getAuthHeaders", () => {
-    it("should return Authorization Bearer header", () => {
+    it("should return Authorization Bearer header", async () => {
       const token = "my-jwt-token";
       const manager = new JwtAuthManager(token);
-      expect(manager.getAuthHeaders()).toEqual({
+      expect(await manager.getAuthHeaders()).toEqual({
         Authorization: `Bearer ${token}`,
       });
     });
 
-    it("should return a new object each call (not cached)", () => {
+    it("should return a new object each call (not cached)", async () => {
       const manager = new JwtAuthManager("token");
-      const h1 = manager.getAuthHeaders();
-      const h2 = manager.getAuthHeaders();
+      const h1 = await manager.getAuthHeaders();
+      const h2 = await manager.getAuthHeaders();
       expect(h1).toEqual(h2);
       expect(h1).not.toBe(h2);
     });
   });
 
   describe("getAccessToken", () => {
-    it("should return the raw token for pinning-service-client", () => {
+    it("should return the raw token for pinning-service-client", async () => {
       const token = "raw-token-123";
       const manager = new JwtAuthManager(token);
-      expect(manager.getAccessToken()).toBe(token);
+      expect(await manager.getAccessToken()).toBe(token);
     });
   });
 
   describe("interface compliance", () => {
-    it("should satisfy the AuthManager interface", () => {
+    it("should satisfy the AuthManager interface", async () => {
       const manager: import("../manager").AuthManager = new JwtAuthManager(
         "token",
       );
-      expect(manager.getAuthToken()).toBe("token");
-      expect(manager.getAuthHeaders()).toHaveProperty("Authorization");
-      expect(manager.getAccessToken()).toBe("token");
+      expect(await manager.getAuthToken()).toBe("token");
+      const headers = await manager.getAuthHeaders();
+      expect(headers).toHaveProperty("Authorization");
+      expect(await manager.getAccessToken()).toBe("token");
     });
   });
 });

--- a/libs/pinner/src/auth/index.ts
+++ b/libs/pinner/src/auth/index.ts
@@ -1,1 +1,2 @@
 export { type AuthManager, JwtAuthManager } from "./manager";
+export { KeyExchangeAuthManager } from "./key-exchange";

--- a/libs/pinner/src/auth/index.ts
+++ b/libs/pinner/src/auth/index.ts
@@ -1,2 +1,3 @@
 export { type AuthManager, JwtAuthManager } from "./manager";
 export { KeyExchangeAuthManager } from "./key-exchange";
+export { JwtPurpose } from "./types";

--- a/libs/pinner/src/auth/key-exchange.ts
+++ b/libs/pinner/src/auth/key-exchange.ts
@@ -1,0 +1,92 @@
+import { jwtDecode } from "jwt-decode";
+import { Sdk } from "@lumeweb/portal-sdk";
+import { JwtAuthManager } from "./manager";
+import { ConfigurationError } from "@/errors";
+
+/**
+ * AuthManager that exchanges an API key JWT for a login JWT when needed.
+ *
+ * Mirrors the Go SDK's AuthServiceDefault.GetLoginToken():
+ * 1. Decode the JWT audience without verification
+ * 2. If aud === "api", call POST /api/auth/key to exchange for a login JWT
+ * 3. Use the login JWT for all subsequent requests
+ *
+ * The exchange happens lazily on first access (getAuthToken/getAuthHeaders)
+ * and is cached for the lifetime of the instance.
+ */
+export class KeyExchangeAuthManager extends JwtAuthManager {
+  private resolvedToken = "";
+  private exchangePromise?: Promise<string>;
+  private readonly sdk: Sdk;
+
+  constructor(jwt: string, endpoint: string) {
+    super(jwt);
+    this.sdk = new Sdk(endpoint);
+  }
+
+  /**
+   * Decode the JWT audience without verification.
+   * Returns undefined if the token can't be decoded or has no audience.
+   */
+  private getAudience(): string | undefined {
+    try {
+      const decoded = jwtDecode(this.token);
+      const aud = decoded.aud;
+      if (Array.isArray(aud)) {
+        return aud[0];
+      }
+      return typeof aud === "string" ? aud : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Exchange the API key JWT for a login JWT if needed.
+   * Returns the login JWT, or the original token if no exchange is necessary.
+   */
+  private resolveToken(): Promise<string> {
+    if (this.resolvedToken) {
+      return Promise.resolve(this.resolvedToken);
+    }
+
+    if (this.exchangePromise) {
+      return this.exchangePromise;
+    }
+
+    const aud = this.getAudience();
+
+    if (aud !== "api") {
+      this.resolvedToken = this.token;
+      return Promise.resolve(this.resolvedToken);
+    }
+
+    this.exchangePromise = (async () => {
+      const result = await this.sdk.account().loginWithApiKey(this.token);
+
+      if (!result.success || !result.data?.token) {
+        throw new ConfigurationError(
+          "Failed to exchange API key for login JWT",
+        );
+      }
+
+      this.resolvedToken = result.data.token;
+      return this.resolvedToken;
+    })();
+
+    return this.exchangePromise;
+  }
+
+  async getAuthToken(): Promise<string> {
+    return this.resolveToken();
+  }
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    const token = await this.resolveToken();
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  async getAccessToken(): Promise<string> {
+    return this.resolveToken();
+  }
+}

--- a/libs/pinner/src/auth/key-exchange.ts
+++ b/libs/pinner/src/auth/key-exchange.ts
@@ -62,16 +62,21 @@ export class KeyExchangeAuthManager extends JwtAuthManager {
     }
 
     this.exchangePromise = (async () => {
-      const result = await this.sdk.account().loginWithApiKey(this.token);
+      try {
+        const result = await this.sdk.account().loginWithApiKey(this.token);
 
-      if (!result.success || !result.data?.token) {
-        throw new ConfigurationError(
-          "Failed to exchange API key for login JWT",
-        );
+        if (!result.success || !result.data?.token) {
+          throw new ConfigurationError(
+            "Failed to exchange API key for login JWT",
+          );
+        }
+
+        this.resolvedToken = result.data.token;
+        return this.resolvedToken;
+      } catch (err) {
+        this.exchangePromise = undefined;
+        throw err;
       }
-
-      this.resolvedToken = result.data.token;
-      return this.resolvedToken;
     })();
 
     return this.exchangePromise;

--- a/libs/pinner/src/auth/key-exchange.ts
+++ b/libs/pinner/src/auth/key-exchange.ts
@@ -1,6 +1,7 @@
 import { jwtDecode } from "jwt-decode";
 import { Sdk } from "@lumeweb/portal-sdk";
 import { JwtAuthManager } from "./manager";
+import { JwtPurpose } from "./types";
 import { ConfigurationError } from "@/errors";
 
 /**
@@ -8,7 +9,7 @@ import { ConfigurationError } from "@/errors";
  *
  * Mirrors the Go SDK's AuthServiceDefault.GetLoginToken():
  * 1. Decode the JWT audience without verification
- * 2. If aud === "api", call POST /api/auth/key to exchange for a login JWT
+ * 2. If aud === JwtPurpose.API, call POST /api/auth/key to exchange for a login JWT
  * 3. Use the login JWT for all subsequent requests
  *
  * The exchange happens lazily on first access (getAuthToken/getAuthHeaders)
@@ -56,7 +57,7 @@ export class KeyExchangeAuthManager extends JwtAuthManager {
 
     const aud = this.getAudience();
 
-    if (aud !== "api") {
+    if (aud !== JwtPurpose.API) {
       this.resolvedToken = this.token;
       return Promise.resolve(this.resolvedToken);
     }

--- a/libs/pinner/src/auth/manager.ts
+++ b/libs/pinner/src/auth/manager.ts
@@ -7,36 +7,39 @@ import { ConfigurationError } from "@/errors";
  * This is the single source of truth for auth in the Pinner SDK.
  * All clients receive an AuthManager instance and call getAuthHeaders()
  * or getAuthToken() — never touch config.jwt directly.
+ *
+ * Methods are async to support token exchange (API key → login JWT).
  */
 export interface AuthManager {
   /**
    * Get the raw auth token string.
+   * May perform a network call to exchange an API key JWT for a login JWT.
    * Throw ConfigurationError if no token is configured.
    */
-  getAuthToken(): string;
+  getAuthToken(): Promise<string>;
 
   /**
    * Get the Authorization header object for use in fetch/ky requests.
    * Example: { Authorization: "Bearer eyJ..." }
+   * May perform a network call if token exchange is needed.
    */
-  getAuthHeaders(): Record<string, string>;
+  getAuthHeaders(): Promise<Record<string, string>>;
 
   /**
    * Get the auth token for use with libraries that expect an accessToken field
    * (e.g. @ipfs-shipyard/pinning-service-client Configuration).
    */
-  getAccessToken(): string;
+  getAccessToken(): Promise<string>;
 }
 
 /**
  * Default AuthManager implementation that holds a JWT token.
  *
  * Mirrors the Go SDK's approach: token is set once at construction time
- * and used for all subsequent requests. If token exchange (API key → login JWT)
- * is needed in the future, it goes here — one place, not scattered across clients.
+ * and used for all subsequent requests.
  */
 export class JwtAuthManager implements AuthManager {
-  private readonly token: string;
+  protected readonly token: string;
 
   constructor(jwt: string) {
     if (!jwt) {
@@ -45,15 +48,15 @@ export class JwtAuthManager implements AuthManager {
     this.token = jwt;
   }
 
-  getAuthToken(): string {
+  async getAuthToken(): Promise<string> {
     return this.token;
   }
 
-  getAuthHeaders(): Record<string, string> {
+  async getAuthHeaders(): Promise<Record<string, string>> {
     return { Authorization: `Bearer ${this.token}` };
   }
 
-  getAccessToken(): string {
+  async getAccessToken(): Promise<string> {
     return this.token;
   }
 }

--- a/libs/pinner/src/auth/types.ts
+++ b/libs/pinner/src/auth/types.ts
@@ -1,0 +1,14 @@
+/**
+ * JWT token purposes, mirroring the Go SDK's jwt.Purpose enum.
+ *
+ * The audience claim in a JWT determines the token's intended use.
+ * @see go.lumeweb.com/portal-middleware/auth/jwt.Purpose
+ */
+export enum JwtPurpose {
+  /** Login session token */
+  Login = "login",
+  /** Two-factor authentication token */
+  TwoFactor = "2fa",
+  /** API key token (must be exchanged for a login JWT) */
+  API = "api",
+}

--- a/libs/pinner/src/pin/__tests__/client.spec.ts
+++ b/libs/pinner/src/pin/__tests__/client.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PinClient } from "../client";
 import type { PinnerConfig } from "@/config";
 import { ConfigurationError, NotFoundError } from "@/errors";
+import { JwtAuthManager } from "@/auth/manager";
+import type { AuthManager } from "@/auth/manager";
 import { CID } from "multiformats/cid";
 import type { RemotePinningServiceClient } from "@ipfs-shipyard/pinning-service-client";
 import { Status } from "@ipfs-shipyard/pinning-service-client";
@@ -11,7 +13,7 @@ import { createMockCID } from "@/__tests__/setup";
 
 // Test helper class to expose protected method for testing
 class TestPinClient extends PinClient {
-  public override getClient(): RemotePinningServiceClient {
+  public override getClient(): Promise<RemotePinningServiceClient> {
     return super.getClient();
   }
 
@@ -26,6 +28,7 @@ class TestPinClient extends PinClient {
 describe("PinClient", () => {
   let mockConfig: PinnerConfig;
   let mockFetch: ReturnType<typeof vi.fn>;
+  let mockAuth: AuthManager;
 
   beforeEach(() => {
     mockConfig = {
@@ -34,13 +37,15 @@ describe("PinClient", () => {
       gateway: "https://gateway.test.com",
     };
 
+    mockAuth = new JwtAuthManager("test-jwt-token");
+
     // Mock fetch implementation
     mockFetch = vi.fn();
   });
 
   describe("constructor", () => {
     it("should create a PinClient instance with valid config", () => {
-      const client = new PinClient(mockConfig);
+      const client = new PinClient(mockConfig, mockAuth);
       expect(client).toBeInstanceOf(PinClient);
     });
 
@@ -49,27 +54,25 @@ describe("PinClient", () => {
         ...mockConfig,
         fetch: mockFetch as any,
       };
-      const client = new PinClient(configWithFetch);
+      const client = new PinClient(configWithFetch, mockAuth);
       expect(client).toBeInstanceOf(PinClient);
     });
   });
 
   describe("getClient", () => {
-    it("should throw ConfigurationError when JWT is missing", () => {
-      const invalidConfig = {
-        ...mockConfig,
-        jwt: undefined as unknown as string,
-      };
-      const client = new TestPinClient(invalidConfig);
-
-      expect(() => client.getClient()).toThrow(ConfigurationError);
-      expect(() => client.getClient()).toThrow("JWT token is required");
+    it("should throw ConfigurationError when JWT is missing", async () => {
+      expect(
+        () => new JwtAuthManager(undefined as unknown as string),
+      ).toThrow(ConfigurationError);
+      expect(
+        () => new JwtAuthManager(undefined as unknown as string),
+      ).toThrow("JWT token is required");
     });
 
     it("should reuse existing client instance", async () => {
-      const client = new TestPinClient(mockConfig);
-      const client1 = client.getClient();
-      const client2 = client.getClient();
+      const client = new TestPinClient(mockConfig, mockAuth);
+      const client1 = await client.getClient();
+      const client2 = await client.getClient();
 
       expect(client1).toBe(client2);
     });
@@ -89,7 +92,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -130,7 +133,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -163,7 +166,7 @@ describe("PinClient", () => {
         pinsPost: vi.fn().mockRejectedValue(new Error("Failed to pin")),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(await createMockCID(2));
@@ -208,7 +211,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -243,7 +246,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -276,7 +279,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -306,7 +309,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -339,7 +342,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -357,7 +360,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -372,7 +375,7 @@ describe("PinClient", () => {
         pinsGet: vi.fn().mockRejectedValue(new Error("Pin not found")),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -407,7 +410,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -435,7 +438,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -450,7 +453,7 @@ describe("PinClient", () => {
         pinsGet: vi.fn().mockRejectedValue(new Error("Service error")),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -492,7 +495,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -551,7 +554,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -581,7 +584,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -615,7 +618,7 @@ describe("PinClient", () => {
           .mockRejectedValue(new Error("Update failed")),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -650,7 +653,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -689,7 +692,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -720,7 +723,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -749,7 +752,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -781,7 +784,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -803,7 +806,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const pins: RemotePin[] = [];
@@ -847,7 +850,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -897,7 +900,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -959,7 +962,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -998,7 +1001,7 @@ describe("PinClient", () => {
           .mockRejectedValue(new Error("Failed to delete pin")),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -1020,7 +1023,7 @@ describe("PinClient", () => {
         pinsRequestidDelete: vi.fn(),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const cid = CID.parse(mockCid);
@@ -1045,7 +1048,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       await client.rmByRequestId("req-123");
@@ -1065,7 +1068,7 @@ describe("PinClient", () => {
         }),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       const abortController = new AbortController();
@@ -1087,7 +1090,7 @@ describe("PinClient", () => {
         pinsRequestidDelete: vi.fn().mockRejectedValue(new Error("Failed to delete pin")),
       };
 
-      const client = new TestPinClient(mockConfig);
+      const client = new TestPinClient(mockConfig, mockAuth);
       vi.spyOn(client, "getClient").mockReturnValue(mockPinningClient as any);
 
       await expect(client.rmByRequestId("req-123")).rejects.toThrow("Failed to delete pin");

--- a/libs/pinner/src/pin/client.ts
+++ b/libs/pinner/src/pin/client.ts
@@ -26,7 +26,7 @@ export class PinClient implements RemotePins {
     this.auth = auth;
   }
 
-  protected getClient(): RemotePinningServiceClient {
+  protected async getClient(): Promise<RemotePinningServiceClient> {
     if (this.client) {
       return this.client;
     }
@@ -34,7 +34,7 @@ export class PinClient implements RemotePins {
     this.client = new RemotePinningServiceClient(
       new Configuration({
         endpointUrl: this.config.endpoint,
-        accessToken: this.auth.getAccessToken(),
+        accessToken: await this.auth.getAccessToken(),
         fetchApi: this.config.fetch ?? fetch,
       }),
     );
@@ -45,7 +45,7 @@ export class PinClient implements RemotePins {
     cid: CID,
     options?: RemoteAddOptions,
   ): AsyncGenerator<CID, void, undefined> {
-    const client = this.getClient();
+    const client = await this.getClient();
 
     const pin: Pin = {
       cid: cid.toString(),
@@ -62,7 +62,7 @@ export class PinClient implements RemotePins {
   async *ls(
     options?: RemoteLsOptions,
   ): AsyncGenerator<RemotePin, void, undefined> {
-    const client = this.getClient();
+    const client = await this.getClient();
     const response = await client.pinsGet(this.normalizeListOptions(options), {
       signal: options?.signal,
     });
@@ -82,7 +82,7 @@ export class PinClient implements RemotePins {
   }
 
   async get(cid: CID, options?: AbortOptions): Promise<RemotePin> {
-    const client = this.getClient();
+    const client = await this.getClient();
     const response = await client.pinsGet(
       { cid: [cid.toString()] },
       {
@@ -102,7 +102,7 @@ export class PinClient implements RemotePins {
     metadata: Record<string, string> | undefined,
     options?: AbortOptions,
   ): Promise<void> {
-    const client = this.getClient();
+    const client = await this.getClient();
     const response = await client.pinsGet(
       { cid: [cid.toString()] },
       {
@@ -133,7 +133,7 @@ export class PinClient implements RemotePins {
     cid: CID,
     options?: AbortOptions,
   ): AsyncGenerator<CID, void, undefined> {
-    const client = this.getClient();
+    const client = await this.getClient();
     const response = await client.pinsGet(
       { cid: [cid.toString()] },
       { signal: options?.signal },
@@ -150,7 +150,7 @@ export class PinClient implements RemotePins {
   }
 
   async rmByRequestId(requestId: string, options?: AbortOptions): Promise<void> {
-    const client = this.getClient();
+    const client = await this.getClient();
     await client.pinsRequestidDelete(
       { requestid: requestId },
       { signal: options?.signal },

--- a/libs/pinner/src/pinner.ts
+++ b/libs/pinner/src/pinner.ts
@@ -3,7 +3,8 @@ import { UploadManager } from "./upload";
 import { PinClient } from "./pin";
 import { IpnsClient } from "./api/ipns";
 import { WebsitesClient } from "./api/websites";
-import { JwtAuthManager, type AuthManager } from "@/auth";
+import { JwtAuthManager, KeyExchangeAuthManager, type AuthManager } from "@/auth";
+import { DEFAULT_CONFIG } from "./config";
 import type { UploadMethodAndBuilder } from "@/upload/builder";
 import { createUploadBuilderNamespace } from "@/upload/builder";
 import type {
@@ -34,7 +35,8 @@ export class Pinner {
    * @param config SDK configuration object
    */
   constructor(config: PinnerConfig) {
-    this.auth = new JwtAuthManager(config.jwt);
+    const endpoint = config.endpoint ?? DEFAULT_CONFIG.endpoint!;
+    this.auth = new KeyExchangeAuthManager(config.jwt, endpoint);
     this.uploadManager = new UploadManager(config, this.auth);
     this._pins = new PinClient(config, this.auth);
     this._ipns = new IpnsClient(config, this.auth);

--- a/libs/pinner/src/upload/base-upload.ts
+++ b/libs/pinner/src/upload/base-upload.ts
@@ -39,7 +39,7 @@ export abstract class BaseUploadHandler {
   ): Promise<UploadOperation> {
     const normalized = normalizeUploadInput(input, options);
     const uppy = new Uppy();
-    const { fileId, resultPromise, progress } = this.#setupUppyHandlers(
+    const { fileId, resultPromise, progress } = await this.#setupUppyHandlers(
       uppy,
       normalized,
       options,
@@ -51,15 +51,15 @@ export abstract class BaseUploadHandler {
     return this.#createUploadOperation(uppy, fileId, resultPromise, progress);
   }
 
-  #setupUppyHandlers(
+  async #setupUppyHandlers(
     uppy: Uppy,
     normalized: { size: number },
     options?: UploadOptions,
-  ): {
+  ): Promise<{
     fileId: string | null;
     resultPromise: Promise<UploadResult>;
     progress: UploadProgress;
-  } {
+  }> {
     let fileId: string | null = null;
     let hasRejected = false;
 
@@ -82,7 +82,7 @@ export abstract class BaseUploadHandler {
       rejectResult(error);
     };
 
-    this.configurePlugin(uppy);
+    await this.configurePlugin(uppy);
 
     uppy.on("progress", (progressBytes) => {
       progress.bytesUploaded = progressBytes;
@@ -278,7 +278,7 @@ export abstract class BaseUploadHandler {
     // No-op since each upload creates its own Uppy instance
   }
 
-  protected abstract configurePlugin(uppy: Uppy): void;
+  protected abstract configurePlugin(uppy: Uppy): void | Promise<void>;
   protected abstract parseResult(result: unknown): UploadResult;
   protected abstract getUploadSource(): string;
 

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -46,7 +46,7 @@ export class UploadManager {
   private xhrHandler: XHRUploadHandler;
   private tusHandler: TUSUploadHandler;
   private portalSdk: Sdk;
-  private portalSdkReady: Promise<void>;
+  private portalSdkReady?: Promise<void>;
   private uploadLimit: number = TUS_SIZE_THRESHOLD; // Default to 100 MB
   private limitFetched: boolean = false;
 
@@ -61,7 +61,6 @@ export class UploadManager {
     this.xhrHandler = new XHRUploadHandler(config, auth);
     this.tusHandler = new TUSUploadHandler(config, auth);
     this.portalSdk = new Sdk(config.endpoint || DEFAULT_ENDPOINT);
-    this.portalSdkReady = this.#initPortalSdk();
     configureCar({
       datastoreName: config.datastoreName,
       datastore: config.datastore,
@@ -73,16 +72,26 @@ export class UploadManager {
     this.portalSdk.setAuthToken(token);
   }
 
+  async #ensurePortalSdkReady(): Promise<void> {
+    if (!this.portalSdkReady) {
+      this.portalSdkReady = this.#initPortalSdk().catch((err) => {
+        this.portalSdkReady = undefined;
+        throw err;
+      });
+    }
+    return this.portalSdkReady;
+  }
+
   /**
    * Fetch the upload size limit from the API. Falls back to 100 MB on failure.
    */
   async fetchUploadLimit(): Promise<number> {
-    await this.portalSdkReady;
     if (this.limitFetched) {
       return this.uploadLimit;
     }
 
     try {
+      await this.#ensurePortalSdkReady();
       const result = await this.portalSdk.account().uploadLimit();
       if (result.success && result.data?.limit) {
         this.uploadLimit = result.data.limit;
@@ -223,7 +232,7 @@ export class UploadManager {
     uploadResult: UploadResult,
     options?: OperationPollingOptions,
   ): Promise<UploadResult> {
-    await this.portalSdkReady;
+    await this.#ensurePortalSdkReady();
     if (!uploadResult.cid) {
       throw new Error("Cannot wait for operation by CID — CID not available. Use upload result ID to poll GET /api/upload/result/{id} instead.");
     }

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -153,6 +153,7 @@ export class UploadManager {
     input: number | UploadResult,
     options?: OperationPollingOptions,
   ): Promise<UploadResult> {
+    await this.#ensurePortalSdkReady();
     // Scenario 1: UploadResult with operationId - use it directly
     if (isUploadResult(input) && input.operationId) {
       return await this.#waitForOperationById(input, options);

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -60,11 +60,16 @@ export class UploadManager {
     this.xhrHandler = new XHRUploadHandler(config, auth);
     this.tusHandler = new TUSUploadHandler(config, auth);
     this.portalSdk = new Sdk(config.endpoint || DEFAULT_ENDPOINT);
-    this.portalSdk.setAuthToken(auth.getAuthToken());
+    this.#initPortalSdk();
     configureCar({
       datastoreName: config.datastoreName,
       datastore: config.datastore,
     });
+  }
+
+  async #initPortalSdk(): Promise<void> {
+    const token = await this.auth.getAuthToken();
+    this.portalSdk.setAuthToken(token);
   }
 
   /**
@@ -318,7 +323,7 @@ export class UploadManager {
 
     const baseUrl = this.config.endpoint || DEFAULT_ENDPOINT;
     const fetchUrl = `${baseUrl}/api/upload/result/${encodeURIComponent(uploadId)}`;
-    const headers = this.auth.getAuthHeaders();
+    const headers = await this.auth.getAuthHeaders();
 
     const result = await poll<UploadResultResponse>(
       async () => {

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -46,6 +46,7 @@ export class UploadManager {
   private xhrHandler: XHRUploadHandler;
   private tusHandler: TUSUploadHandler;
   private portalSdk: Sdk;
+  private portalSdkReady: Promise<void>;
   private uploadLimit: number = TUS_SIZE_THRESHOLD; // Default to 100 MB
   private limitFetched: boolean = false;
 
@@ -60,7 +61,7 @@ export class UploadManager {
     this.xhrHandler = new XHRUploadHandler(config, auth);
     this.tusHandler = new TUSUploadHandler(config, auth);
     this.portalSdk = new Sdk(config.endpoint || DEFAULT_ENDPOINT);
-    this.#initPortalSdk();
+    this.portalSdkReady = this.#initPortalSdk();
     configureCar({
       datastoreName: config.datastoreName,
       datastore: config.datastore,
@@ -76,6 +77,7 @@ export class UploadManager {
    * Fetch the upload size limit from the API. Falls back to 100 MB on failure.
    */
   async fetchUploadLimit(): Promise<number> {
+    await this.portalSdkReady;
     if (this.limitFetched) {
       return this.uploadLimit;
     }
@@ -221,6 +223,7 @@ export class UploadManager {
     uploadResult: UploadResult,
     options?: OperationPollingOptions,
   ): Promise<UploadResult> {
+    await this.portalSdkReady;
     if (!uploadResult.cid) {
       throw new Error("Cannot wait for operation by CID — CID not available. Use upload result ID to poll GET /api/upload/result/{id} instead.");
     }

--- a/libs/pinner/src/upload/tus-upload.ts
+++ b/libs/pinner/src/upload/tus-upload.ts
@@ -10,10 +10,10 @@ export class TUSUploadHandler extends BaseUploadHandler {
   constructor(config: PinnerConfig, auth: AuthManager) {
     super(config, auth);
   }
-  protected configurePlugin(uppy: Uppy): void {
+  protected async configurePlugin(uppy: Uppy): Promise<void> {
     uppy.use(TusPlugin, {
       endpoint: `${this.config.endpoint}/api/upload/tus`,
-      headers: this.auth.getAuthHeaders(),
+      headers: await this.auth.getAuthHeaders(),
       chunkSize: 10 * 1024 * 1024,
       retryDelays: [0, 1000, 3000, 5000],
     });

--- a/libs/pinner/src/upload/xhr-upload.ts
+++ b/libs/pinner/src/upload/xhr-upload.ts
@@ -5,12 +5,12 @@ import { BaseUploadHandler } from "./base-upload";
 import { UPLOAD_SOURCE_XHR } from "./constants";
 
 export class XHRUploadHandler extends BaseUploadHandler {
-  protected configurePlugin(uppy: Uppy): void {
+  protected async configurePlugin(uppy: Uppy): Promise<void> {
     uppy.use(XHRUpload, {
       endpoint: `${this.config.endpoint}/api/upload`,
       fieldName: "file",
       formData: true,
-      headers: this.auth.getAuthHeaders(),
+      headers: await this.auth.getAuthHeaders(),
       timeout: this.config.timeout,
       retries: this.config.retries,
     });

--- a/libs/portal-sdk/src/account.ts
+++ b/libs/portal-sdk/src/account.ts
@@ -194,7 +194,7 @@ export class AccountApi {
     apiKey: string,
   ): Promise<Result<LoginResponse>> {
     const result = await this.fetchJson<LoginResponse>("/api/auth/key", {
-      headers: { Authorization: apiKey } as Record<string, string>,
+      headers: { Authorization: `Bearer ${apiKey}` } as Record<string, string>,
       method: "POST",
     });
 

--- a/libs/portal-sdk/src/account.ts
+++ b/libs/portal-sdk/src/account.ts
@@ -185,6 +185,27 @@ export class AccountApi {
   }
 
   /**
+   * Exchange an API key JWT for a login JWT.
+   * The API key is sent as the raw Authorization header value (not Bearer).
+   * @param apiKey API key JWT to exchange
+   * @returns Result containing login response with the login JWT
+   */
+  public async loginWithApiKey(
+    apiKey: string,
+  ): Promise<Result<LoginResponse>> {
+    const result = await this.fetchJson<LoginResponse>("/api/auth/key", {
+      headers: { Authorization: apiKey } as Record<string, string>,
+      method: "POST",
+    });
+
+    if (result.success && result.data?.token) {
+      this.setToken(result.data.token);
+    }
+
+    return result;
+  }
+
+  /**
    * Logout from the account service
    * @returns Result indicating success or failure
    */
@@ -473,12 +494,14 @@ export class AccountApi {
   private buildOptions(init: RequestInit = {}): RequestInit {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      ...init.headers!,
     };
 
     if (this.jwtToken) {
       headers.Authorization = `Bearer ${this.jwtToken}`;
     }
+
+    // Custom headers from init take precedence over defaults
+    Object.assign(headers, init.headers);
 
     return {
       ...init,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,7 +442,7 @@ importers:
         version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -466,10 +466,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       vocs:
         specifier: 'catalog:'
-        version: 2.0.15(patch_hash=d09bb41c090c7717924369ae328e85a5d79cae5288f0de08d82c63e3eb2f03b9)(a38e4a4101e45bfc460543ee87b605cb)
+        version: 2.0.15(patch_hash=d09bb41c090c7717924369ae328e85a5d79cae5288f0de08d82c63e3eb2f03b9)(b510c40cde6d0d7b19f84462d0bc81f1)
       waku:
         specifier: 1.0.0-beta.0
-        version: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   apps/docs.pinner.xyz:
     dependencies:
@@ -487,10 +487,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       vocs:
         specifier: 'catalog:'
-        version: 2.0.15(patch_hash=d09bb41c090c7717924369ae328e85a5d79cae5288f0de08d82c63e3eb2f03b9)(a38e4a4101e45bfc460543ee87b605cb)
+        version: 2.0.15(patch_hash=d09bb41c090c7717924369ae328e85a5d79cae5288f0de08d82c63e3eb2f03b9)(b510c40cde6d0d7b19f84462d0bc81f1)
       waku:
         specifier: 1.0.0-beta.0
-        version: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     devDependencies:
       '@radix-ui/react-tabs':
         specifier: ^1.1.15
@@ -722,7 +722,7 @@ importers:
         version: 1.100.0
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   apps/portal-frontend:
     dependencies:
@@ -849,7 +849,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
 
   libs/pinner:
     dependencies:
@@ -907,6 +907,9 @@ importers:
       ipaddr.js:
         specifier: ^2.4.0
         version: 2.4.0
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       ky:
         specifier: 'catalog:'
         version: 2.0.2
@@ -1010,7 +1013,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-framework-auth:
     dependencies:
@@ -1487,7 +1490,7 @@ importers:
         version: 1.16.8(node-fetch@3.3.2)(typescript@6.0.3)(vite@8.0.16)
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-plugin-abuse-common:
     devDependencies:
@@ -1575,7 +1578,7 @@ importers:
     devDependencies:
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-plugin-admin:
     dependencies:
@@ -1624,7 +1627,7 @@ importers:
     devDependencies:
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-plugin-billing:
     dependencies:
@@ -1730,10 +1733,10 @@ importers:
         version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -1809,7 +1812,7 @@ importers:
     devDependencies:
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-plugin-dashboard:
     dependencies:
@@ -1903,7 +1906,7 @@ importers:
         version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-plugin-ipfs:
     dependencies:
@@ -2024,7 +2027,7 @@ importers:
         version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-plugin-lbry:
     dependencies:
@@ -2161,10 +2164,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -2228,10 +2231,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-plugin-template:
     dependencies:
@@ -2265,7 +2268,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:framework
-        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   libs/portal-sdk:
     dependencies:
@@ -2359,7 +2362,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
 
   libs/tsdown-config:
     devDependencies:
@@ -2411,7 +2414,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
 
 packages:
 
@@ -7121,9 +7124,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/debug@1.0.1':
-    resolution: {integrity: sha512-ovyIps5Q+wp/6TAiVWqP9mWxJ9hWaP05JevNys17UB4/NNK/3EDTtOen7wCNsjoxoZCP5MR268CkyMkD5klcvw==}
-
   '@rolldown/debug@1.1.2':
     resolution: {integrity: sha512-eLvb7Vs0mUYr+lm7D3R99E4VRgJa3ABskr9pMqSBgp1kmQe+IvjNPs1QtLG9Zy2lwdLN72jn8T6SSYVuWJu7Ag==}
 
@@ -8787,60 +8787,31 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
-  '@vue/compiler-core@3.5.34':
-    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
-
   '@vue/compiler-core@3.5.38':
     resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
-
-  '@vue/compiler-dom@3.5.34':
-    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
 
   '@vue/compiler-dom@3.5.38':
     resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
 
-  '@vue/compiler-sfc@3.5.34':
-    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
-
   '@vue/compiler-sfc@3.5.38':
     resolution: {integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==}
-
-  '@vue/compiler-ssr@3.5.34':
-    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
 
   '@vue/compiler-ssr@3.5.38':
     resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
 
-  '@vue/reactivity@3.5.34':
-    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
-
   '@vue/reactivity@3.5.38':
     resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
-
-  '@vue/runtime-core@3.5.34':
-    resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
 
   '@vue/runtime-core@3.5.38':
     resolution: {integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==}
 
-  '@vue/runtime-dom@3.5.34':
-    resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
-
   '@vue/runtime-dom@3.5.38':
     resolution: {integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==}
-
-  '@vue/server-renderer@3.5.34':
-    resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
-    peerDependencies:
-      vue: 3.5.34
 
   '@vue/server-renderer@3.5.38':
     resolution: {integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==}
     peerDependencies:
       vue: 3.5.38
-
-  '@vue/shared@3.5.34':
-    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
   '@vue/shared@3.5.38':
     resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
@@ -11902,6 +11873,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
@@ -15493,14 +15468,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  valibot@1.4.0:
-    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   valibot@1.4.1:
     resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
@@ -15810,23 +15777,10 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-virtual-scroller@3.0.3:
-    resolution: {integrity: sha512-nLWjtpPf/GyvIEEIWAuzevmTlC/aVf0yOcNkXDTUxZWyshsK6B6vc8R8wo9Nb8bpjy7wbi1zPMhzTKwUvWHQmg==}
-    peerDependencies:
-      vue: ^3.3.0
-
   vue-virtual-scroller@3.0.4:
     resolution: {integrity: sha512-3qh3c9VUVysuXynaa4fVZ3ncx3VgD7EPRiQcj+jUVZl5u/TTkD3c27XvSEu3JGJfsJt/vVTVziZ3djiiHtW4cQ==}
     peerDependencies:
       vue: ^3.3.0
-
-  vue@3.5.34:
-    resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   vue@3.5.38:
     resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
@@ -17589,7 +17543,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -19401,7 +19355,7 @@ snapshots:
       '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@6.0.3)
       '@module-federation/runtime': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - bufferutil
       - node-fetch
@@ -21275,7 +21229,7 @@ snapshots:
   '@react-native/codegen@0.81.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       glob: 7.2.3
       hermes-parser: 0.29.1
       invariant: 2.2.4
@@ -21508,9 +21462,6 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
 
-  '@rolldown/debug@1.0.1':
-    optional: true
-
   '@rolldown/debug@1.1.2': {}
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)':
@@ -21520,7 +21471,7 @@ snapshots:
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@rolldown/plugin-node-polyfills@1.0.3': {}
 
@@ -22305,14 +22256,14 @@ snapshots:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.1(vite@8.0.16)':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@takumi-rs/core-darwin-arm64@0.62.8':
     optional: true
@@ -22998,11 +22949,6 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
     optional: true
 
-  '@valibot/to-json-schema@1.7.0(valibot@1.4.0(typescript@6.0.3))':
-    dependencies:
-      valibot: 1.4.0(typescript@6.0.3)
-    optional: true
-
   '@valibot/to-json-schema@1.7.0(valibot@1.4.1(typescript@6.0.3))':
     dependencies:
       valibot: 1.4.1(typescript@6.0.3)
@@ -23015,7 +22961,7 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
       perfect-debounce: 2.1.0
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
       vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -23032,8 +22978,8 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
       perfect-debounce: 2.1.0
-      tinyexec: 1.1.2
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      tinyexec: 1.2.4
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -23059,11 +23005,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
-      '@rolldown/debug': 1.0.1
+      '@rolldown/debug': 1.1.2
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)(vite@8.0.16)
       birpc: 4.0.0
       cac: 7.0.0
@@ -23082,7 +23028,7 @@ snapshots:
       tinyglobby: 0.2.17
       unconfig: 7.5.0
       unstorage: 1.17.5(idb-keyval@6.2.5)
-      vue-virtual-scroller: 3.0.3(vue@3.5.34(typescript@6.0.3))
+      vue-virtual-scroller: 3.0.4(vue@3.5.38(typescript@6.0.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -23113,11 +23059,11 @@ snapshots:
       - vue
     optional: true
 
-  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
-      '@rolldown/debug': 1.0.1
+      '@rolldown/debug': 1.1.2
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
       birpc: 4.0.0
       cac: 7.0.0
@@ -23136,7 +23082,7 @@ snapshots:
       tinyglobby: 0.2.17
       unconfig: 7.5.0
       unstorage: 1.17.5(idb-keyval@6.2.5)
-      vue-virtual-scroller: 3.0.3(vue@3.5.34(typescript@6.0.3))
+      vue-virtual-scroller: 3.0.4(vue@3.5.38(typescript@6.0.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -23218,22 +23164,22 @@ snapshots:
       - vite
       - vue
 
-  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)':
+  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)(vite@8.0.16)
-      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.34(typescript@6.0.3))
+      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.38(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
       devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)
       h3: 1.15.11
       logs-sdk: 0.0.6
       mlly: 1.8.2
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       perfect-debounce: 2.1.0
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
       vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vue: 3.5.34(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
       ws: 8.21.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -23265,19 +23211,63 @@ snapshots:
   '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
-      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.34(typescript@6.0.3))
+      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.38(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
       devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)
       h3: 1.15.11
       logs-sdk: 0.0.6
       mlly: 1.8.2
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       perfect-debounce: 2.1.0
-      tinyexec: 1.1.2
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vue: 3.5.34(typescript@6.0.3)
+      tinyexec: 1.2.4
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vue: 3.5.38(typescript@6.0.3)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@pnpm/logger'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - idb-keyval
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+    optional: true
+
+  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)':
+    dependencies:
+      '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.38(typescript@6.0.3))
+      birpc: 4.0.0
+      cac: 7.0.0
+      devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)
+      h3: 1.15.11
+      logs-sdk: 0.0.6
+      mlly: 1.8.2
+      obug: 2.1.3
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.2.4
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vue: 3.5.38(typescript@6.0.3)
       ws: 8.21.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -23365,7 +23355,7 @@ snapshots:
   '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)
       babel-plugin-react-compiler: 1.0.0
@@ -23389,7 +23379,7 @@ snapshots:
       srvx: 0.11.16
       strip-literal: 3.1.0
       turbo-stream: 3.2.0
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.16)
     optionalDependencies:
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13))
@@ -23471,7 +23461,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@25.9.4)(typescript@6.0.3)
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -23607,15 +23597,6 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
-  '@vue/compiler-core@3.5.34':
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@vue/shared': 3.5.34
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-    optional: true
-
   '@vue/compiler-core@3.5.38':
     dependencies:
       '@babel/parser': 7.29.7
@@ -23624,29 +23605,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.34':
-    dependencies:
-      '@vue/compiler-core': 3.5.34
-      '@vue/shared': 3.5.34
-    optional: true
-
   '@vue/compiler-dom@3.5.38':
     dependencies:
       '@vue/compiler-core': 3.5.38
       '@vue/shared': 3.5.38
-
-  '@vue/compiler-sfc@3.5.34':
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@vue/compiler-core': 3.5.34
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.15
-      source-map-js: 1.2.1
-    optional: true
 
   '@vue/compiler-sfc@3.5.38':
     dependencies:
@@ -23660,44 +23622,19 @@ snapshots:
       postcss: 8.5.15
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.34':
-    dependencies:
-      '@vue/compiler-dom': 3.5.34
-      '@vue/shared': 3.5.34
-    optional: true
-
   '@vue/compiler-ssr@3.5.38':
     dependencies:
       '@vue/compiler-dom': 3.5.38
       '@vue/shared': 3.5.38
 
-  '@vue/reactivity@3.5.34':
-    dependencies:
-      '@vue/shared': 3.5.34
-    optional: true
-
   '@vue/reactivity@3.5.38':
     dependencies:
       '@vue/shared': 3.5.38
-
-  '@vue/runtime-core@3.5.34':
-    dependencies:
-      '@vue/reactivity': 3.5.34
-      '@vue/shared': 3.5.34
-    optional: true
 
   '@vue/runtime-core@3.5.38':
     dependencies:
       '@vue/reactivity': 3.5.38
       '@vue/shared': 3.5.38
-
-  '@vue/runtime-dom@3.5.34':
-    dependencies:
-      '@vue/reactivity': 3.5.34
-      '@vue/runtime-core': 3.5.34
-      '@vue/shared': 3.5.34
-      csstype: 3.2.3
-    optional: true
 
   '@vue/runtime-dom@3.5.38':
     dependencies:
@@ -23706,21 +23643,11 @@ snapshots:
       '@vue/shared': 3.5.38
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      vue: 3.5.34(typescript@6.0.3)
-    optional: true
-
   '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.38
       '@vue/shared': 3.5.38
       vue: 3.5.38(typescript@6.0.3)
-
-  '@vue/shared@3.5.34':
-    optional: true
 
   '@vue/shared@3.5.38': {}
 
@@ -24213,7 +24140,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -25205,14 +25132,14 @@ snapshots:
 
   devframe@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3):
     dependencies:
-      '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@6.0.3))
+      '@valibot/to-json-schema': 1.7.0(valibot@1.4.1(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
       h3: 1.15.11
       logs-sdk: 0.0.6
       mrmime: 2.0.1
       pathe: 2.0.3
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
       ws: 8.21.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
@@ -25224,14 +25151,14 @@ snapshots:
 
   devframe@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3):
     dependencies:
-      '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@6.0.3))
+      '@valibot/to-json-schema': 1.7.0(valibot@1.4.1(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
       h3: 1.15.11
       logs-sdk: 0.0.6
       mrmime: 2.0.1
       pathe: 2.0.3
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
       ws: 8.21.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
@@ -27213,7 +27140,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -27588,6 +27515,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  jwt-decode@4.0.0: {}
 
   katex@0.16.45:
     dependencies:
@@ -28254,7 +28183,7 @@ snapshots:
   metro-source-map@0.83.7:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.83.7
@@ -28291,8 +28220,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       metro: 0.83.7
       metro-babel-transformer: 0.83.7
@@ -28312,10 +28241,10 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       accepts: 2.0.0
       ci-info: 2.0.0
       connect: 3.7.0
@@ -29961,7 +29890,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       strip-bom: 4.0.0
     optional: true
 
@@ -31934,11 +31863,6 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  valibot@1.4.0(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-    optional: true
-
   valibot@1.4.1(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
@@ -32001,7 +31925,7 @@ snapshots:
 
   vite-plugin-wasm@3.6.0(vite@8.0.16):
     dependencies:
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vite@7.3.2(@types/node@25.9.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -32022,7 +31946,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -32031,7 +31955,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.4
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -32050,10 +31974,29 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.4
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
+      sass: 1.100.0
+      sass-embedded: 1.100.0
+      terser: 5.48.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vite@8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.4
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16)
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
       sass: 1.100.0
       sass-embedded: 1.100.0
       terser: 5.48.0
@@ -32085,13 +32028,13 @@ snapshots:
 
   vitefu@1.1.3(vite@8.0.16):
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vitest-browser-react@2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+      vitest: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -32116,7 +32059,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.4
@@ -32128,9 +32071,40 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vitest@4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.4
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(playwright@1.61.0)(vite@8.0.16)(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+      happy-dom: 20.10.6
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
   vlq@1.0.1: {}
 
-  vocs@2.0.15(patch_hash=d09bb41c090c7717924369ae328e85a5d79cae5288f0de08d82c63e3eb2f03b9)(a38e4a4101e45bfc460543ee87b605cb):
+  vocs@2.0.15(patch_hash=d09bb41c090c7717924369ae328e85a5d79cae5288f0de08d82c63e3eb2f03b9)(b510c40cde6d0d7b19f84462d0bc81f1):
     dependencies:
       '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -32208,8 +32182,8 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       mermaid: 11.14.0
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      waku: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      waku: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@date-fns/tz'
@@ -32329,25 +32303,9 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-virtual-scroller@3.0.3(vue@3.5.34(typescript@6.0.3)):
-    dependencies:
-      vue: 3.5.34(typescript@6.0.3)
-    optional: true
-
   vue-virtual-scroller@3.0.4(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       vue: 3.5.38(typescript@6.0.3)
-
-  vue@3.5.34(typescript@6.0.3):
-    dependencies:
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-sfc': 3.5.34
-      '@vue/runtime-dom': 3.5.34
-      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@6.0.3))
-      '@vue/shared': 3.5.34
-    optionalDependencies:
-      typescript: 6.0.3
-    optional: true
 
   vue@3.5.38(typescript@6.0.3):
     dependencies:
@@ -32365,7 +32323,7 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  waku@1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  waku@1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@hono/node-server': 2.0.5(hono@4.12.14)
       '@vitejs/plugin-react': 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)
@@ -32378,7 +32336,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13))
       rsc-html-stream: 0.0.7
-      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - '@types/node'
@@ -32633,7 +32591,7 @@ snapshots:
 
   write-yaml-file@5.0.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       write-file-atomic: 5.0.1
     optional: true
 


### PR DESCRIPTION
## Problem

The JS SDK was sending raw API key JWTs (audience `"api"`) as Bearer tokens, but the upload/pins endpoints reject them — a login JWT obtained via key exchange is required. The Go CLI does this exchange in `AuthServiceDefault.GetLoginToken()`; the JS SDK never implemented it (TODO comment remained in `manager.ts`).

## Solution

Mimic the Go CLI's auth flow in the JS SDK:

### portal-sdk changes
- **Add `loginWithApiKey()`** to `AccountApi` — calls `POST /api/auth/key` on `account.pinner.xyz` with `Authorization: Bearer <apiKey>` (server strips `Bearer ` prefix via `ParseAuthTokenHeader`)
- **Fix `buildOptions()`** — custom headers from `init` now override the default `Bearer` token, so `loginWithApiKey`'s custom auth header takes precedence

### pinner SDK changes
- **Add `KeyExchangeAuthManager`** (`auth/key-exchange.ts`) — uses `jwt-decode` to inspect JWT audience without verification; if `aud === "api"`, exchanges via `sdk.account().loginWithApiKey()` and caches the login JWT
- **Make `AuthManager` interface async** — `getAuthToken`/`getAuthHeaders`/`getAccessToken` now return `Promise`s (needed because key exchange is a network call)
- **Update `Pinner` class** to use `KeyExchangeAuthManager` by default
- **Update all clients** to `await` async auth methods (`pin/client.ts`, `api/client.ts`, `upload/manager.ts`, `upload/tus-upload.ts`, `upload/xhr-upload.ts`, `upload/base-upload.ts`)
- **Update auth tests** for async interface

### Auth flow (mirrors Go CLI)
1. Decode JWT unverified, read `aud` claim
2. If `aud === "api"` → exchange via `POST account.pinner.xyz/api/auth/key` with `Bearer <apiKey>`
3. Cache the login JWT, use it as `Bearer` for subsequent requests
4. If `aud !== "api"` (already a login JWT) → use as-is

### Verified against portal server source
- `portal-plugin-dashboard/internal/api/api_auth.go:79` — route registration for `/api/auth/key`
- `portal-plugin-dashboard/internal/api/api_keys.go:220` — `authWithAPIKey` handler
- `portal-middleware/auth/auth.go:28` — `ParseAuthTokenHeader` strips `Bearer `/`bearer ` prefix
- Go SDK test (`account_test.go:1139-1143`) confirms raw JWT also works (server falls through)

## Test plan
- [ ] CI passes
- [ ] pinner-deploy-action can upload with API key JWT

---

<!-- kody-pr-summary:start -->
## Summary

This PR implements automatic API key exchange for JWT authentication in the pinner library. When a user provides an API key JWT (identified by having `"api"` as its audience claim), the system now automatically exchanges it for a login JWT via the portal's `POST /api/auth/key` endpoint before making any authenticated requests.

### Key Changes

- **New `KeyExchangeAuthManager`**: A new auth manager that extends `JwtAuthManager`. It lazily decodes the JWT audience on first use and, if the audience is `"api"`, exchanges the API key for a login JWT through the Portal SDK. The exchange is cached and deduplicated via a shared promise to avoid redundant network calls.

- **Async `AuthManager` interface**: All interface methods (`getAuthToken`, `getAuthHeaders`, `getAccessToken`) were changed from synchronous to async (`Promise`-returning) to accommodate the potential network call during token exchange. All consumers across the pinner library (API client, pin client, upload handlers, upload manager) were updated to `await` these calls.

- **Portal SDK `loginWithApiKey` method**: Added a new method to the Portal SDK's `AccountApi` that performs the API key-to-login-JWT exchange. Also fixed header merging logic so custom headers passed in `init` take precedence over default headers.

- **Pinner entry point**: The `Pinner` class now instantiates `KeyExchangeAuthManager` (instead of `JwtAuthManager`), passing both the JWT and the API endpoint.

- Added `jwt-decode` as a dependency for decoding JWT claims without verification.
<!-- kody-pr-summary:end -->