### PR TITLE
fix(pinner): share single Sdk instance between auth and upload managers

### DIFF
--- a/libs/pinner/src/auth/key-exchange.ts
+++ b/libs/pinner/src/auth/key-exchange.ts
@@ -18,23 +18,9 @@ import { ConfigurationError } from "@/errors";
 export class KeyExchangeAuthManager extends JwtAuthManager {
   private resolvedToken = "";
   private exchangePromise?: Promise<string>;
-  private readonly sdk: Sdk;
 
-  constructor(jwt: string, endpoint: string) {
+  constructor(jwt: string, private readonly sdk: Sdk) {
     super(jwt);
-    // Derive the account endpoint from the pinner endpoint.
-    // Go SDK uses hardcoded DefaultEndpoint = "account.pinner.xyz".
-    // AccountApi constructor prepends "account." to the hostname,
-    // so we strip the first subdomain (e.g. ipfs.pinner.xyz → pinner.xyz)
-    // and let AccountApi add "account." → account.pinner.xyz.
-    // Mutate hostname in-place to preserve port, path, and other URL components.
-    const url = new URL(endpoint);
-    const parts = url.hostname.split(".");
-    if (parts.length > 2) {
-      parts.shift(); // Remove first subdomain (e.g. "ipfs")
-      url.hostname = parts.join(".");
-    }
-    this.sdk = new Sdk(url.toString());
   }
 
   /**

--- a/libs/pinner/src/config.ts
+++ b/libs/pinner/src/config.ts
@@ -74,3 +74,19 @@ export const DEFAULT_CONFIG: Partial<PinnerConfig> = {
   timeout: 120_000,
   retries: 3,
 };
+
+/**
+ * Derive the account API endpoint from a pinner endpoint.
+ *
+ * The portal-sdk AccountApi constructor prepends "account." to the hostname.
+ * We strip the first subdomain (e.g. ipfs.pinner.xyz → pinner.xyz) so
+ * AccountApi produces account.pinner.xyz, not account.ipfs.pinner.xyz.
+ * Port and path are preserved.
+ */
+export function deriveAccountEndpoint(endpoint: string): string {
+  const url = new URL(endpoint);
+  const parts = url.hostname.split(".");
+  if (parts.length > 2) parts.shift();
+  url.hostname = parts.join(".");
+  return url.toString();
+}

--- a/libs/pinner/src/pinner.ts
+++ b/libs/pinner/src/pinner.ts
@@ -1,10 +1,11 @@
 import type { PinnerConfig } from "./config";
+import { DEFAULT_CONFIG, deriveAccountEndpoint } from "./config";
 import { UploadManager } from "./upload";
 import { PinClient } from "./pin";
 import { IpnsClient } from "./api/ipns";
 import { WebsitesClient } from "./api/websites";
 import { JwtAuthManager, KeyExchangeAuthManager, type AuthManager } from "@/auth";
-import { DEFAULT_CONFIG } from "./config";
+import { Sdk } from "@lumeweb/portal-sdk";
 import type { UploadMethodAndBuilder } from "@/upload/builder";
 import { createUploadBuilderNamespace } from "@/upload/builder";
 import type {
@@ -36,8 +37,9 @@ export class Pinner {
    */
   constructor(config: PinnerConfig) {
     const endpoint = config.endpoint ?? DEFAULT_CONFIG.endpoint!;
-    this.auth = new KeyExchangeAuthManager(config.jwt, endpoint);
-    this.uploadManager = new UploadManager(config, this.auth);
+    const sdk = new Sdk(deriveAccountEndpoint(endpoint));
+    this.auth = new KeyExchangeAuthManager(config.jwt, sdk);
+    this.uploadManager = new UploadManager(config, this.auth, sdk);
     this._pins = new PinClient(config, this.auth);
     this._ipns = new IpnsClient(config, this.auth);
     this._websites = new WebsitesClient(config, this.auth);

--- a/libs/pinner/src/upload/manager.ts
+++ b/libs/pinner/src/upload/manager.ts
@@ -55,12 +55,12 @@ export class UploadManager {
    * @param config SDK configuration
    * @param auth AuthManager for authentication
    */
-  constructor(config: PinnerConfig, auth: AuthManager) {
+  constructor(config: PinnerConfig, auth: AuthManager, sdk: Sdk) {
     this.config = config;
     this.auth = auth;
     this.xhrHandler = new XHRUploadHandler(config, auth);
     this.tusHandler = new TUSUploadHandler(config, auth);
-    this.portalSdk = new Sdk(config.endpoint || DEFAULT_ENDPOINT);
+    this.portalSdk = sdk;
     configureCar({
       datastoreName: config.datastoreName,
       datastore: config.datastore,


### PR DESCRIPTION
## Problem

PR #1019 fixed the account endpoint derivation in `KeyExchangeAuthManager`, but `UploadManager` was constructing its own separate `Sdk` with the raw pinner endpoint (`ipfs.pinner.xyz`). This caused `AccountApi` to derive `account.ipfs.pinner.xyz` (nonexistent DNS), so `listOperations` silently failed with `fetch failed` and `waitForOperationByCid` could never find uploaded operations.

This was the root cause of the CI failure: upload succeeds, CID is returned, but `waitForOperation` fails immediately with "Failed to find operation with CID ...".

## Fix

- Create one `Sdk` in the `Pinner` constructor with the derived account endpoint
- Inject the shared `Sdk` into both `KeyExchangeAuthManager` and `UploadManager`
- Extract `deriveAccountEndpoint()` into `config.ts` as the single source of truth

## Verified

- 133/133 unit tests pass
- E2e test with real API key: upload → CID → `waitForOperation` → operation found successfully

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR refactors the pinner library to share a single `Sdk` instance between the `KeyExchangeAuthManager` and `UploadManager`, rather than having each create its own instance independently.

### Changes

- **Shared SDK instance**: The `Pinner` class now creates one `Sdk` instance and passes it to both the auth manager and upload manager, ensuring they operate on the same SDK instance with consistent configuration and state.

- **Extracted endpoint derivation**: The logic for deriving the account API endpoint from a pinner endpoint (stripping the first subdomain so the SDK's `AccountApi` produces `account.pinner.xyz` instead of `account.ipfs.pinner.xyz`) was moved from `KeyExchangeAuthManager` into a reusable `deriveAccountEndpoint()` function in the config module.

- **Simplified constructors**: `KeyExchangeAuthManager` and `UploadManager` no longer create their own `Sdk` instances internally; both now accept an `Sdk` instance as a constructor parameter.

### Purpose

Previously, the auth manager and upload manager each instantiated separate `Sdk` objects, which could lead to inconsistent state or configuration between authentication and upload operations. Sharing a single instance ensures both components use the same SDK configuration and connection state.
<!-- kody-pr-summary:end -->