### PR TITLE
feat(portal-framework-core): add ignore flag for excluding plugins from /api/meta

### DIFF
--- a/libs/portal-framework-core/src/schemas/plugin-registry.v1.json
+++ b/libs/portal-framework-core/src/schemas/plugin-registry.v1.json
@@ -34,6 +34,11 @@
           "default": "https",
           "description": "Protocol for tunnel connection. Defaults to https."
         },
+        "ignore": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, this plugin is excluded from the /api/meta response entirely — both local entries and upstream (server-side) plugins with the same name. The client will never see the plugin, so Module Federation won't load it. Useful for skipping server-side plugins that should not be loaded in a specific dev/preview environment."
+        },
         "local": {
           "type": "boolean",
           "default": false,

--- a/libs/portal-framework-core/src/vite/__tests__/config.spec.ts
+++ b/libs/portal-framework-core/src/vite/__tests__/config.spec.ts
@@ -468,4 +468,25 @@ describe("setupPluginRegistryConfig", () => {
     const result = setupPluginRegistryConfig(baseOpts);
     expect(result.portalConfig.feature_flags).toEqual({});
   });
+
+  it("skips ignored plugins and adds them to ignoredPlugins set", () => {
+    const registry = [
+      { name: "active-plugin", port: 4100 },
+      { name: "ignored-plugin", port: 4101, ignore: true },
+    ];
+
+    existsSyncSpy.mockReturnValue(true);
+    readFileSyncSpy.mockImplementation((path: string) => {
+      if (path.includes("plugin-registry.v1.json")) {
+        return JSON.stringify({ type: "array" });
+      }
+      return JSON.stringify(registry);
+    });
+
+    const result = setupPluginRegistryConfig(baseOpts);
+    expect(result.portalConfig.plugins["active-plugin"]).toBeDefined();
+    expect(result.portalConfig.plugins["ignored-plugin"]).toBeUndefined();
+    expect(result.ignoredPlugins.has("ignored-plugin")).toBe(true);
+    expect(result.ignoredPlugins.has("active-plugin")).toBe(false);
+  });
 });

--- a/libs/portal-framework-core/src/vite/__tests__/express-middleware.spec.ts
+++ b/libs/portal-framework-core/src/vite/__tests__/express-middleware.spec.ts
@@ -150,22 +150,54 @@ describe("mergeUpstreamConfig", () => {
     mergeUpstreamConfig(localConfig, upstreamConfig);
     expect(localConfig).toEqual(original);
   });
+
+  // ── ignore flag cascade ──
+
+  it("removes ignored plugins from upstream response", async () => {
+    const { mergeUpstreamConfig } = await import("../express-middleware");
+    const ignored = new Set(["upstreamOnly"]);
+    const result = mergeUpstreamConfig(localConfig, upstreamConfig, ignored);
+    expect(result.plugins["upstreamOnly"]).toBeUndefined();
+    expect(result.plugins["dashboard"]).toBeDefined();
+  });
+
+  it("does not strip non-ignored upstream plugins", async () => {
+    const { mergeUpstreamConfig } = await import("../express-middleware");
+    const ignored = new Set(["nonexistent"]);
+    const result = mergeUpstreamConfig(localConfig, upstreamConfig, ignored);
+    expect(result.plugins["dashboard"]).toBeDefined();
+    expect(result.plugins["upstreamOnly"]).toBeDefined();
+  });
+
+  it("with empty ignore set behaves like no filtering", async () => {
+    const { mergeUpstreamConfig } = await import("../express-middleware");
+    const resultWith = mergeUpstreamConfig(
+      localConfig,
+      upstreamConfig,
+      new Set(),
+    );
+    const resultWithout = mergeUpstreamConfig(localConfig, upstreamConfig);
+    expect(resultWith.plugins).toEqual(resultWithout.plugins);
+  });
 });
 
 // ── createExpressMiddlewarePlugin ───────────────────────────────────
 
 describe("createExpressMiddlewarePlugin", () => {
+  const loaderResult = {
+    portalConfig: {
+      domain: DEFAULT_PORTAL_DOMAIN,
+      feature_flags: {},
+      plugins: {},
+    },
+    ignoredPlugins: new Set<string>(),
+  };
+
   it("returns a Vite plugin with correct name", async () => {
     const { createExpressMiddlewarePlugin } = await import(
       "../express-middleware"
     );
-    const loader = () =>
-      ({
-        domain: DEFAULT_PORTAL_DOMAIN,
-        feature_flags: {},
-        plugins: {},
-      }) as PortalMetaConfig;
-    const plugin = createExpressMiddlewarePlugin(loader);
+    const plugin = createExpressMiddlewarePlugin(() => loaderResult);
     expect(plugin.name).toBe("portal-express-middleware");
   });
 
@@ -173,13 +205,7 @@ describe("createExpressMiddlewarePlugin", () => {
     const { createExpressMiddlewarePlugin } = await import(
       "../express-middleware"
     );
-    const loader = () =>
-      ({
-        domain: DEFAULT_PORTAL_DOMAIN,
-        feature_flags: {},
-        plugins: {},
-      }) as PortalMetaConfig;
-    const plugin = createExpressMiddlewarePlugin(loader);
+    const plugin = createExpressMiddlewarePlugin(() => loaderResult);
     expect(plugin.apply).toBe("serve");
   });
 
@@ -187,13 +213,7 @@ describe("createExpressMiddlewarePlugin", () => {
     const { createExpressMiddlewarePlugin } = await import(
       "../express-middleware"
     );
-    const loader = () =>
-      ({
-        domain: DEFAULT_PORTAL_DOMAIN,
-        feature_flags: {},
-        plugins: {},
-      }) as PortalMetaConfig;
-    const plugin = createExpressMiddlewarePlugin(loader);
+    const plugin = createExpressMiddlewarePlugin(() => loaderResult);
     expect(typeof plugin.configureServer).toBe("function");
     expect(typeof plugin.configurePreviewServer).toBe("function");
   });

--- a/libs/portal-framework-core/src/vite/config.ts
+++ b/libs/portal-framework-core/src/vite/config.ts
@@ -50,6 +50,7 @@ export function normalizeConfigOptions(opts: ConfigOptions): ConfigOptions {
 
 export function setupPluginRegistryConfig(opts: ConfigOptions): {
   portalConfig: PortalMetaConfig;
+  ignoredPlugins: Set<string>;
 } {
   const configFile =
     opts.pluginRegistryConfigFile ?? DEFAULT_PLUGIN_REGISTRY_FILE;
@@ -80,9 +81,15 @@ export function setupPluginRegistryConfig(opts: ConfigOptions): {
     }
 
     const plugins: Record<string, PortalPluginConfig> = {};
+    const ignoredPlugins = new Set<string>();
 
     for (const entry of registry) {
       const { name, web_bundles, meta, build, port } = entry;
+
+      if (entry.ignore) {
+        ignoredPlugins.add(name);
+        continue;
+      }
 
       if (web_bundles && web_bundles.length > 0) {
         plugins[name] = {
@@ -107,7 +114,7 @@ export function setupPluginRegistryConfig(opts: ConfigOptions): {
       plugins,
     };
 
-    return { portalConfig };
+    return { portalConfig, ignoredPlugins };
   } catch (error) {
     console.error("Error reading or parsing proxy config file:", error);
     throw new Error(

--- a/libs/portal-framework-core/src/vite/express-middleware.ts
+++ b/libs/portal-framework-core/src/vite/express-middleware.ts
@@ -10,12 +10,15 @@ import { DEFAULT_PORTAL_DOMAIN } from "./types";
 export function mergeUpstreamConfig(
   portalConfig: PortalMetaConfig,
   upstreamConfig: PortalMetaConfig,
+  ignoredPlugins?: Set<string>,
 ): PortalMetaConfig {
+  const ignored = ignoredPlugins ?? new Set<string>();
   const mergedConfig: PortalMetaConfig = { ...portalConfig };
 
   mergedConfig.plugins = Object.fromEntries(
-    Object.entries(upstreamConfig.plugins).map(
-      ([pluginName, upstreamPlugin]) => {
+    Object.entries(upstreamConfig.plugins)
+      .filter(([pluginName]) => !ignored.has(pluginName))
+      .map(([pluginName, upstreamPlugin]) => {
         const localPlugin = portalConfig.plugins[pluginName];
         return [
           pluginName,
@@ -24,8 +27,7 @@ export function mergeUpstreamConfig(
             web_bundles: localPlugin?.web_bundles ?? upstreamPlugin.web_bundles,
           },
         ];
-      },
-    ),
+      }),
   );
 
   for (const [pluginName, localPlugin] of Object.entries(
@@ -58,6 +60,7 @@ export function mergeUpstreamConfig(
 export function setupExpressMiddleware(
   server: ViteDevServer | PreviewServer,
   portalConfig: PortalMetaConfig,
+  ignoredPlugins?: Set<string>,
 ): void {
   const expressApp = express();
   expressApp.use(express.json());
@@ -92,7 +95,11 @@ export function setupExpressMiddleware(
             throw new Error(`Failed to parse upstream config: ${err.message}`);
           })) as PortalMetaConfig;
 
-          mergedConfig = mergeUpstreamConfig(portalConfig, upstreamConfig);
+          mergedConfig = mergeUpstreamConfig(
+            portalConfig,
+            upstreamConfig,
+            ignoredPlugins,
+          );
         } catch (error) {
           console.error("Failed to fetch/process upstream meta config:", error);
         } finally {
@@ -149,17 +156,20 @@ export function setupExpressMiddleware(
 }
 
 export function createExpressMiddlewarePlugin(
-  configLoader: () => PortalMetaConfig,
+  configLoader: () => {
+    portalConfig: PortalMetaConfig;
+    ignoredPlugins: Set<string>;
+  },
 ): Plugin {
   return {
     apply: "serve",
     configurePreviewServer(server) {
-      const portalConfig = configLoader();
-      setupExpressMiddleware(server, portalConfig);
+      const { portalConfig, ignoredPlugins } = configLoader();
+      setupExpressMiddleware(server, portalConfig, ignoredPlugins);
     },
     configureServer(server) {
-      const portalConfig = configLoader();
-      setupExpressMiddleware(server, portalConfig);
+      const { portalConfig, ignoredPlugins } = configLoader();
+      setupExpressMiddleware(server, portalConfig, ignoredPlugins);
     },
     name: "portal-express-middleware",
   };

--- a/libs/portal-framework-core/src/vite/types.ts
+++ b/libs/portal-framework-core/src/vite/types.ts
@@ -41,6 +41,12 @@ export interface PortalPlugin {
   tunnelHost?: string;
   tunnelProtocol?: "http" | "https";
   local?: boolean;
+  /**
+   * When true, this plugin is excluded from the /api/meta response entirely
+   * — both local entries and upstream (server-side) plugins with the same name.
+   * The client will never see the plugin, so Module Federation won't load it.
+   */
+  ignore?: boolean;
   web_bundles?: RegistryWebBundle[];
   meta?: PluginMeta;
   build?: BuildInfo;

--- a/libs/portal-framework-core/src/vite/vite-config.ts
+++ b/libs/portal-framework-core/src/vite/vite-config.ts
@@ -123,8 +123,7 @@ function createHostConfig(opts: ConfigOptions) {
 
   config.plugins!.push(
     createExpressMiddlewarePlugin(() => {
-      const { portalConfig } = setupPluginRegistryConfig(opts);
-      return portalConfig;
+      return setupPluginRegistryConfig(opts);
     }),
   );
 

--- a/tunnel-lib.sh
+++ b/tunnel-lib.sh
@@ -345,8 +345,10 @@ tunnel_single_app() {
 }
 
 # --- Generate Plugin Config JSON ---
-# Usage: tunnel_generate_plugin_config <base_port> <domain> <plugins_base_dir> [local:]plugin1,[local:]plugin2,...
-# Use "local:" prefix for client-only plugins (no Go backend, e.g. local:onboarding)
+# Usage: tunnel_generate_plugin_config <base_port> <domain> <plugins_base_dir> [prefix:]plugin1,[prefix:]plugin2,...
+# Supported prefixes:
+#   local:  Client-only plugin (no Go backend, e.g. local:onboarding)
+#   ignore: Plugin excluded from /api/meta response (skips server start + tunnel creation)
 tunnel_generate_plugin_config() {
     local base_port="${1:-4174}"
     local domain="${2:-$TUNNEL_DOMAIN}"
@@ -364,8 +366,9 @@ tunnel_generate_plugin_config() {
     local jq_args=("--arg" "domain" "$domain")
     local idx=0
     local -a local_indices=()
+    local -a ignore_indices=()
 
-    # Parse comma-separated list (supports "local:" prefix for client-only plugins)
+    # Parse comma-separated list (supports "local:" and "ignore:" prefixes)
     IFS=',' read -ra plugins <<< "$plugin_list"
     for entry in "${plugins[@]}"; do
         # Trim whitespace
@@ -373,12 +376,19 @@ tunnel_generate_plugin_config() {
         [ -z "$entry" ] && continue
 
         local is_local=false
+        local is_ignore=false
         local name="$entry"
 
         # Check for local: prefix
         if [[ "$entry" == local:* ]]; then
             is_local=true
             name="${entry#local:}"
+        fi
+
+        # Check for ignore: prefix
+        if [[ "$entry" == ignore:* ]]; then
+            is_ignore=true
+            name="${entry#ignore:}"
         fi
 
         local plugin_dir="$plugins_base_dir/portal-plugin-$name"
@@ -392,6 +402,7 @@ tunnel_generate_plugin_config() {
         jq_args+=("--arg" "name$idx" "$name")
         jq_args+=("--argjson" "port$idx" "$port")
         local_indices[idx]=$is_local
+        ignore_indices[idx]=$is_ignore
         idx=$((idx + 1))
         port=$((port + 1))
     done
@@ -404,9 +415,12 @@ tunnel_generate_plugin_config() {
     local filter="["
     for i in $(seq 0 $((idx - 1))); do
         [ "$i" -gt 0 ] && filter="$filter,"
-        filter="$filter{name: \$name$i, port: \$port$i, tunnelHost: \"\(\$name$i).\(\$domain)\""
+        filter="$filter{name: \$name$i, port: \$port$i, tunnelHost: \"\$(\$name$i).\$(\$domain)\""
         if [ "${local_indices[$i]}" = true ]; then
             filter="$filter, local: true"
+        fi
+        if [ "${ignore_indices[$i]}" = true ]; then
+            filter="$filter, ignore: true"
         fi
         filter="$filter}"
     done
@@ -468,6 +482,14 @@ tunnel_multi_app() {
             name=$(echo "$plugin" | jq -r '.name')
             local tunnelHost
             tunnelHost=$(echo "$plugin" | jq -r '.tunnelHost')
+            local is_ignored
+            is_ignored=$(echo "$plugin" | jq -r '.ignore // false')
+
+            if [ "$is_ignored" = "true" ]; then
+                echo "Skipping ignored plugin '$name' (server start)"
+                continue
+            fi
+
             local plugin_dir="$plugins_base_dir/portal-plugin-$name"
 
             if [ ! -d "$plugin_dir" ]; then
@@ -495,9 +517,16 @@ tunnel_multi_app() {
             name=$(echo "$plugin" | jq -r '.name')
             local tunnelHost
             tunnelHost=$(echo "$plugin" | jq -r '.tunnelHost')
+            local is_ignored
+            is_ignored=$(echo "$plugin" | jq -r '.ignore // false')
             local plugin_dir="$plugins_base_dir/portal-plugin-$name"
 
             if [ ! -d "$plugin_dir" ]; then
+                continue
+            fi
+
+            if [ "$is_ignored" = "true" ]; then
+                echo "Skipping ignored plugin '$name' (tunnel creation)"
                 continue
             fi
 


### PR DESCRIPTION
## Summary
- Adds `ignore` flag to portal plugin config entries, cascading through the full pipeline
- `TUNNEL_PLUGINS` env var supports `ignore:pluginName` prefix (same pattern as existing `local:`)
- Ignored plugins are excluded from local config, stripped from upstream `/api/meta` response, and skip dev server + tunnel creation

## Changes
- **types.ts**: `ignore?: boolean` on `PortalPlugin`
- **plugin-registry.v1.json**: `ignore` property in JSON schema
- **config.ts**: `setupPluginRegistryConfig` skips ignored entries, returns `ignoredPlugins` set
- **express-middleware.ts**: `mergeUpstreamConfig` filters ignored plugins from upstream; threaded through `setupExpressMiddleware` and `createExpressMiddlewarePlugin`
- **vite-config.ts**: config loader returns full `{ portalConfig, ignoredPlugins }` object
- **tunnel-lib.sh**: parses `ignore:` prefix, emits `"ignore": true` in generated config, skips server/tunnel start

## Test Plan
- [x] 58 tests pass (23 express-middleware + 35 config)
- [x] New tests for ignore cascade in mergeUpstreamConfig (removes from upstream, preserves non-ignored, empty set = no filtering)
- [x] New test for setupPluginRegistryConfig (skips ignored, adds to ignoredPlugins set)
- [x] Existing createExpressMiddlewarePlugin tests updated for new config loader type

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds an `ignore` flag that allows plugins to be completely excluded from the `/api/meta` response, ensuring the client never sees them and Module Federation won't attempt to load them.

### Changes

**Plugin type definition** (`types.ts`): Added an optional `ignore` boolean property to the `PortalPlugin` interface, with documentation noting it excludes the plugin from both local and upstream `/api/meta` entries.

**Plugin registry config** (`config.ts`): `setupPluginRegistryConfig` now tracks ignored plugins in a `Set<string>`. When a registry entry has `ignore: true`, it is added to this set and skipped entirely — it won't appear in the local `portalConfig.plugins`.

**Express middleware** (`express-middleware.ts`): `mergeUpstreamConfig` now accepts an optional `ignoredPlugins` set and filters out any upstream plugins whose names are in that set before merging. This ensures ignored plugins are stripped from the server-side response as well. The `configLoader` callback type was updated to return both `portalConfig` and `ignoredPlugins`, and both server hooks (`configureServer`, `configurePreviewServer`) pass the set through.

**Vite config** (`vite-config.ts`): Updated the middleware plugin callback to return the full `setupPluginRegistryConfig` result (including `ignoredPlugins`) instead of just the portal config.

**Tunnel script** (`tunnel-lib.sh`): Added support for an `ignore:` prefix in the plugin list (alongside the existing `local:` prefix). Ignored plugins get `ignore: true` in the generated registry JSON, and during multi-app tunneling, both server startup and tunnel creation are skipped for ignored plugins.

**Tests**: Added coverage verifying that ignored plugins are excluded from the local config, stripped from upstream merges, and that an empty ignore set behaves identically to no filtering.
<!-- kody-pr-summary:end -->