### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/early-candies-jump.md
+++ b/.changeset/early-candies-jump.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- implement API key exchange for JWT auth
+- clear exchangePromise on failure, await portalSdk init
+- make portalSdk init lazily retryable
+- await #ensurePortalSdkReady in waitForOperation
+- derive account endpoint from pinner endpoint
+- preserve port/path in account endpoint derivation

--- a/.changeset/frank-areas-dream.md
+++ b/.changeset/frank-areas-dream.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-sdk: patch
+---
+
+## Fixes
+
+- implement API key exchange for JWT auth
+- use Bearer prefix for API key exchange


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This pull request adds changeset files to document upcoming patches for two packages: `@lumeweb/pinner` and `@lumeweb/portal-sdk`.

### `@lumeweb/pinner` (patch)
- Implements API key exchange for JWT authentication
- Clears `exchangePromise` on failure and awaits `portalSdk` initialization
- Makes `portalSdk` initialization lazily retryable
- Awaits `#ensurePortalSdkReady` in `waitForOperation`
- Derives the account endpoint from the pinner endpoint, preserving port and path

### `@lumeweb/portal-sdk` (patch)
- Implements API key exchange for JWT authentication
- Uses the `Bearer` prefix for API key exchange

These changesets serve as release documentation for the associated fixes and improvements across the pinner and portal SDK packages.
<!-- kody-pr-summary:end -->