### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/easy-beds-bathe.md
+++ b/.changeset/easy-beds-bathe.md
@@ -1,0 +1,10 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- implement API key exchange for JWT auth
+- clear exchangePromise on failure, await portalSdk init
+- make portalSdk init lazily retryable
+- await #ensurePortalSdkReady in waitForOperation

--- a/.changeset/green-walls-attack.md
+++ b/.changeset/green-walls-attack.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-sdk: patch
+---
+
+## Fixes
+
+- implement API key exchange for JWT auth
+- use Bearer prefix for API key exchange


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This PR adds changeset entries documenting fixes for two packages:

**@lumeweb/pinner (patch):**
- Implement API key exchange for JWT authentication
- Clear `exchangePromise` on failure and await portal SDK initialization
- Make portal SDK initialization lazily retryable
- Await `#ensurePortalSdkReady` in `waitForOperation`

**@lumeweb/portal-sdk (patch):**
- Implement API key exchange for JWT authentication
- Use Bearer prefix for API key exchange
<!-- kody-pr-summary:end -->