### PR TITLE
fix(tunnel-lib): skip directory check for local: plugins

### DIFF
--- a/tunnel-lib.sh
+++ b/tunnel-lib.sh
@@ -388,12 +388,13 @@ tunnel_generate_plugin_config() {
             name="${entry#ignore:}"
         fi
 
-        local plugin_dir="$plugins_base_dir/portal-plugin-$name"
-
-        # Verify plugin exists
-        if [ ! -d "$plugin_dir" ]; then
-            echo "Warning: Plugin directory not found: $plugin_dir" >&2
-            continue
+        # Local plugins (client-only) have no portal-plugin-* directory
+        if [ "$is_local" = false ]; then
+            local plugin_dir="$plugins_base_dir/portal-plugin-$name"
+            if [ ! -d "$plugin_dir" ]; then
+                echo "Warning: Plugin directory not found: $plugin_dir" >&2
+                continue
+            fi
         fi
 
         # Build JSON object with jq -n (all values safely interpolated, no manual escaping)


### PR DESCRIPTION
local: prefix marks client-only plugins with no portal-plugin-* directory. The directory existence check was silently skipping them, so local:sia never appeared in the generated plugin.config.json.

---

<!-- kody-pr-summary:start -->
## Pull Request Description

**Fix: Skip directory check for local plugins in tunnel config generation**

The `tunnel_generate_plugin_config()` function previously validated the existence of a `portal-plugin-*` directory for all plugins, skipping any plugin where the directory was not found. This caused local (client-only) plugins to be incorrectly skipped, as they do not have a corresponding `portal-plugin-*` directory on the server side.

The fix wraps the directory existence check in a condition that only applies to non-local plugins (`is_local = false`), allowing local plugins to proceed through the configuration generation without requiring a server-side plugin directory.
<!-- kody-pr-summary:end -->