### PR TITLE
fix(tunnel-lib): correct tunnelHost jq interpolation and DRY plugin config generation

### DIFF
--- a/tunnel-lib.sh
+++ b/tunnel-lib.sh
@@ -362,11 +362,8 @@ tunnel_generate_plugin_config() {
         exit 1
     fi
 
-    # Build jq array using --arg and --argjson
-    local jq_args=("--arg" "domain" "$domain")
-    local idx=0
-    local -a local_indices=()
-    local -a ignore_indices=()
+    # Collect per-plugin JSON objects (built with jq -n, no manual escaping)
+    local -a entries=()
 
     # Parse comma-separated list (supports "local:" and "ignore:" prefixes)
     IFS=',' read -ra plugins <<< "$plugin_list"
@@ -399,34 +396,29 @@ tunnel_generate_plugin_config() {
             continue
         fi
 
-        jq_args+=("--arg" "name$idx" "$name")
-        jq_args+=("--argjson" "port$idx" "$port")
-        local_indices[idx]=$is_local
-        ignore_indices[idx]=$is_ignore
-        idx=$((idx + 1))
+        # Build JSON object with jq -n (all values safely interpolated, no manual escaping)
+        local obj
+        obj=$(jq -n \
+            --arg name "$name" \
+            --argjson port "$port" \
+            --arg tunnelHost "$name.$domain" \
+            --argjson local "$is_local" \
+            --argjson ignore "$is_ignore" \
+            '{name: $name, port: $port, tunnelHost: $tunnelHost} +
+             (if $local then {local: true} else {} end) +
+             (if $ignore then {ignore: true} else {} end)')
+        entries+=("$obj")
+
         port=$((port + 1))
     done
 
-    if [ $idx -eq 0 ]; then
+    if [ ${#entries[@]} -eq 0 ]; then
         echo "[]"
         return 0
     fi
 
-    local filter="["
-    for i in $(seq 0 $((idx - 1))); do
-        [ "$i" -gt 0 ] && filter="$filter,"
-        filter="$filter{name: \$name$i, port: \$port$i, tunnelHost: \"\$(\$name$i).\$(\$domain)\""
-        if [ "${local_indices[$i]}" = true ]; then
-            filter="$filter, local: true"
-        fi
-        if [ "${ignore_indices[$i]}" = true ]; then
-            filter="$filter, ignore: true"
-        fi
-        filter="$filter}"
-    done
-    filter="$filter]"
-
-    jq "${jq_args[@]}" -n "$filter"
+    # Assemble final array from all collected JSON objects
+    printf '%s\n' "${entries[@]}" | jq -s '.'
 }
 
 # --- Multi-App Tunnel (module-federation with plugins) ---


### PR DESCRIPTION
## Summary
- Fixes broken `tunnelHost` values in generated `plugin.config.json` — was outputting literal `\$($nameN).\$($domain)` instead of e.g. `dashboard.tunnel.pinner.xyz`
- Replaced the fragile jq filter-string approach (manual `\\$name$i` escaping, parallel index arrays) with per-entry `jq -n` calls using `--arg`/`--argjson` for safe interpolation
- Final array assembled with `jq -s '.'` — no manual JSON escaping anywhere
- Shellcheck passes clean

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR fixes a bug in the `tunnel_generate_plugin_config()` function in `tunnel-lib.sh` where the `tunnelHost` field was being generated with incorrect jq interpolation syntax, resulting in malformed or invalid JSON output.

### What Changed

**Bug Fix — `tunnelHost` jq interpolation:**
The previous implementation built a single jq filter string manually, using invalid interpolation syntax (`$($name0).$($domain)`) for the `tunnelHost` field. In jq, string interpolation requires `\($var)` syntax, not `$($var)`. This caused the `tunnelHost` value (which should be `name.domain`) to be incorrectly constructed.

**Refactor — DRY plugin config generation:**
Instead of constructing one large jq filter string with indexed variable names (`name0`, `name1`, `port0`, `port1`, etc.) and tracking separate arrays for `local` and `ignore` flags, the code now:
- Builds each plugin's JSON object individually using `jq -n` with proper `--arg`/`--argjson` flags
- Constructs the `tunnelHost` value (`name.domain`) at the bash level via simple string concatenation, avoiding jq interpolation entirely
- Collects all JSON objects and assembles the final array using `jq -s '.'` (slurp mode)

This eliminates the error-prone manual filter string construction and removes the need for indexed variable naming, making the code more maintainable and correct.
<!-- kody-pr-summary:end -->