### PR TITLE
fix: publish valid ESM-only entrypoints across all packages

### DIFF
--- a/libs/pinner/package.json
+++ b/libs/pinner/package.json
@@ -7,22 +7,21 @@
     "public",
     "package.json"
   ],
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": "./dist/esm/index.js"
     },
     "./mocks": {
       "types": "./dist/esm/api/mocks.d.ts",
       "import": "./dist/esm/api/mocks.js"
     },
     "./adapters/pinata": {
-      "types": "./dist/esm/adapters/pinata.d.ts",
-      "import": "./dist/esm/adapters/pinata.js"
+      "types": "./dist/esm/adapters/pinata/index.d.ts",
+      "import": "./dist/esm/adapters/pinata/index.js"
     },
     "./blockstore": {
       "types": "./dist/esm/blockstore/index.d.ts",

--- a/libs/portal-framework-auth/package.json
+++ b/libs/portal-framework-auth/package.json
@@ -6,8 +6,8 @@
     "dist",
     "package.json"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/libs/portal-framework-core/package.json
+++ b/libs/portal-framework-core/package.json
@@ -6,8 +6,8 @@
     "dist",
     "package.json"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/libs/portal-framework-ui-core/package.json
+++ b/libs/portal-framework-ui-core/package.json
@@ -6,8 +6,8 @@
     "dist",
     "package.json"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/libs/portal-framework-ui-core/src/components/ui/chart.tsx
+++ b/libs/portal-framework-ui-core/src/components/ui/chart.tsx
@@ -252,7 +252,7 @@ const ChartTooltipContent = React.forwardRef<
 );
 ChartTooltipContent.displayName = "ChartTooltip";
 
-const ChartLegend = RechartsPrimitive.Legend;
+const ChartLegend: React.ComponentType<RechartsPrimitive.LegendProps> = RechartsPrimitive.Legend;
 
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,

--- a/libs/portal-framework-ui-core/tsdown.config.ts
+++ b/libs/portal-framework-ui-core/tsdown.config.ts
@@ -17,7 +17,7 @@ export default defineConfig([
   {
     ...baseOptions,
     clean: true,
-    dts: false,
+    dts: true,
     entry: ["./src/index.ts", "!**/*.stories.tsx", "!**/*.css"],
     format: {
       esm: {

--- a/libs/portal-framework-ui/package.json
+++ b/libs/portal-framework-ui/package.json
@@ -6,8 +6,8 @@
     "dist",
     "package.json"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/libs/portal-plugin-abuse-common/package.json
+++ b/libs/portal-plugin-abuse-common/package.json
@@ -8,13 +8,12 @@
     "lint": "oxlint .",
     "orval": "orval"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./vite": {
       "types": "./dist/esm/vite/index.d.ts",

--- a/libs/portal-sdk/package.json
+++ b/libs/portal-sdk/package.json
@@ -6,23 +6,20 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./openapi": {
       "types": "./dist/esm/openapi.d.ts",
-      "import": "./dist/esm/openapi.js",
-      "require": "./dist/cjs/openapi.cjs"
+      "import": "./dist/esm/openapi.js"
     },
     "./mocks": {
       "types": "./dist/esm/account/mocks.d.ts",
-      "import": "./dist/esm/account/mocks.js",
-      "require": "./dist/cjs/account/mocks.cjs"
+      "import": "./dist/esm/account/mocks.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/portal-storybook-config/package.json
+++ b/libs/portal-storybook-config/package.json
@@ -3,18 +3,16 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "exports": {
     "./main": {
       "types": "./dist/esm/main.d.ts",
-      "import": "./dist/esm/main.js",
-      "require": "./dist/cjs/main.cjs"
+      "import": "./dist/esm/main.js"
     },
     "./preview": {
       "types": "./dist/esm/preview.d.ts",
-      "import": "./dist/esm/preview.js",
-      "require": "./dist/cjs/preview.cjs"
+      "import": "./dist/esm/preview.js"
     }
   },
   "scripts": {

--- a/libs/portal-test-util/package.json
+++ b/libs/portal-test-util/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",

--- a/libs/query-builder/package.json
+++ b/libs/query-builder/package.json
@@ -2,13 +2,12 @@
   "name": "@lumeweb/query-builder",
   "version": "0.1.1",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/rego/package.json
+++ b/libs/rego/package.json
@@ -3,13 +3,12 @@
   "version": "0.1.1",
   "description": "React components that compile to Go templates for email generation - combining React/Tailwind DX with Go native templating",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/libs/uppy-post-upload/package.json
+++ b/libs/uppy-post-upload/package.json
@@ -2,7 +2,7 @@
   "name": "@lumeweb/uppy-post-upload",
   "version": "0.1.2",
   "type": "module",
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "files": [
     "dist",
@@ -14,8 +14,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
The shared `tsdown-config` produces ESM output exclusively to `dist/esm/` with no CJS build. 12 packages had broken entrypoint metadata:

- `main`/`types` pointing at `dist/index.js` instead of `dist/esm/index.js`
- Dead `require` conditions in exports referencing non-existent `dist/cjs/`

## Fixed packages

| Package | Issues fixed |
|---|---|
| `@lumeweb/portal-sdk` | 3 dead require exports, broken main/types |
| `@lumeweb/uppy-post-upload` | dead require, main → CJS |
| `@lumeweb/query-builder` | dead require, broken main/types |
| `@lumeweb/pinner` | dead require, main → CJS, broken `./adapters/pinata` export path (file → directory) |
| `@lumeweb/rego` | dead require, broken main/types |
| `@lumeweb/portal-framework-core` | broken main/types |
| `@lumeweb/portal-framework-ui` | broken main/types |
| `@lumeweb/portal-framework-auth` | broken main/types |
| `@lumeweb/portal-framework-ui-core` | broken main/types, `dts: false` on main entry → enabled to generate `index.d.ts` |
| `@lumeweb/portal-test-util` | broken main/types |
| `@lumeweb/portal-plugin-abuse-common` | dead require, broken main/types |
| `portal-storybook-config` | dead require exports, main → CJS |

`@lumeweb/tsdown-config` left unchanged — it has its own config producing both ESM and CJS output.

Closes #1023

---

<!-- kody-pr-summary:start -->
## Description

This PR enables TypeScript declaration file (`.d.ts`) generation for the `portal-framework-ui-core` package by setting `dts: true` in its `tsdown.config.ts` build configuration.

Previously, declaration files were disabled (`dts: false`), which meant the package was published without type definitions. This is part of a broader effort to ensure all packages publish valid ESM-only entrypoints with proper type declarations, allowing consumers to benefit from TypeScript type checking when importing from this package.
<!-- kody-pr-summary:end -->