### PR TITLE
fix(portal-sdk): publish valid ESM entrypoints

### DIFF
--- a/libs/portal-sdk/package.json
+++ b/libs/portal-sdk/package.json
@@ -6,23 +6,20 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./openapi": {
       "types": "./dist/esm/openapi.d.ts",
-      "import": "./dist/esm/openapi.js",
-      "require": "./dist/cjs/openapi.cjs"
+      "import": "./dist/esm/openapi.js"
     },
     "./mocks": {
       "types": "./dist/esm/account/mocks.d.ts",
-      "import": "./dist/esm/account/mocks.js",
-      "require": "./dist/cjs/account/mocks.cjs"
+      "import": "./dist/esm/account/mocks.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Summary
- point `@lumeweb/portal-sdk` root `main`/`types` fields at the published ESM files
- remove CommonJS `require` export targets that are not generated or shipped

## Why
The package is `type: module` and the published `0.1.8` tarball only contains `dist/esm/*` files. It does not include `dist/index.js`, `dist/index.d.ts`, or any `dist/cjs/*.cjs` files, so the advertised root and CommonJS entrypoints currently resolve to missing files.

## Validation
- `npm pack @lumeweb/portal-sdk@0.1.8` and verified all patched `main`, `types`, and ESM export targets exist in the tarball
- verified the published tarball contains no `dist/cjs/` files
- `corepack pnpm --filter @lumeweb/portal-sdk lint` attempted, but dependencies are not installed in this environment (`tsc` not found)