### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/brave-moose-open.md
+++ b/.changeset/brave-moose-open.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- share single Sdk instance between auth and upload managers


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds a changeset entry documenting a fix for the `@lumeweb/pinner` package. The change ensures that a single SDK instance is shared between the authentication and upload managers, rather than each manager potentially maintaining its own instance.
<!-- kody-pr-summary:end -->