### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/bold-books-dig.md
+++ b/.changeset/bold-books-dig.md
@@ -1,0 +1,15 @@
+---
+@lumeweb/pinner: patch
+@lumeweb/portal-framework-auth: patch
+@lumeweb/portal-framework-core: patch
+@lumeweb/portal-framework-ui: patch
+@lumeweb/portal-framework-ui-core: patch
+@lumeweb/portal-sdk: patch
+@lumeweb/query-builder: patch
+@lumeweb/rego: patch
+@lumeweb/uppy-post-upload: patch
+---
+
+## Fixes
+
+- publish valid ESM-only entrypoints across all packages

--- a/.changeset/chart-legend-type.md
+++ b/.changeset/chart-legend-type.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-ui-core: patch
+---
+
+## Fixes
+
+- add type annotation for ChartLegend


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This pull request adds changeset files to document upcoming patch releases for multiple packages in the LumeWeb monorepo. The changesets record fixes for publishing valid ESM-only entrypoints across all packages, as well as a type annotation fix for `ChartLegend` in the `@lumeweb/portal-framework-ui-core` package.

### Affected Packages

The following packages will receive patch version bumps:

- `@lumeweb/pinner`
- `@lumeweb/rego`
- `@lumeweb/portal-framework-ui-core`
- `@lumeweb/uppy-post-upload`
- `@lumeweb/query-builder`
- `@lumeweb/portal-sdk`
- `@lumeweb/portal-framework-auth`
- `@lumeweb/portal-framework-core`
- `@lumeweb/portal-framework-ui`

### Changes Documented

- **ESM-only entrypoints**: All listed packages will publish valid ESM-only entrypoints.
- **Type annotation**: `@lumeweb/portal-framework-ui-core` will also include a type annotation for `ChartLegend`.
<!-- kody-pr-summary:end -->