### PR TITLE
refactor: migrate to namespaced IDs across framework and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ apps/*/build
 
 # Generated tunnel plugin configs
 plugin.config.json
+
+# Docs
+docs/
+.worktrees/
+apps/*/devtools-output/

--- a/libs/portal-framework-auth/src/capabilities/refineConfig.ts
+++ b/libs/portal-framework-auth/src/capabilities/refineConfig.ts
@@ -1,6 +1,8 @@
 import {
+  createNamespacedId,
   CapabilityStatus,
   Framework,
+  FRAMEWORK_NS,
   getSdk,
   RefineConfigCapability,
 } from "@lumeweb/portal-framework-core";
@@ -9,10 +11,10 @@ import { AuthProvider } from "@refinedev/core";
 import { createAuthProvider } from "../dataProviders/auth";
 
 export class Capability implements RefineConfigCapability {
-  dependencies = ["core:sdk-auth"];
-  readonly id = "core:refine-config-auth";
+  dependencies = [createNamespacedId(FRAMEWORK_NS, "sdk-auth")];
+  readonly id = createNamespacedId(FRAMEWORK_NS, "refine-config-auth");
   status: CapabilityStatus = "inactive";
-  readonly type = "core:refine-config";
+  readonly type = "framework:refine-config";
   #authProvider?: AuthProvider;
 
   async destroy() {

--- a/libs/portal-framework-auth/src/capabilities/sdk.ts
+++ b/libs/portal-framework-auth/src/capabilities/sdk.ts
@@ -1,14 +1,16 @@
 import {
+  createNamespacedId,
   Framework,
+  FRAMEWORK_NS,
   getApiBaseUrl,
   SdkCapability,
 } from "@lumeweb/portal-framework-core";
 import { Sdk } from "@lumeweb/portal-sdk";
 
 export class Capability implements SdkCapability {
-  readonly id: string = "core:sdk-auth";
+  readonly id = createNamespacedId(FRAMEWORK_NS, "sdk-auth");
   status: "active" | "error" | "inactive";
-  readonly type: "core:sdk" = "core:sdk";
+  readonly type = "framework:sdk" as const;
   #sdk?: Sdk;
 
   async destroy() {

--- a/libs/portal-framework-auth/src/ui/components/login/OtpForm.tsx
+++ b/libs/portal-framework-auth/src/ui/components/login/OtpForm.tsx
@@ -17,7 +17,7 @@ export interface OtpParams {
   to?: string;
 }
 
-function OtpForm(): JSX.Element {
+function OtpForm(): React.JSX.Element {
   const parsed = useParsed<OtpParams>();
   const login = useLogin();
   const resetPasswordUrl = useResetPasswordUrl();

--- a/libs/portal-framework-core/src/api/builder.spec.ts
+++ b/libs/portal-framework-core/src/api/builder.spec.ts
@@ -5,6 +5,7 @@ import { MOCK_PLUGINS } from "@lumeweb/portal-test-util";
 import { loadRemote } from "@module-federation/enhanced/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createNamespacedId } from "../util/namespace";
 import { getPluginInfo } from "../util/getPluginInfo";
 import { Builder } from "./builder";
 import { Framework } from "./framework";
@@ -49,13 +50,13 @@ describe("Builder", () => {
       const builder = new Builder("test-app");
       const factory = () => mockPlugin;
 
-      builder.registerPluginFactory("test:plugin", factory);
+      builder.registerPluginFactory(createNamespacedId("test", "plugin"), factory);
 
       // Trigger build to process the queued operation
       const framework = await builder.build();
       const mockPluginManager = framework.getPluginManager();
       expect(mockPluginManager.registerFactory).toHaveBeenCalledWith(
-        "test:plugin",
+        createNamespacedId("test", "plugin"),
         factory,
       );
     });
@@ -64,10 +65,10 @@ describe("Builder", () => {
   describe("registerRemoteModule", () => {
     it("should load and register remote module", async () => {
       const mockModule = {
-        default: () => ({ ...mockPlugin, id: "test:plugin" }),
+        default: () => ({ ...mockPlugin, id: createNamespacedId("test", "plugin") }),
       }; // Ensure the mock plugin has the correct ID
       vi.mocked(loadRemote).mockResolvedValue(mockModule);
-      vi.mocked(getPluginInfo).mockReturnValue({ id: "test:plugin" });
+      vi.mocked(getPluginInfo).mockReturnValue({ id: createNamespacedId("test", "plugin") });
 
       const builder = new Builder("test-app");
       await builder.registerRemoteModule(
@@ -82,24 +83,24 @@ describe("Builder", () => {
       expect(mockPluginManager.registerRemoteModule).toHaveBeenCalledWith(
         "remote-1",
         "http://example.com/remote.js",
-        "test:plugin",
+        createNamespacedId("test", "plugin"),
       );
       expect(mockPluginManager.registerFactory).toHaveBeenCalledWith(
-        "test:plugin",
+        createNamespacedId("test", "plugin"),
         expect.any(Function),
       ); // Factory is the mod.default
       expect(mockPluginManager.enableAndActivatePlugin).toHaveBeenCalledWith(
-        "test:plugin",
+        createNamespacedId("test", "plugin"),
       );
       // Wait for plugin to be loaded
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(mockPluginManager.registerFactory).toHaveBeenCalledWith(
-        "test:plugin",
+        createNamespacedId("test", "plugin"),
         expect.any(Function)
       );
       expect(mockPluginManager.enableAndActivatePlugin).toHaveBeenCalledWith(
-        "test:plugin"
+        createNamespacedId("test", "plugin")
       );
     });
 
@@ -123,23 +124,23 @@ describe("Builder", () => {
 
     it("should execute queued operations in order", async () => {
       const builder = new Builder("test-app");
-      builder.registerPluginFactory("test:plugin1", () => ({
+      builder.registerPluginFactory(createNamespacedId("test", "plugin1"), () => ({
         ...mockPlugin,
-        id: "test:plugin1",
+        id: createNamespacedId("test", "plugin1"),
       }));
-      builder.registerPluginFactory("test:plugin2", () => ({
+      builder.registerPluginFactory(createNamespacedId("test", "plugin2"), () => ({
         ...mockPlugin,
-        id: "test:plugin2",
+        id: createNamespacedId("test", "plugin2"),
       }));
 
       const framework = await builder.build();
       const pluginManager = framework.getPluginManager(); // Get the mock manager instance created during build
 
       // Verify registration calls were made in order
-      const registerCalls = pluginManager.registerFactory.mock.calls;
+      const registerCalls = vi.mocked(pluginManager.registerFactory).mock.calls;
       expect(registerCalls).toHaveLength(2);
-      expect(registerCalls[0][0]).toBe("test:plugin1");
-      expect(registerCalls[1][0]).toBe("test:plugin2");
+      expect(registerCalls[0][0]).toBe(createNamespacedId("test", "plugin1"));
+      expect(registerCalls[1][0]).toBe(createNamespacedId("test", "plugin2"));
     });
   });
 });

--- a/libs/portal-framework-core/src/api/framework.spec.ts
+++ b/libs/portal-framework-core/src/api/framework.spec.ts
@@ -3,6 +3,7 @@ import { createMockPluginManager } from "@lumeweb/portal-test-util";
 import { createMockSdkCapability } from "@lumeweb/portal-test-util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { CORE_NS, createNamespacedId } from "../util/namespace";
 import { Framework } from "./framework";
 import { ERROR_CATEGORIES } from "../types/api";
 
@@ -11,7 +12,7 @@ describe("Framework", () => {
   let framework: Framework;
   let mockPluginManager: ReturnType<typeof createMockPluginManager>;
   let mockCapabilityManager: ReturnType<typeof createMockCapabilityManager>;
-  let consoleWarnSpy: vi.SpyInstance; // Declare spy variable
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>; // Declare spy variable
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -197,35 +198,35 @@ describe("Framework", () => {
     const mockModule: any = {
       entry: "http://example.com/remote.js",
       moduleId: "remote-1",
-      pluginId: "core:plugin",
+      pluginId: createNamespacedId(CORE_NS, "plugin"),
     };
     mockPluginManager.getRemoteModule = vi.fn().mockReturnValue(mockModule);
 
-    const result = framework.resolvePluginModule("core:plugin", "ComponentA");
+    const result = framework.resolvePluginModule(createNamespacedId(CORE_NS, "plugin"), "ComponentA");
     expect(result).toBe("remote-1/ComponentA");
     expect(mockPluginManager.getRemoteModule).toHaveBeenCalledWith(
-      "core:plugin",
+      createNamespacedId(CORE_NS, "plugin"),
     );
   });
 
   it("should load features", async () => {
     const mockFeature = {
       destroy: vi.fn(),
-      id: "core:feature",
+      id: createNamespacedId(CORE_NS, "feature"),
       initialize: vi.fn(),
     };
     mockPluginManager.loadFeature = vi.fn().mockResolvedValue(mockFeature);
 
-    const result = await framework.loadFeature("core:feature");
+    const result = await framework.loadFeature(createNamespacedId(CORE_NS, "feature"));
     expect(result).toBe(mockFeature);
-    expect(mockPluginManager.loadFeature).toHaveBeenCalledWith("core:feature");
+    expect(mockPluginManager.loadFeature).toHaveBeenCalledWith(createNamespacedId(CORE_NS, "feature"));
   });
 
   it("should register capabilities", () => {
-    framework.registerCapability(mockSdkCapability, "core:plugin");
+    framework.registerCapability(mockSdkCapability, createNamespacedId(CORE_NS, "plugin"));
     expect(mockCapabilityManager.register).toHaveBeenCalledWith(
       mockSdkCapability,
-      "core:plugin",
+      createNamespacedId(CORE_NS, "plugin"),
     );
   });
 });

--- a/libs/portal-framework-core/src/api/framework.ts
+++ b/libs/portal-framework-core/src/api/framework.ts
@@ -134,7 +134,7 @@ export class Framework {
     return this.#plugins.getPlugins();
   }
 
-  getPrimaryCapability(associatedCapabilityId: string): null | string {
+  getPrimaryCapability(associatedCapabilityId: NamespacedId): null | NamespacedId {
     // Iterate through all plugins to find capability associations
     for (const plugin of this.getPlugins()) {
       if (plugin.capabilityAssociations) {
@@ -239,7 +239,7 @@ export class Framework {
             ),
             id: plugin.id,
           });
-          return;
+          continue;
         }
 
         // Register capabilities from the plugin with plugin ID

--- a/libs/portal-framework-core/src/capabilities/manager.spec.ts
+++ b/libs/portal-framework-core/src/capabilities/manager.spec.ts
@@ -2,6 +2,7 @@ import { createMockPluginManager } from "@lumeweb/portal-test-util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Framework } from "../api/framework";
+import type { NamespacedId } from "../types/namespace";
 import type { BaseCapability } from "../types/capabilities";
 
 import { CapabilityManager } from "./manager";
@@ -11,6 +12,7 @@ describe("CapabilityManager", () => {
   let mockFramework: Framework;
   // @ts-ignore
   let mockPluginManager: ReturnType<typeof createMockPluginManager>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -20,6 +22,7 @@ describe("CapabilityManager", () => {
     manager = new CapabilityManager();
     mockFramework = createMockFramework();
     manager.framework = mockFramework;
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -27,9 +30,9 @@ describe("CapabilityManager", () => {
   });
 
   const createMockCapability = (
-    id: string,
+    id: NamespacedId,
     type: string,
-    deps?: string[],
+    deps?: NamespacedId[],
   ): BaseCapability => ({
     dependencies: deps,
     destroy: vi.fn().mockResolvedValue(undefined),
@@ -78,8 +81,8 @@ describe("CapabilityManager", () => {
   };
 
   it("should register and retrieve capabilities", async () => {
-    const cap1 = createMockCapability("cap1", "typeA");
-    const cap2 = createMockCapability("cap2", "typeB", ["cap1"]);
+    const cap1 = createMockCapability("cap1" as NamespacedId, "typeA");
+    const cap2 = createMockCapability("cap2" as NamespacedId, "typeB", ["cap1" as NamespacedId]);
 
     manager.register(cap1, "plugin1");
     manager.register(cap2, "plugin2");
@@ -87,15 +90,15 @@ describe("CapabilityManager", () => {
     // Initialize capabilities after registration
     await manager.initializeAll();
 
-    expect(await manager.get("cap1")).toBe(cap1);
+    expect(await manager.get("cap1" as NamespacedId)).toBe(cap1);
     expect(await manager.getAllOfType("typeB")).toEqual([
-      expect.objectContaining({ id: "cap2" }),
+      expect.objectContaining({ id: "cap2" as NamespacedId }),
     ]);
   });
 
   it("should warn when registering a capability that is already registered", () => {
-    const cap1 = createMockCapability("cap1", "typeA");
-    const cap1_duplicate = createMockCapability("cap1", "typeA"); // Same ID
+    const cap1 = createMockCapability("cap1" as NamespacedId, "typeA");
+    const cap1_duplicate = createMockCapability("cap1" as NamespacedId, "typeA"); // Same ID
 
     manager.register(cap1, "plugin1");
     manager.register(cap1_duplicate, "plugin2"); // Attempt to re-register
@@ -103,14 +106,13 @@ describe("CapabilityManager", () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       "Capability cap1 already registered by plugin plugin1. Plugin plugin2 attempted to re-register it.",
     );
-    // Ensure the original capability is still the one registered
-    expect(manager["#capabilities"].get("cap1")).toBe(cap1);
-    expect(manager["#capabilityToPlugin"].get("cap1")).toBe("plugin1");
+    // Ensure the original capability is still the one registered — use manager.get() instead of private field access
+    expect(manager.get("cap1" as NamespacedId)).resolves.toBe(cap1);
   });
 
   it("should initialize in dependency order", async () => {
-    const cap1 = createMockCapability("cap1", "typeA");
-    const cap2 = createMockCapability("cap2", "typeB", ["cap1"]);
+    const cap1 = createMockCapability("cap1" as NamespacedId, "typeA");
+    const cap2 = createMockCapability("cap2" as NamespacedId, "typeB", ["cap1" as NamespacedId]);
 
     manager.register(cap1, "plugin1");
     manager.register(cap2, "plugin2");
@@ -126,8 +128,8 @@ describe("CapabilityManager", () => {
 
   it("should handle initialization errors", async () => {
     const error = new Error("Init failed");
-    const cap1 = createMockCapability("cap1", "typeA");
-    const cap2 = createMockCapability("cap2", "typeB", ["cap1"]);
+    const cap1 = createMockCapability("cap1" as NamespacedId, "typeA");
+    const cap2 = createMockCapability("cap2" as NamespacedId, "typeB", ["cap1" as NamespacedId]);
     vi.mocked(cap2.initialize).mockRejectedValue(error);
 
     // Mock console.error to suppress expected error output
@@ -139,10 +141,10 @@ describe("CapabilityManager", () => {
       manager.register(cap2, "plugin2");
 
       const failures = await manager.initializeAll();
-      expect(failures.get("cap2")).toBe(error);
+      expect(failures.get("cap2" as NamespacedId)).toBe(error);
       // Explicitly try to get the failed capability to consume the rejected promise
       // and assert that it rejects as expected.
-      await expect(manager.get("cap2")).rejects.toThrow("Init failed");
+      await expect(manager.get("cap2" as NamespacedId)).rejects.toThrow("Init failed");
     } finally {
       // Restore console.error
       console.error = originalError;
@@ -150,8 +152,8 @@ describe("CapabilityManager", () => {
   });
 
   it("should destroy in reverse order", async () => {
-    const cap1 = createMockCapability("cap1", "typeA");
-    const cap2 = createMockCapability("cap2", "typeB", ["cap1"]);
+    const cap1 = createMockCapability("cap1" as NamespacedId, "typeA");
+    const cap2 = createMockCapability("cap2" as NamespacedId, "typeB", ["cap1" as NamespacedId]);
 
     manager.register(cap1, "plugin1");
     manager.register(cap2, "plugin2");
@@ -175,9 +177,9 @@ describe("CapabilityManager", () => {
     });
 
     const caps = [
-      createMockCapability("cap1", "typeA"),
-      createMockCapability("cap2", "typeA"),
-      createMockCapability("cap3", "typeB"),
+      createMockCapability("cap1" as NamespacedId, "typeA"),
+      createMockCapability("cap2" as NamespacedId, "typeA"),
+      createMockCapability("cap3" as NamespacedId, "typeB"),
     ];
 
     manager.register(caps[0], "plugin1");
@@ -188,13 +190,13 @@ describe("CapabilityManager", () => {
     await manager.initializeAll();
 
     const results = await manager.getAllOfType("typeA");
-    expect(results.map((c) => c.id)).toEqual(["cap2", "cap1"]);
+    expect(results.map((c) => c.id)).toEqual(["cap2" as NamespacedId, "cap1" as NamespacedId]);
   });
 
   it("should handle capability dependencies across plugins", async () => {
-    const cap1 = createMockCapability("cap1", "typeA");
-    const cap2 = createMockCapability("cap2", "typeB", ["cap1"]);
-    const cap3 = createMockCapability("cap3", "typeC", ["cap2"]);
+    const cap1 = createMockCapability("cap1" as NamespacedId, "typeA");
+    const cap2 = createMockCapability("cap2" as NamespacedId, "typeB", ["cap1" as NamespacedId]);
+    const cap3 = createMockCapability("cap3" as NamespacedId, "typeC", ["cap2" as NamespacedId]);
 
     manager.register(cap1, "plugin1");
     manager.register(cap2, "plugin2");
@@ -204,7 +206,7 @@ describe("CapabilityManager", () => {
     await manager.initializeAll();
 
     const sorted = await manager.getAllOfType("typeC");
-    expect(sorted[0].id).toBe("cap3");
-    expect(sorted[0].dependencies).toEqual(["cap2"]);
+    expect(sorted[0].id).toBe("cap3" as NamespacedId);
+    expect(sorted[0].dependencies).toEqual(["cap2" as NamespacedId]);
   });
 });

--- a/libs/portal-framework-core/src/errors.spec.ts
+++ b/libs/portal-framework-core/src/errors.spec.ts
@@ -46,7 +46,7 @@ describe("Custom Errors", () => {
   });
 
   it("should handle errors without cause", () => {
-    const error = new PluginLoadError("core:plugin", undefined as any);
+    const error = new PluginLoadError("core:plugin" as NamespacedId, undefined as any);
     expect(error.cause).toBeUndefined();
   });
 });

--- a/libs/portal-framework-core/src/index.ts
+++ b/libs/portal-framework-core/src/index.ts
@@ -30,6 +30,7 @@ export { useBrand } from "./hooks/useBrand";
 
 // Plugin Management
 export { PluginManager } from "./plugins/manager";
+export { NamespaceRegistry } from "./plugins/namespaceRegistry";
 export {
   createRemoteComponentLoader,
   defaultRemoteOptions,

--- a/libs/portal-framework-core/src/plugins/manager.spec.ts
+++ b/libs/portal-framework-core/src/plugins/manager.spec.ts
@@ -7,7 +7,7 @@ import { Framework } from "../api/framework";
 import { FeatureLoadError } from "../errors";
 import { BaseCapability } from "../types/capabilities";
 import { NamespacedId } from "../types/plugin";
-import { validateNamespacedId } from "../util/namespace";
+import { createNamespacedId, validateNamespacedId } from "../util/namespace";
 import { PluginManager } from "./manager";
 
 // Mock dependencies
@@ -19,13 +19,13 @@ const mockFramework = {} as Framework;
 
 describe("PluginManager", () => {
   let manager: PluginManager;
-  const mockPluginFactory = vi.fn(() => createMockPlugin("test:factory"));
+  const mockPluginFactory = vi.fn(() => createMockPlugin("test:factory" as NamespacedId));
   const mockCapability: BaseCapability = {
     destroy: vi.fn().mockResolvedValue(undefined),
-    id: "test:capability",
+    id: "test:capability" as NamespacedId,
     initialize: vi.fn().mockResolvedValue(undefined),
     status: "inactive",
-    type: "test",
+    type: "framework:test" as any,
   };
 
   beforeEach(() => {
@@ -50,8 +50,9 @@ describe("PluginManager", () => {
     features: [
       {
         destroy: vi.fn().mockResolvedValue(undefined),
-        id: "test:feature" as NamespacedId,
+        id: createNamespacedId("test", "feature"),
         initialize: vi.fn().mockResolvedValue(undefined),
+        status: "enabled" as const,
       },
     ],
     id: id,
@@ -65,24 +66,24 @@ describe("PluginManager", () => {
 
   // -- Core Functionality Tests --
   it("should register and activate plugins", () => {
-    const plugin = createMockPlugin("test:plugin");
+    const plugin = createMockPlugin("test:plugin" as NamespacedId);
     manager.register(plugin);
 
-    const loadedPlugin = manager.getPlugin("test:plugin");
+    const loadedPlugin = manager.getPlugin("test:plugin" as NamespacedId);
     expect(loadedPlugin).toBeDefined();
     expect(loadedPlugin?.id).toEqual(plugin.id);
-    expect(manager.isPluginEnabled("test:plugin")).toBe(true);
+    expect(manager.isPluginEnabled("test:plugin" as NamespacedId)).toBe(true);
   });
 
   it("should register plugin factories", () => {
-    const factory = () => createMockPlugin("test:factory");
-    manager.registerFactory("test:factory", factory);
+    const factory = () => createMockPlugin("test:factory" as NamespacedId);
+    manager.registerFactory("test:factory" as NamespacedId, factory);
 
     // Need to enable the plugin first
-    manager.enablePlugin("test:factory");
-    const plugin = manager.getOrActivatePlugin("test:factory");
+    manager.enablePlugin("test:factory" as NamespacedId);
+    const plugin = manager.getOrActivatePlugin("test:factory" as NamespacedId);
     expect(plugin).toBeDefined();
-    expect(plugin?.id).toBe("test:factory");
+    expect(plugin?.id).toBe("test:factory" as NamespacedId);
   });
 
   it("should handle failed plugin activation", () => {
@@ -90,10 +91,10 @@ describe("PluginManager", () => {
     const failingFactory = () => {
       throw error;
     };
-    manager.registerFactory("test:failed", failingFactory);
-    manager.enablePlugin("test:failed");
+    manager.registerFactory("test:failed" as NamespacedId, failingFactory);
+    manager.enablePlugin("test:failed" as NamespacedId);
 
-    expect(manager.getOrActivatePlugin("test:failed")).toBeUndefined();
+    expect(manager.getOrActivatePlugin("test:failed" as NamespacedId)).toBeUndefined();
 
     const failedPlugins = manager.getFailedPlugins();
     expect(failedPlugins).toContainEqual(
@@ -106,21 +107,23 @@ describe("PluginManager", () => {
 
   // -- Dependency Handling Tests --
   it("should enforce plugin dependencies", async () => {
-    const depPlugin = createMockPlugin("test:dep");
-    const mainPlugin = createMockPlugin("test:main", [{ id: "test:dep" }]);
+    const depPlugin = createMockPlugin("test:dep" as NamespacedId);
+    const mainPlugin = createMockPlugin("other:main" as NamespacedId, [{ id: "test:dep" as NamespacedId }]);
 
     manager.register(depPlugin);
     manager.register(mainPlugin);
 
-    manager.enablePlugin("test:dep");
-    manager.enablePlugin("test:main");
+    manager.enablePlugin("test:dep" as NamespacedId);
+    manager.enablePlugin("other:main" as NamespacedId);
     const failures = await manager.initializePlugins();
-    expect(manager.isPluginReady("test:main")).toBe(true);
-    expect(failures.has("test:main")).toBe(false);
+    expect(manager.isPluginReady("other:main" as NamespacedId)).toBe(true);
+    expect(failures.has("other:main")).toBe(false);
+    expect(manager.getRegistry().has("test")).toBe(true);
+    expect(manager.getRegistry().has("other")).toBe(true);
   });
 
   it("should detect missing dependencies", async () => {
-    const mainPlugin = createMockPlugin("test:main", [{ id: "test:missing" }]);
+    const mainPlugin = createMockPlugin("test:main" as NamespacedId, [{ id: "test:missing" as NamespacedId }]);
 
     expect(() => manager.register(mainPlugin)).toThrowError(
       "Plugin test:main: Missing required plugin dependency: test:missing",
@@ -128,8 +131,8 @@ describe("PluginManager", () => {
   });
 
   it("should detect plugin already registered", () => {
-    const plugin1 = createMockPlugin("test:plugin");
-    const plugin2 = createMockPlugin("test:plugin"); // Same ID
+    const plugin1 = createMockPlugin("test:plugin" as NamespacedId);
+    const plugin2 = createMockPlugin("test:plugin" as NamespacedId); // Same ID
 
     manager.register(plugin1);
 
@@ -140,7 +143,7 @@ describe("PluginManager", () => {
 
   it("should detect missing feature dependencies", () => {
     const pluginWithFeatureDep = createMockPlugin(
-      "test:plugin-with-feature-dep",
+      "test:plugin-with-feature-dep" as NamespacedId,
     );
     pluginWithFeatureDep.features = [
       {
@@ -148,6 +151,7 @@ describe("PluginManager", () => {
         destroy: vi.fn(),
         id: "test:my-feature" as NamespacedId,
         initialize: vi.fn(),
+        status: "enabled" as const,
       },
     ];
 
@@ -158,13 +162,13 @@ describe("PluginManager", () => {
 
   // -- Feature Loading Tests --
   it("should load and track feature states", async () => {
-    const plugin = createMockPlugin("test:plugin");
+    const plugin = createMockPlugin("test:plugin" as NamespacedId);
     manager.register(plugin);
     manager.enablePlugin(plugin.id);
     manager.getOrActivatePlugin(plugin.id); // Explicitly activate the plugin first
 
     // Use the ID from the mock feature
-    const featureId = "test:feature";
+    const featureId = "test:feature" as NamespacedId;
     validateNamespacedId(featureId); // Ensure the ID is valid
 
     await expect(manager.loadFeature(featureId)).resolves.toBeDefined();
@@ -174,7 +178,7 @@ describe("PluginManager", () => {
   });
 
   it("should handle feature loading errors", async () => {
-    const plugin = createMockPlugin("test:bad-feature");
+    const plugin = createMockPlugin("test:bad-feature" as NamespacedId);
     const featureId = "test:feature" as NamespacedId;
     plugin.features![0].id = featureId;
 
@@ -219,27 +223,27 @@ describe("PluginManager", () => {
 
   // -- Remote Module Tests --
   it("should register remote modules", async () => {
-    const plugin = createMockPlugin("test:remote");
+    const plugin = createMockPlugin("test:remote" as NamespacedId);
     const mockEntry = "http://example.com/remote.js";
     const mockModule = { default: () => plugin };
 
     const loadRemoteMock = vi.mocked(loadRemote);
     loadRemoteMock.mockResolvedValue(mockModule);
 
-    manager.registerRemoteModule("test-module", mockEntry, "test:remote");
+    manager.registerRemoteModule("test-module", mockEntry, "test:remote" as NamespacedId);
 
     const module = manager.remoteModules.get("test-module");
     expect(module).toEqual({
       entry: mockEntry,
       moduleId: "test-module",
-      pluginId: "test:remote",
+      pluginId: "test:remote" as NamespacedId,
     });
   });
 
   // -- Route Validation Tests --
   describe("route validation", () => {
     it("should reject routes with non-namespaced IDs", () => {
-      const plugin = createMockPlugin("test:routes-validation");
+      const plugin = createMockPlugin("test:routes-validation" as NamespacedId);
       plugin.routes = [
         {
           component: "HomePage",
@@ -254,72 +258,75 @@ describe("PluginManager", () => {
     });
 
     it("should accept routes with valid namespaced IDs", () => {
-      const plugin = createMockPlugin("test:routes-validation");
+      const plugin = createMockPlugin("test:routes-validation" as NamespacedId);
       plugin.routes = [
         {
           component: "HomePage",
-          id: "test:home", // Valid namespaced ID
+          id: "test:home" as NamespacedId, // Valid namespaced ID
           path: "/",
         },
       ];
       expect(() => manager.register(plugin)).not.toThrow();
     });
 
-    it("should auto-generate namespaced route IDs when not provided", () => {
-      const plugin = createMockPlugin("test:routes-validation");
+    it("should reject routes without an ID", () => {
+      const plugin = createMockPlugin("test:routes-validation" as NamespacedId);
       plugin.routes = [
         {
           component: "HomePage",
           path: "/",
         },
-      ];
-      expect(() => manager.register(plugin)).not.toThrow();
-      expect(plugin.routes[0].id).toBe("test:routes-validation:/");
+      ] as any;
+      expect(() => manager.register(plugin)).toThrowError(
+        "missing a route ID",
+      );
     });
   });
 
   // -- Lifecycle Tests --
   it("should handle plugin destruction", async () => {
-    const plugin = createMockPlugin("test:destruction");
+    const plugin = createMockPlugin("test:destruction" as NamespacedId);
     manager.register(plugin);
     await manager.initializePlugins();
 
-    await manager.destroyPlugin("test:destruction");
+    await manager.destroyPlugin("test:destruction" as NamespacedId);
     expect(plugin.destroy).toHaveBeenCalled();
-    expect(manager.getPlugin("test:destruction")).toBeUndefined();
+    expect(manager.getPlugin("test:destruction" as NamespacedId)).toBeUndefined();
   });
 
   // -- Error Handling Tests --
   it("should track failed plugins", async () => {
-    const plugin = createMockPlugin("test:failed-init");
+    const plugin = createMockPlugin("test:failed-init" as NamespacedId);
     plugin.initialize.mockRejectedValue(new Error("Init failed"));
     manager.register(plugin);
     manager.enablePlugin(plugin.id);
 
     const failures = await manager.initializePlugins();
     expect(failures.has("test:failed-init")).toBe(true);
-    expect(manager.getPluginState("test:failed-init")?.initState).toBe(
+    expect(manager.getPluginState("test:failed-init" as NamespacedId)?.initState).toBe(
       "failed",
     );
   });
 
   // -- Capability Tests --
   it("should expose plugin capabilities", () => {
-    const plugin = createMockPlugin("test:caps");
+    const plugin = createMockPlugin("test:caps" as NamespacedId);
     manager.register(plugin);
 
-    expect(manager.hasCapability("test")).toBe(true);
+    expect(manager.hasCapability("framework:test")).toBe(true);
     expect(manager.hasCapability("missing")).toBe(false);
   });
 
   // -- Initialization Order Tests --
   it("should sort plugins topologically", () => {
-    const a = createMockPlugin("test:a");
-    const b = createMockPlugin("test:b", [{ id: "test:a" }]);
+    const a = createMockPlugin("alpha:a" as NamespacedId);
+    const b = createMockPlugin("beta:b" as NamespacedId, [{ id: "alpha:a" as NamespacedId }]);
     manager.register(a);
     manager.register(b);
 
     const order = manager.getInitializationOrder();
-    expect(order).toEqual(["test:a", "test:b"]); // a should come first since b depends on it
+    expect(order).toEqual(["alpha:a", "beta:b",]); // a should come first since b depends on it
+    expect(manager.getRegistry().getPluginId("alpha")).toBe("alpha:a");
+    expect(manager.getRegistry().getPluginId("beta")).toBe("beta:b");
   });
 });

--- a/libs/portal-framework-core/src/plugins/manager.ts
+++ b/libs/portal-framework-core/src/plugins/manager.ts
@@ -1,20 +1,25 @@
 import type { RouteDefinition } from "../types/navigation";
 import type {
   FeatureState,
-  NamespacedId,
   Plugin,
   PluginState,
 } from "../types/plugin";
+import { Namespace, NamespacedId } from "../types/namespace";
 
 import { Framework } from "../api/framework";
 import { FeatureLoadError, PluginInitError, PluginLoadError } from "../errors";
 import { FrameworkFeature } from "../types/api";
 import { DependencyGraph } from "../util/dependencyGraph";
-import { isNamespacedId, validateNamespacedId } from "../util/namespace";
+import {
+  isNamespacedId,
+  parseNamespacedId,
+  validateNamespacedId,
+} from "../util/namespace";
 import {
   validateFeatureDetailed,
   validatePluginDetailed,
 } from "../util/validation";
+import { NamespaceRegistry } from "./namespaceRegistry";
 
 export interface RemoteModule {
   entry: string;
@@ -47,6 +52,7 @@ export class PluginManager {
   readonly #pluginFactories = new Map<NamespacedId, () => Plugin>();
   readonly #pluginStates = new Map<NamespacedId, PluginState>();
   readonly #remoteModules = new Map<string, RemoteModule>();
+  readonly #registry = new NamespaceRegistry();
   private _framework: Framework | null = null;
   async destroyPlugin(id: NamespacedId) {
     const plugin = this.#loadedPlugins.get(id);
@@ -204,6 +210,10 @@ export class PluginManager {
     );
   }
 
+  getRegistry(): NamespaceRegistry {
+    return this.#registry;
+  }
+
   hasCapability(type: string): boolean {
     return Array.from(this.#loadedPlugins.values()).some((plugin) =>
       plugin.capabilities?.some((cap) => cap.type === type),
@@ -238,7 +248,6 @@ export class PluginManager {
 
       const plugin = this.#loadedPlugins.get(pluginId);
       if (!plugin?.initialize) continue;
-
       // Defensive check for plugin interface compliance
       const pluginValidationResult = validatePluginDetailed(plugin);
       if (!pluginValidationResult.isValid) {
@@ -365,12 +374,36 @@ export class PluginManager {
       throw new Error("Invalid plugin configuration");
     }
 
-    // Validate routes if present
-    if (plugin.routes) {
-      this.ensureValidRoutes(plugin);
-    }
+      // Validate routes if present
+      if (plugin.routes) {
+        plugin.routes = plugin.routes.map((route) =>
+          this.#normalizeAndValidateRoute(plugin.id, route),
+        );
+      }
+
+      // Validate capabilities if present
+      plugin.capabilities?.forEach((capability) => {
+        validateNamespacedId(capability.id);
+        validateNamespacedId(capability.type);
+      });
+
+      // Validate widget areas and widgets if present
+      plugin.widgets?.areas?.forEach((area) => {
+        validateNamespacedId(area.id);
+      });
+      plugin.widgets?.widgets?.forEach((widget) => {
+        validateNamespacedId(widget.id);
+        validateNamespacedId(widget.areaId);
+      });
 
     const pluginId = plugin.id;
+
+    // Claim the plugin's namespace in the registry
+    const namespace = parseNamespacedId(pluginId).namespace;
+    this.#registry.claim(namespace, pluginId);
+
+    // Claim additional namespaces if provided
+    plugin.namespaces?.forEach((ns) => this.#registry.claim(ns, pluginId));
 
     // Check if already registered as either factory or loaded plugin
     if (
@@ -469,6 +502,9 @@ export class PluginManager {
 
     this.#loadedPlugins.delete(id);
     this.#pluginStates.delete(id);
+
+    // Release any namespaces claimed by this plugin
+    this.#registry.release(id);
   }
 
   async #destroyFeature(id: NamespacedId) {
@@ -558,39 +594,49 @@ export class PluginManager {
     });
   }
 
-  private ensureValidRoutes(plugin: Plugin) {
-    if (!plugin.routes) return;
+  #normalizeAndValidateRoute(
+    pluginId: NamespacedId,
+    route: RouteDefinition,
+  ): RouteDefinition {
+    if (!route.component) {
+      throw new Error(
+        `Route in plugin ${pluginId} must specify a component export name`,
+      );
+    }
 
-    const validateRoute = (route: RouteDefinition) => {
-      if (!route.component) {
+    if (typeof route.component !== "string") {
+      throw new Error(
+        `Route component in plugin ${pluginId} must be a string (export name)`,
+      );
+    }
+
+    // Route IDs must be valid NamespacedId at definition time. If a route ID
+    // lacks a namespace, throw with a clear error pointing at the plugin.
+    if (route.id) {
+      if (typeof route.id !== "string" || !isNamespacedId(route.id)) {
         throw new Error(
-          `Route in plugin ${plugin.id} must specify a component export name`,
+          `Route ID "${route.id}" in plugin ${pluginId} must be a namespaced ID (format: "namespace:name")`,
         );
       }
+    } else {
+      throw new Error(
+        `Route in plugin ${pluginId} is missing a route ID. Route IDs must be valid namespaced IDs.`,
+      );
+    }
 
-      if (typeof route.component !== "string") {
-        throw new Error(
-          `Route component in plugin ${plugin.id} must be a string (export name)`,
-        );
-      }
+    // After the runtime check above, TypeScript still sees route.id as
+    // string | undefined. We narrow it once so subsequent code can rely on the
+    // NamespacedId type.
+    const routeId = route.id as NamespacedId;
+    route.id = routeId;
 
-      if (route.id && typeof route.id === "string") {
-        if (!isNamespacedId(route.id)) {
-          throw new Error(
-            `Route ID "${route.id}" in plugin ${plugin.id} must be a namespaced ID (format: "namespace:name")`,
-          );
-        }
-      } else {
-        // Auto-generate ID if not provided
-        route.id = `${plugin.id}:${route.path || "index"}`;
-      }
+    if (route.children) {
+      route.children = route.children.map((child) =>
+        this.#normalizeAndValidateRoute(pluginId, child),
+      );
+    }
 
-      if (route.children) {
-        route.children.forEach(validateRoute);
-      }
-    };
-
-    plugin.routes.forEach(validateRoute);
+    return route;
   }
 
   private findPluginForFeature(id: NamespacedId): Plugin | undefined {

--- a/libs/portal-framework-core/src/plugins/namespaceRegistry.spec.ts
+++ b/libs/portal-framework-core/src/plugins/namespaceRegistry.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { NamespaceRegistry } from "./namespaceRegistry";
+
+describe("NamespaceRegistry", () => {
+  let registry: NamespaceRegistry;
+
+  beforeEach(() => {
+    registry = new NamespaceRegistry();
+  });
+
+  describe("claim", () => {
+    it("allows a plugin to claim an unreserved namespace", () => {
+      registry.claim("acme", "acme:plugin" as any);
+      expect(registry.has("acme")).toBe(true);
+      expect(registry.getPluginId("acme")).toBe("acme:plugin");
+    });
+
+    it("rejects reserved namespaces for non-core plugins", () => {
+      expect(() => registry.claim("core", "acme:plugin" as any)).toThrow(
+        'Namespace "core" is reserved by the framework',
+      );
+      expect(() => registry.claim("framework", "acme:plugin" as any)).toThrow(
+        'Namespace "framework" is reserved by the framework',
+      );
+    });
+
+    it("allows core plugins to claim reserved namespaces", () => {
+      expect(() => registry.claim("core", "core:dashboard" as any)).not.toThrow();
+      expect(registry.has("core")).toBe(true);
+    });
+
+    it("is idempotent when the same plugin reclaims a namespace", () => {
+      registry.claim("acme", "acme:plugin" as any);
+      expect(() => registry.claim("acme", "acme:plugin" as any)).not.toThrow();
+      expect(registry.getPluginId("acme")).toBe("acme:plugin");
+    });
+
+    it("throws when a different plugin claims an already claimed namespace", () => {
+      registry.claim("acme", "acme:plugin" as any);
+      expect(() => registry.claim("acme", "other:plugin" as any)).toThrow(
+        'Namespace "acme" is already claimed by "acme:plugin"',
+      );
+    });
+  });
+
+  describe("release", () => {
+    it("removes all namespaces claimed by a plugin", () => {
+      registry.claim("acme", "acme:plugin" as any);
+      registry.release("acme:plugin" as any);
+      expect(registry.has("acme")).toBe(false);
+      expect(registry.getPluginId("acme")).toBeUndefined();
+    });
+  });
+
+  describe("has", () => {
+    it("returns true for reserved namespaces", () => {
+      expect(registry.has("core")).toBe(true);
+      expect(registry.has("framework")).toBe(true);
+    });
+
+    it("returns true for claimed namespaces and false otherwise", () => {
+      registry.claim("acme", "acme:plugin" as any);
+      expect(registry.has("acme")).toBe(true);
+      expect(registry.has("unclaimed")).toBe(false);
+    });
+  });
+
+  describe("resolve", () => {
+    it("returns namespace, name, and owning pluginId", () => {
+      registry.claim("acme", "acme:plugin" as any);
+      expect(registry.resolve("acme:widget" as any)).toEqual({
+        name: "widget",
+        namespace: "acme",
+        pluginId: "acme:plugin",
+      });
+    });
+
+    it("returns undefined pluginId for unclaimed namespaces", () => {
+      expect(registry.resolve("orphan:thing" as any)).toEqual({
+        name: "thing",
+        namespace: "orphan",
+        pluginId: undefined,
+      });
+    });
+  });
+});

--- a/libs/portal-framework-core/src/plugins/namespaceRegistry.ts
+++ b/libs/portal-framework-core/src/plugins/namespaceRegistry.ts
@@ -1,0 +1,47 @@
+import type { NamespacedId } from "../types/plugin";
+import { parseNamespacedId } from "../util/namespace";
+
+const RESERVED_NAMESPACES = new Set(["core", "framework"]);
+
+export class NamespaceRegistry {
+  readonly #namespaces = new Map<string, NamespacedId>();
+
+  claim(namespace: string, pluginId: NamespacedId): void {
+    if (RESERVED_NAMESPACES.has(namespace) && !pluginId.startsWith("core:")) {
+      throw new Error(`Namespace "${namespace}" is reserved by the framework`);
+    }
+    const existing = this.#namespaces.get(namespace);
+    if (existing && existing !== pluginId) {
+      throw new Error(
+        `Namespace "${namespace}" is already claimed by "${existing}"`,
+      );
+    }
+    this.#namespaces.set(namespace, pluginId);
+  }
+
+  release(pluginId: NamespacedId): void {
+    for (const [ns, id] of this.#namespaces) {
+      if (id === pluginId) {
+        this.#namespaces.delete(ns);
+      }
+    }
+  }
+
+  has(namespace: string): boolean {
+    return RESERVED_NAMESPACES.has(namespace) || this.#namespaces.has(namespace);
+  }
+
+  getPluginId(namespace: string): NamespacedId | undefined {
+    return this.#namespaces.get(namespace);
+  }
+
+  resolve(id: NamespacedId): {
+    name: string;
+    namespace: string;
+    pluginId?: NamespacedId;
+  } {
+    const parsed = parseNamespacedId(id);
+    const pluginId = this.#namespaces.get(parsed.namespace);
+    return { ...parsed, pluginId };
+  }
+}

--- a/libs/portal-framework-core/src/types/capabilities.ts
+++ b/libs/portal-framework-core/src/types/capabilities.ts
@@ -2,15 +2,16 @@ import { Sdk } from "@lumeweb/portal-sdk";
 import { RefineProps } from "@refinedev/core";
 
 import { Framework } from "../api/framework";
+import { NamespacedId } from "./namespace";
 
 export interface BaseCapability<
   TType extends string = string,
-  TID extends string = string,
+  TID extends NamespacedId = NamespacedId,
 > {
   /**
    * Array of capability IDs that must be initialized before this one
    */
-  dependencies?: string[];
+  dependencies?: NamespacedId[];
   destroy(framework: Framework): Promise<void>;
 
   readonly id: TID;
@@ -22,10 +23,10 @@ export interface BaseCapability<
 export type CapabilityStatus = "active" | "error" | "inactive";
 
 export interface RefineConfigCapability
-  extends BaseCapability<"core:refine-config"> {
+  extends BaseCapability<string> {
   getConfig(existing?: Partial<RefineProps>): Partial<RefineProps>;
 }
 
-export interface SdkCapability extends BaseCapability<"core:sdk"> {
+export interface SdkCapability extends BaseCapability<string> {
   getSdk(): Sdk;
 }

--- a/libs/portal-framework-core/src/types/namespace.ts
+++ b/libs/portal-framework-core/src/types/namespace.ts
@@ -1,0 +1,8 @@
+declare const __namespaceBrand: unique symbol;
+declare const __namespacedIdBrand: unique symbol;
+
+/** A validated namespace string (e.g. "core", "ipfs", "acme") */
+export type Namespace = string & { readonly [__namespaceBrand]: true };
+
+/** A validated namespaced ID (e.g. "core:dashboard") */
+export type NamespacedId = string & { readonly [__namespacedIdBrand]: true };

--- a/libs/portal-framework-core/src/types/navigation.ts
+++ b/libs/portal-framework-core/src/types/navigation.ts
@@ -2,7 +2,7 @@ import type React from "react";
 
 import { RouteObject } from "react-router";
 
-import { NamespacedId } from "./plugin";
+import { NamespacedId } from "./namespace";
 
 export interface NavigationBadge {
   content: string;
@@ -37,7 +37,7 @@ export interface NavigationItem {
   /**
    * Unique identifier for the navigation item
    */
-  id?: string;
+  id?: NamespacedId;
   /**
    * If true, this route is an index route
    */
@@ -85,9 +85,9 @@ export interface RouteDefinition extends Omit<RouteObject, "children"> {
   /**
    * Optional unique identifier for the route.
    * If not provided, path will be used to generate an ID.
-   * Will be namespaced with plugin ID if not already namespaced.
+   * Must be a valid NamespacedId — bare strings are no longer accepted.
    */
-  id?: string;
+  id?: NamespacedId;
   index?: boolean;
   /**
    * If true, the component will be loaded lazily.

--- a/libs/portal-framework-core/src/types/plugin.ts
+++ b/libs/portal-framework-core/src/types/plugin.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 
 import { FrameworkFeature } from "../types/api";
+import { Namespace, NamespacedId } from "../types/namespace";
 import { BaseCapability } from "./capabilities";
 import { RouteDefinition } from "./navigation";
 import type { QueryParamPersistConfig } from "../util/queryParamPersist";
@@ -13,8 +14,7 @@ export interface FeatureState {
 
 export type FeatureStateStatus = "failed" | "loaded" | "loading";
 
-// Type safety for namespaced IDs
-export type NamespacedId = `${string}:${string}`;
+export type { Namespace, NamespacedId };
 
 export interface Plugin {
   // Capabilities also map to exposed modules
@@ -26,6 +26,8 @@ export interface Plugin {
   features?: FrameworkFeature[];
   id: NamespacedId;
   initialize(framework: Framework): Promise<void>;
+  /** Additional namespaces this plugin claims (beyond the one in its ID) */
+  namespaces?: Namespace[];
   queryParamConfig?: QueryParamPersistConfig[];
   // Routes map to exposed components
   routes?: RouteDefinition[];
@@ -60,9 +62,9 @@ export interface CapabilityAssociation {
   /**
    * The primary capability that others are associated with
    */
-  primary: string;
+  primary: NamespacedId;
   /**
    * The associated capabilities
    */
-  associated: string[];
+  associated: NamespacedId[];
 }

--- a/libs/portal-framework-core/src/types/widget.ts
+++ b/libs/portal-framework-core/src/types/widget.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { NamespacedId } from "./plugin";
+import { NamespacedId } from "./namespace";
 
 export interface WidgetAreaDefinition {
   grid?: {
@@ -16,7 +16,7 @@ export interface WidgetAreaDefinition {
      */
     rowHeight?: "auto" | number;
   };
-  id: string;
+  id: NamespacedId;
 }
 
 export const DEFAULT_WIDGET_AREA_DEFINITION: Required<
@@ -37,9 +37,9 @@ export interface WidgetDefinition
 }
 
 export interface WidgetRegistration {
-  areaId: string;
+  areaId: NamespacedId;
   componentName: string;
-  id: string;
+  id: NamespacedId;
   minHeight?: number;
   minWidth?: number;
   order?: number;

--- a/libs/portal-framework-core/src/util/namespace.spec.ts
+++ b/libs/portal-framework-core/src/util/namespace.spec.ts
@@ -2,42 +2,128 @@ import { describe, expect, it } from "vitest";
 
 import {
   createNamespacedId,
+  createNamespace,
   isNamespacedId,
   normalizeId,
   parseNamespacedId,
   validateNamespacedId,
+  type Namespace,
+  type NamespacedId,
 } from "./namespace";
 
+// Produce branded types in tests by going through the validation functions
+const core = "core";
+const ipfs = "ipfs";
+const framework = "framework";
+
 describe("namespace utils", () => {
+  describe("createNamespace", () => {
+    it("should create a valid namespace", () => {
+      expect(createNamespace("core")).toBe("core");
+      expect(createNamespace("ipfs")).toBe("ipfs");
+    });
+
+    it("should throw on invalid namespace", () => {
+      expect(() => createNamespace("Core")).toThrow(); // uppercase
+      expect(() => createNamespace("")).toThrow(); // empty
+      expect(() => createNamespace("has:colon")).toThrow();
+      expect(() => createNamespace("has space")).toThrow();
+    });
+  });
+
   describe("createNamespacedId", () => {
     it("should create valid namespaced ID", () => {
-      expect(createNamespacedId("core", "plugin")).toBe("core:plugin");
+      expect(createNamespacedId(core, "plugin")).toBe("core:plugin");
+      expect(createNamespacedId(ipfs, "file-manager")).toBe("ipfs:file-manager");
+    });
+
+    it("should throw on invalid namespace", () => {
+      expect(() => createNamespacedId("core", "Plugin")).toThrow();
+      expect(() => createNamespacedId("core", "")).toThrow();
+      expect(() => createNamespacedId("core", "has:colon")).toThrow();
     });
   });
 
   describe("isNamespacedId", () => {
     it("should validate namespaced IDs", () => {
       expect(isNamespacedId("core:plugin")).toBe(true);
+      expect(isNamespacedId("ipfs:file-manager")).toBe(true);
+    });
+
+    it("should reject bare strings", () => {
       expect(isNamespacedId("invalid")).toBe(false);
+      expect(isNamespacedId("")).toBe(false);
+    });
+
+    it("should reject multi-colon strings", () => {
       expect(isNamespacedId("too:many:colons")).toBe(false);
+      expect(isNamespacedId("a:b:c")).toBe(false);
+    });
+
+    it("should reject empty segments", () => {
+      expect(isNamespacedId(":plugin")).toBe(false);
+      expect(isNamespacedId("core:")).toBe(false);
+      expect(isNamespacedId("core::plugin")).toBe(false);
+    });
+
+    it("should reject uppercase", () => {
+      expect(isNamespacedId("Core:plugin")).toBe(false);
+      expect(isNamespacedId("core:Plugin")).toBe(false);
+    });
+
+    it("should narrow to NamespacedId", () => {
+      const id = "core:plugin";
+      if (isNamespacedId(id)) {
+        const _typed: NamespacedId = id;
+        expect(_typed).toBe("core:plugin");
+      }
     });
   });
 
   describe("normalizeId", () => {
-    it("should namespaced unqualified IDs", () => {
-      expect(normalizeId("core:base", "plugin")).toBe("core:plugin");
+    const base: NamespacedId = createNamespacedId(core, "base");
+    const ipfsBase: NamespacedId = createNamespacedId(ipfs, "base");
+
+    it("should namespace bare IDs", () => {
+      expect(normalizeId(base, "plugin")).toBe("core:plugin");
+      expect(normalizeId(ipfsBase, "file-manager")).toBe("ipfs:file-manager");
     });
 
-    it("should preserve existing namespaced IDs", () => {
-      expect(normalizeId("core:base", "other:plugin")).toBe("other:plugin");
+    it("should preserve valid namespaced IDs", () => {
+      expect(normalizeId(base, "other:plugin")).toBe("other:plugin");
+      expect(normalizeId(base, "ipfs:file-manager")).toBe("ipfs:file-manager");
+    });
+
+    it("should throw on invalid multi-colon strings", () => {
+      expect(() => normalizeId(base, "a:b:c")).toThrow();
+      expect(() => normalizeId(base, "too:many:colons")).toThrow();
+    });
+
+    it("should throw on empty segments", () => {
+      expect(() => normalizeId(base, ":plugin")).toThrow();
+      expect(() => normalizeId(base, "core:")).toThrow();
+      expect(() => normalizeId(base, "")).toThrow();
+    });
+
+    it("should throw on uppercase segments with colon", () => {
+      expect(() => normalizeId(base, "Core:plugin")).toThrow();
     });
   });
 
   describe("parseNamespacedId", () => {
     it("should split valid IDs", () => {
-      expect(parseNamespacedId("core:plugin")).toEqual({
+      const id = createNamespacedId(core, "plugin");
+      expect(parseNamespacedId(id)).toEqual({
         name: "plugin",
         namespace: "core",
+      });
+    });
+
+    it("should handle names with hyphens", () => {
+      const id = createNamespacedId(framework, "refine-config");
+      expect(parseNamespacedId(id)).toEqual({
+        name: "refine-config",
+        namespace: "framework",
       });
     });
   });
@@ -45,7 +131,27 @@ describe("namespace utils", () => {
   describe("validateNamespacedId", () => {
     it("should throw on invalid format", () => {
       expect(() => validateNamespacedId("invalid")).toThrow();
+      expect(() => validateNamespacedId("")).toThrow();
+    });
+
+    it("should throw on multi-colon", () => {
+      expect(() => validateNamespacedId("a:b:c")).toThrow();
+      expect(() => validateNamespacedId("too:many:colons")).toThrow();
+    });
+
+    it("should throw on empty segments", () => {
+      expect(() => validateNamespacedId(":plugin")).toThrow();
+      expect(() => validateNamespacedId("core:")).toThrow();
+    });
+
+    it("should throw on uppercase", () => {
+      expect(() => validateNamespacedId("Core:plugin")).toThrow();
+    });
+
+    it("should not throw on valid IDs", () => {
       expect(() => validateNamespacedId("core:plugin")).not.toThrow();
+      expect(() => validateNamespacedId("framework:refine-config")).not.toThrow();
+      expect(() => validateNamespacedId("ipfs:file-manager")).not.toThrow();
     });
   });
 });

--- a/libs/portal-framework-core/src/util/namespace.ts
+++ b/libs/portal-framework-core/src/util/namespace.ts
@@ -1,36 +1,73 @@
-import { NamespacedId } from "../types/plugin";
+import { Namespace, NamespacedId } from "../types/namespace";
+
+export type { Namespace, NamespacedId };
+
+const NAMESPACE_REGEX = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const NAME_REGEX = /^[a-z0-9][a-z0-9-]{0,127}$/;
+
+export const CORE_NS: Namespace = "core" as Namespace;
+export const FRAMEWORK_NS: Namespace = "framework" as Namespace;
 
 export function createNamespacedId(
   namespace: string,
   name: string,
 ): NamespacedId {
-  return `${namespace}:${name}`;
-}
-
-export function isNamespacedId(id: string): boolean {
-  const parts = id.split(":");
-  return parts.length === 2 && parts.every((part) => part.length > 0);
-}
-
-export function normalizeId(pluginId: NamespacedId, id: string): NamespacedId {
-  if (id.includes(":")) {
-    return id as NamespacedId;
+  if (!NAMESPACE_REGEX.test(namespace)) {
+    throw new Error(`Invalid namespace: "${namespace}"`);
   }
-  const [namespace] = pluginId.split(":");
-  return createNamespacedId(namespace, id);
+  if (!NAME_REGEX.test(name)) {
+    throw new Error(`Invalid name: "${name}"`);
+  }
+  return `${namespace}:${name}` as NamespacedId;
 }
 
-export function parseNamespacedId(id: string): {
+export function createNamespace(ns: string): Namespace {
+  if (!NAMESPACE_REGEX.test(ns)) {
+    throw new Error(`Invalid namespace: "${ns}"`);
+  }
+  return ns as Namespace;
+}
+
+export function isNamespacedId(id: string): id is NamespacedId {
+  const idx = id.indexOf(":");
+  if (idx === -1 || idx === 0 || idx === id.length - 1) return false;
+  const ns = id.slice(0, idx);
+  const name = id.slice(idx + 1);
+  // Reject nested colons: name must not contain ":"
+  if (name.includes(":")) return false;
+  return NAMESPACE_REGEX.test(ns) && NAME_REGEX.test(name);
+}
+
+export function normalizeId(
+  pluginId: NamespacedId,
+  id: string,
+): NamespacedId {
+  // If already valid, pass through
+  if (isNamespacedId(id)) {
+    return id;
+  }
+  // If it has a colon but isn't valid, throw — no silent pass-through
+  if (id.includes(":")) {
+    throw new Error(`Invalid namespaced ID: "${id}"`);
+  }
+  // Bare name — prepend plugin's namespace
+  const ns = parseNamespacedId(pluginId).namespace;
+  return createNamespacedId(ns, id);
+}
+
+export function parseNamespacedId(id: NamespacedId): {
+  namespace: Namespace;
   name: string;
-  namespace: string;
 } {
-  const [namespace, ...rest] = id.split(":");
-  const name = rest.join(":");
-  return { name, namespace };
+  const idx = id.indexOf(":");
+  return {
+    namespace: id.slice(0, idx) as Namespace,
+    name: id.slice(idx + 1),
+  };
 }
 
 export function validateNamespacedId(id: string): asserts id is NamespacedId {
-  if (!id.includes(":") || id.split(":").length !== 2) {
-    throw new Error(`Invalid namespaced identifier: ${id}`);
+  if (!isNamespacedId(id)) {
+    throw new Error(`Invalid namespaced identifier: "${id}"`);
   }
 }

--- a/libs/portal-framework-core/src/util/validation.ts
+++ b/libs/portal-framework-core/src/util/validation.ts
@@ -1,4 +1,6 @@
 import { BaseCapability } from "../types/capabilities";
+import type { FrameworkFeature } from "../types/api";
+import type { Plugin } from "../types/plugin";
 
 export interface ValidationErrorResult {
   isValid: boolean;

--- a/libs/portal-framework-ui/src/components/app/AppComponent.tsx
+++ b/libs/portal-framework-ui/src/components/app/AppComponent.tsx
@@ -184,7 +184,10 @@ function AppContent({
 
   const options = {
     ...combinedPluginConfig,
-    options: getDefaultRefineOptions(),
+    options: {
+      ...getDefaultRefineOptions(),
+      ...combinedPluginConfig.options,
+    },
     routerProvider,
   } satisfies Partial<RefineProps>;
 

--- a/libs/portal-framework-ui/src/components/app/AppComponent.tsx
+++ b/libs/portal-framework-ui/src/components/app/AppComponent.tsx
@@ -1,13 +1,16 @@
 import {
   Builder,
+  CORE_NS,
   createNamespacedId,
   createRemoteComponentLoader,
   defaultRemoteOptions,
   ErrorDisplay,
   Framework,
+  FRAMEWORK_NS,
   FrameworkProvider,
   getDefaultRefineOptions,
-  NamespacedId,
+  isNamespacedId,
+  type NamespacedId,
   NavigationFeature,
   NavigationItem,
   parseNamespacedId,
@@ -109,14 +112,14 @@ function AppContent({
 
         if (loadNavigation) {
           navigationFeature = await framework!.getFeature<NavigationFeature>(
-            createNamespacedId("core", "navigation"),
+            createNamespacedId(CORE_NS, "navigation"),
           );
         }
 
         if (loadRoutes) {
           capabilities =
             await framework!.getCapabilitiesByType<RefineConfigCapability>(
-              "core:refine-config",
+              createNamespacedId(FRAMEWORK_NS, "refine-config"),
             );
         }
 
@@ -264,7 +267,7 @@ function AppContentInner({
   ): React.ReactNode {
     const LazyComponent = getLazyComponent(
       route.component ?? "",
-      route.pluginId ?? createNamespacedId("core", "fallback"),
+      route.pluginId ?? createNamespacedId(CORE_NS, "fallback"),
       framework,
       route.id!,
     );
@@ -314,8 +317,8 @@ function AppContentInner({
 function getLazyComponent(
   componentString: string | undefined,
   pluginId: NamespacedId | undefined,
-  framework: Framework, // Pass framework instance
-  routeId: NamespacedId | string, // For logging
+  framework: Framework,
+  routeId: NamespacedId,
 ): ComponentType<unknown> | null {
   if (!componentString || !pluginId) {
     console.error(
@@ -330,8 +333,8 @@ function getLazyComponent(
 
   let componentName: string;
   try {
-    if (componentString.includes(":")) {
-      componentName = parseNamespacedId(componentString as NamespacedId).name;
+    if (isNamespacedId(componentString)) {
+      componentName = parseNamespacedId(componentString).name;
     } else {
       componentName = componentString;
     }

--- a/libs/portal-framework-ui/src/components/layout/DesktopSidebar.tsx
+++ b/libs/portal-framework-ui/src/components/layout/DesktopSidebar.tsx
@@ -1,4 +1,9 @@
-import { FlexWidgetArea, useBrand } from "@lumeweb/portal-framework-core";
+import {
+  CORE_NS,
+  createNamespacedId,
+  FlexWidgetArea,
+  useBrand,
+} from "@lumeweb/portal-framework-core";
 import { Button, cn } from "@lumeweb/portal-framework-ui-core";
 import React from "react";
 
@@ -40,7 +45,7 @@ function DesktopSidebar() {
           </Button>
           <MainNavigation isOpen={!isCollapsed} />
         </div>
-        <FlexWidgetArea id={"core:desktop-sidebar"} />
+        <FlexWidgetArea id={createNamespacedId(CORE_NS, "desktop-sidebar")} />
         <span
           className={cn(
             "text-foreground/60 mb-4 space-y-1 transition-opacity duration-300",

--- a/libs/portal-framework-ui/src/hooks/useMenuItems.spec.ts
+++ b/libs/portal-framework-ui/src/hooks/useMenuItems.spec.ts
@@ -1,10 +1,17 @@
-import type { NavigationItem } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type NavigationItem,
+  type NamespacedId,
+} from "@lumeweb/portal-framework-core";
 
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Import the hook *after* the mocks are defined
 import { useMenuItems } from "./useMenuItems";
+
+const CORE_NS = "core";
+const core = (name: string) => createNamespacedId(CORE_NS, name);
 
 // Mock the zustand store
 const mockStoreState = {
@@ -45,9 +52,9 @@ describe("useMenuItems", () => {
   });
 
   it("should return the menuItems array from the store", () => {
-    const initialMenuItems = [{ id: "dashboard", label: "Dashboard" }];
-    const updatedMenuItems = [{ id: "settings", label: "Settings" }];
-    // Update the mock state before rendering the hook
+    const initialMenuItems: NavigationItem[] = [
+      { id: core("dashboard"), label: "Dashboard" },
+    ];
     mockAppStore.setState({ menuItems: initialMenuItems });
 
     const { result } = renderHook(() => useMenuItems());
@@ -70,8 +77,12 @@ describe("useMenuItems", () => {
   });
 
   it("should return a getMenuItems function that returns the current menuItems from the latest render", () => {
-    const initialMenuItems = [{ id: "dashboard", label: "Dashboard" }]; // Initial state for the first render
-    const stateAfterUpdate = [{ id: "settings", label: "Settings" }]; // State we will set later
+    const initialMenuItems: NavigationItem[] = [
+      { id: core("dashboard"), label: "Dashboard" },
+    ];
+    const stateAfterUpdate: NavigationItem[] = [
+      { id: core("settings"), label: "Settings" },
+    ];
 
     const { result } = renderHook(() => useMenuItems());
     // The hook captures the state at the time of its render.
@@ -104,11 +115,4 @@ describe("useMenuItems", () => {
       stateAfterUpdate,
     );
   });
-
-  // Note: Testing reactive updates of `menuItems` itself (the array reference)
-  // would require a more sophisticated mock that simulates Zustand's subscription
-  // and triggers updates, or using `@testing-library/react-hooks`'s `rerender`
-  // with a mock that changes its return value. The current test for `getMenuItems`
-  // tests that the function returns the value from the *last render*, which is correct
-  // behavior for the hook's implementation.
 });

--- a/libs/portal-framework-ui/src/store/appStore.helpers.spec.ts
+++ b/libs/portal-framework-ui/src/store/appStore.helpers.spec.ts
@@ -1,188 +1,190 @@
-import { NavigationItem } from "@lumeweb/portal-framework-core";
+import { createNamespacedId, NavigationItem } from "@lumeweb/portal-framework-core";
 import { describe, expect, it } from "vitest";
 
 import { appStore, helpers } from "./appStore";
+
+const CORE_NS = "core";
+const core = (name: string) => createNamespacedId(CORE_NS, name);
 
 describe("appStore helpers", () => {
   describe("addMenuItems", () => {
     it("should handle complex nested menu structures correctly", () => {
       // Add parent items first
       appStore.getState().addMenuItems([
-        { id: "parent1", label: "Parent 1" },
-        { id: "parent2", label: "Parent 2" },
+        { id: core("parent1"), label: "Parent 1" },
+        { id: core("parent2"), label: "Parent 2" },
       ]);
 
       // Add mixed items with different parent relationships
       appStore.getState().addMenuItems([
-        { id: "child1", label: "Child 1", parentId: "parent1" },
-        { id: "child2", label: "Child 2", parentId: "parent2" },
-        { id: "grandchild1", label: "Grandchild 1", parentId: "child1" }, // Parent doesn't exist yet
-        { id: "root1", label: "Root 1" },
+        { id: core("child1"), label: "Child 1", parentId: core("parent1") },
+        { id: core("child2"), label: "Child 2", parentId: core("parent2") },
+        { id: core("grandchild1"), label: "Grandchild 1", parentId: core("child1") }, // Parent doesn't exist yet
+        { id: core("root1"), label: "Root 1" },
       ]);
 
       // Verify initial placement
       const parent1 = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "parent1",
+        core("parent1"),
       );
       const parent2 = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "parent2",
+        core("parent2"),
       );
 
       expect(parent1?.children).toHaveLength(1);
-      expect(parent1?.children?.[0].id).toBe("child1");
+      expect(parent1?.children?.[0].id).toBe(core("child1"));
       expect(parent2?.children).toHaveLength(1);
-      expect(parent2?.children?.[0].id).toBe("child2");
+      expect(parent2?.children?.[0].id).toBe(core("child2"));
       expect(
-        appStore.getState().menuItems.some((item) => item.id === "root1"),
+        appStore.getState().menuItems.some((item) => item.id === core("root1")),
       ).toBe(true);
       // Grandchild should be under child1 immediately since we process items individually
       const initialChild1 = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "child1",
+        core("child1"),
       );
       expect(initialChild1?.children).toHaveLength(1);
-      expect(initialChild1?.children?.[0].id).toBe("grandchild1");
+      expect(initialChild1?.children?.[0].id).toBe(core("grandchild1"));
       expect(
-        appStore.getState().menuItems.some((item) => item.id === "grandchild1"),
+        appStore.getState().menuItems.some((item) => item.id === core("grandchild1")),
       ).toBe(false);
 
       // Add the missing parent relationship in a second batch
       appStore
         .getState()
         .addMenuItems([
-          { id: "grandchild1", label: "Grandchild 1", parentId: "child1" },
+          { id: core("grandchild1"), label: "Grandchild 1", parentId: core("child1") },
         ]);
 
       // Verify grandchild was moved under child1
       const updatedChild1 = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "child1",
+        core("child1"),
       );
       expect(updatedChild1?.children).toHaveLength(1);
-      expect(updatedChild1?.children?.[0].id).toBe("grandchild1");
+      expect(updatedChild1?.children?.[0].id).toBe(core("grandchild1"));
       expect(
-        appStore.getState().menuItems.some((item) => item.id === "grandchild1"),
+        appStore.getState().menuItems.some((item) => item.id === core("grandchild1")),
       ).toBe(false);
     });
 
     it("should add multiple items to the root when no parentKey is provided", () => {
-      const initialState = { menuItems: [] };
       const itemsToAdd: NavigationItem[] = [
-        { id: "item1", label: "Item 1" },
-        { id: "item2", label: "Item 2" },
+        { id: core("item1"), label: "Item 1" },
+        { id: core("item2"), label: "Item 2" },
       ];
       appStore.getState().addMenuItems(itemsToAdd);
       expect(appStore.getState().menuItems).toHaveLength(2);
-      expect(appStore.getState().menuItems[0].id).toBe("item1");
-      expect(appStore.getState().menuItems[1].id).toBe("item2");
+      expect(appStore.getState().menuItems[0].id).toBe(core("item1"));
+      expect(appStore.getState().menuItems[1].id).toBe(core("item2"));
     });
 
     it("should add multiple items as children to a parent when parentKey is provided", () => {
-      appStore.getState().addMenuItem({ id: "parent", label: "Parent" });
+      appStore.getState().addMenuItem({ id: core("parent"), label: "Parent" });
       const itemsToAdd: NavigationItem[] = [
-        { id: "child1", label: "Child 1" },
-        { id: "child2", label: "Child 2" },
+        { id: core("child1"), label: "Child 1" },
+        { id: core("child2"), label: "Child 2" },
       ];
-      appStore.getState().addMenuItems(itemsToAdd, "parent");
+      appStore.getState().addMenuItems(itemsToAdd, core("parent"));
       const parentItem = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "parent",
+        core("parent"),
       );
       expect(parentItem?.children).toHaveLength(2);
-      expect(parentItem?.children?.[0].id).toBe("child1");
-      expect(parentItem?.children?.[1].id).toBe("child2");
+      expect(parentItem?.children?.[0].id).toBe(core("child1"));
+      expect(parentItem?.children?.[1].id).toBe(core("child2"));
     });
 
     it("should handle items with parentId when no parentKey is provided", () => {
-      appStore.getState().addMenuItem({ id: "parent1", label: "Parent 1" });
-      appStore.getState().addMenuItem({ id: "parent2", label: "Parent 2" });
-      const itemsToAdd = [
-        { id: "child1", label: "Child 1", parentId: "parent1" },
-        { id: "child2", label: "Child 2", parentId: "parent2" },
-        { id: "root1", label: "Root 1" },
+      appStore.getState().addMenuItem({ id: core("parent1"), label: "Parent 1" });
+      appStore.getState().addMenuItem({ id: core("parent2"), label: "Parent 2" });
+      const itemsToAdd: NavigationItem[] = [
+        { id: core("child1"), label: "Child 1", parentId: core("parent1") },
+        { id: core("child2"), label: "Child 2", parentId: core("parent2") },
+        { id: core("root1"), label: "Root 1" },
       ];
       appStore.getState().addMenuItems(itemsToAdd);
       const parent1 = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "parent1",
+        core("parent1"),
       );
       const parent2 = helpers.findMenuItem(
         appStore.getState().menuItems,
-        "parent2",
+        core("parent2"),
       );
       expect(parent1?.children).toHaveLength(1);
-      expect(parent1?.children?.[0].id).toBe("child1");
+      expect(parent1?.children?.[0].id).toBe(core("child1"));
       expect(parent2?.children).toHaveLength(1);
-      expect(parent2?.children?.[0].id).toBe("child2");
+      expect(parent2?.children?.[0].id).toBe(core("child2"));
       expect(
-        appStore.getState().menuItems.some((item) => item.id === "root1"),
+        appStore.getState().menuItems.some((item) => item.id === core("root1")),
       ).toBe(true);
     });
 
     it("should fall back to root when parentId is not found", () => {
-      const itemsToAdd = [
-        { id: "child1", label: "Child 1", parentId: "nonexistent" },
+      const itemsToAdd: NavigationItem[] = [
+        { id: core("child1"), label: "Child 1", parentId: createNamespacedId(CORE_NS, "nonexistent") },
       ];
       appStore.getState().addMenuItems(itemsToAdd);
       expect(
-        appStore.getState().menuItems.some((item) => item.id === "child1"),
+        appStore.getState().menuItems.some((item) => item.id === core("child1")),
       ).toBe(true);
     });
   });
 
   const mockMenuItems: NavigationItem[] = [
-    { children: [], id: "dashboard", label: "Dashboard", path: "/dashboard" },
+    { children: [], id: core("dashboard"), label: "Dashboard", path: "/dashboard" },
     {
       children: [
         {
           children: [],
-          id: "profile",
+          id: core("profile"),
           label: "Profile",
           path: "/settings/profile",
         },
         {
           children: [],
-          id: "account",
+          id: core("account"),
           label: "Account",
           path: "/settings/account",
         },
       ],
-      id: "settings",
+      id: core("settings"),
       label: "Settings",
     },
-    { children: [], id: "plugins", label: "Plugins" },
+    { children: [], id: core("plugins"), label: "Plugins" },
   ];
 
   describe("addItemsToRoot", () => {
     it("should add new items to the root level", () => {
       const existingItems: NavigationItem[] = [
-        { id: "item1", label: "Item 1" },
+        { id: core("item1"), label: "Item 1" },
       ];
       const newItems: NavigationItem[] = [
-        { id: "item2", label: "Item 2" },
-        { id: "item3", label: "Item 3" },
+        { id: core("item2"), label: "Item 2" },
+        { id: core("item3"), label: "Item 3" },
       ];
       const result = helpers.addItemsToRoot(newItems, existingItems);
       expect(result).toHaveLength(3);
-      expect(result[0]).toEqual({ id: "item1", label: "Item 1" });
-      expect(result[1]).toEqual({ children: [], id: "item2", label: "Item 2" });
-      expect(result[2]).toEqual({ children: [], id: "item3", label: "Item 3" });
+      expect(result[0]).toEqual({ id: core("item1"), label: "Item 1" });
+      expect(result[1]).toEqual({ children: [], id: core("item2"), label: "Item 2" });
+      expect(result[2]).toEqual({ children: [], id: core("item3"), label: "Item 3" });
     });
 
     it("should not add duplicate items to the root level", () => {
       const existingItems: NavigationItem[] = [
-        { id: "item1", label: "Item 1" },
+        { id: core("item1"), label: "Item 1" },
       ];
       const newItems: NavigationItem[] = [
-        { id: "item1", label: "Item 1" }, // Duplicate
-        { id: "item2", label: "Item 2" },
+        { id: core("item1"), label: "Item 1" }, // Duplicate
+        { id: core("item2"), label: "Item 2" },
       ];
       const result = helpers.addItemsToRoot(newItems, existingItems);
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({ id: "item1", label: "Item 1" });
-      expect(result[1]).toEqual({ children: [], id: "item2", label: "Item 2" });
+      expect(result[0]).toEqual({ id: core("item1"), label: "Item 1" });
+      expect(result[1]).toEqual({ children: [], id: core("item2"), label: "Item 2" });
     });
   });
 
@@ -190,43 +192,43 @@ describe("appStore helpers", () => {
     it("should add new items to the children of a parent item", () => {
       const parent: NavigationItem = {
         children: [],
-        id: "parent1",
+        id: core("parent1"),
         label: "Parent 1",
       };
       const newItems: NavigationItem[] = [
-        { id: "child1", label: "Child 1" },
-        { id: "child2", label: "Child 2" },
+        { id: core("child1"), label: "Child 1" },
+        { id: core("child2"), label: "Child 2" },
       ];
       const result = helpers.addItemsToChildren(newItems, parent);
       expect(result.children).toHaveLength(2);
       expect(result.children![0]).toEqual({
         children: [],
-        id: "child1",
+        id: core("child1"),
         label: "Child 1",
       });
       expect(result.children![1]).toEqual({
         children: [],
-        id: "child2",
+        id: core("child2"),
         label: "Child 2",
       });
     });
 
     it("should not add duplicate items to the children of a parent item", () => {
       const parent: NavigationItem = {
-        children: [{ id: "child1", label: "Child 1" }],
-        id: "parent1",
+        children: [{ id: core("child1"), label: "Child 1" }],
+        id: core("parent1"),
         label: "Parent 1",
       };
       const newItems: NavigationItem[] = [
-        { id: "child1", label: "Child 1" }, // Duplicate
-        { id: "child2", label: "Child 2" },
+        { id: core("child1"), label: "Child 1" }, // Duplicate
+        { id: core("child2"), label: "Child 2" },
       ];
       const result = helpers.addItemsToChildren(newItems, parent);
       expect(result.children).toHaveLength(2);
-      expect(result.children![0]).toEqual({ id: "child1", label: "Child 1" });
+      expect(result.children![0]).toEqual({ id: core("child1"), label: "Child 1" });
       expect(result.children![1]).toEqual({
         children: [],
-        id: "child2",
+        id: core("child2"),
         label: "Child 2",
       });
     });
@@ -235,28 +237,28 @@ describe("appStore helpers", () => {
   describe("findMenuItem", () => {
     it("should find a menu item by ID in a flat structure", () => {
       const items: NavigationItem[] = [
-        { id: "item1", label: "Item 1" },
-        { id: "item2", label: "Item 2" },
+        { id: core("item1"), label: "Item 1" },
+        { id: core("item2"), label: "Item 2" },
       ];
-      const result = helpers.findMenuItem(items, "item2");
-      expect(result).toEqual({ id: "item2", label: "Item 2" });
+      const result = helpers.findMenuItem(items, core("item2"));
+      expect(result).toEqual({ id: core("item2"), label: "Item 2" });
     });
 
     it("should find a menu item by ID in a nested structure", () => {
       const items: NavigationItem[] = [
         {
-          children: [{ id: "item2", label: "Item 2" }],
-          id: "item1",
+          children: [{ id: core("item2"), label: "Item 2" }],
+          id: core("item1"),
           label: "Item 1",
         },
       ];
-      const result = helpers.findMenuItem(items, "item2");
-      expect(result).toEqual({ id: "item2", label: "Item 2" });
+      const result = helpers.findMenuItem(items, core("item2"));
+      expect(result).toEqual({ id: core("item2"), label: "Item 2" });
     });
 
     it("should return undefined if the menu item is not found", () => {
-      const items: NavigationItem[] = [{ id: "item1", label: "Item 1" }];
-      const result = helpers.findMenuItem(items, "item2");
+      const items: NavigationItem[] = [{ id: core("item1"), label: "Item 1" }];
+      const result = helpers.findMenuItem(items, core("item2"));
       expect(result).toBeUndefined();
     });
   });
@@ -269,11 +271,11 @@ describe("appStore helpers", () => {
       });
       const result = helpers.findAndModifyMenuItem(
         [...mockMenuItems],
-        "dashboard",
+        core("dashboard"),
         modifier,
       );
       expect(result).toHaveLength(3);
-      const modifiedItem = result.find((item) => item.id === "dashboard");
+      const modifiedItem = result.find((item: NavigationItem) => item.id === core("dashboard"));
       expect(modifiedItem?.label).toBe("Modified Dashboard");
     });
 
@@ -284,19 +286,19 @@ describe("appStore helpers", () => {
       });
       const result = helpers.findAndModifyMenuItem(
         [...mockMenuItems],
-        "profile",
+        core("profile"),
         modifier,
       );
       expect(result).toHaveLength(3);
-      const settingsItem = result.find((item) => item.id === "settings");
+      const settingsItem = result.find((item: NavigationItem) => item.id === core("settings"));
       expect(settingsItem?.children).toBeDefined();
       expect(settingsItem?.children).toHaveLength(2);
       const modifiedChild = settingsItem?.children!.find(
-        (item) => item.id === "profile",
+        (item: NavigationItem) => item.id === core("profile"),
       );
       expect(modifiedChild?.label).toBe("Modified Profile");
       const otherChild = settingsItem?.children!.find(
-        (item) => item.id === "account",
+        (item: NavigationItem) => item.id === core("account"),
       );
       expect(otherChild?.label).toBe("Account"); // Ensure other children are untouched
     });
@@ -309,7 +311,7 @@ describe("appStore helpers", () => {
       const originalItems = [...mockMenuItems];
       const result = helpers.findAndModifyMenuItem(
         originalItems,
-        "non-existent",
+        core("non-existent"),
         modifier,
       );
       expect(result).toBe(originalItems); // Should return the exact same array reference for efficiency
@@ -320,7 +322,7 @@ describe("appStore helpers", () => {
       const originalItems = [...mockMenuItems];
       const result = helpers.findAndModifyMenuItem(
         originalItems,
-        "non-existent-child",
+        core("non-existent-child"),
         modifier,
       );
       expect(result).toBe(originalItems); // Should return the exact same array reference
@@ -334,13 +336,13 @@ describe("appStore helpers", () => {
       const originalItems = [...mockMenuItems];
       const result = helpers.findAndModifyMenuItem(
         originalItems,
-        "profile",
+        core("profile"),
         modifier,
       );
       expect(result).not.toBe(originalItems); // Should return a new array reference
-      const settingsItem = result.find((item) => item.id === "settings");
+      const settingsItem = result.find((item: NavigationItem) => item.id === core("settings"));
       const originalSettingsItem = originalItems.find(
-        (item) => item.id === "settings",
+        (item: NavigationItem) => item.id === core("settings"),
       );
       expect(settingsItem).not.toBe(originalSettingsItem); // The parent should also be a new object
       expect(settingsItem?.children).not.toBe(originalSettingsItem?.children); // The children array should be new
@@ -351,31 +353,31 @@ describe("appStore helpers", () => {
     it("should remove a root level item", () => {
       const result = helpers.removeItemFromMenu(
         [...mockMenuItems],
-        "dashboard",
+        core("dashboard"),
       );
       expect(result).toHaveLength(2);
-      expect(result.find((item) => item.id === "dashboard")).toBeUndefined();
-      expect(result.find((item) => item.id === "settings")).toBeDefined();
-      expect(result.find((item) => item.id === "plugins")).toBeDefined();
+      expect(result.find((item: NavigationItem) => item.id === core("dashboard"))).toBeUndefined();
+      expect(result.find((item: NavigationItem) => item.id === core("settings"))).toBeDefined();
+      expect(result.find((item: NavigationItem) => item.id === core("plugins"))).toBeDefined();
     });
 
     it("should remove a nested item", () => {
-      const result = helpers.removeItemFromMenu([...mockMenuItems], "profile");
+      const result = helpers.removeItemFromMenu([...mockMenuItems], core("profile"));
       expect(result).toHaveLength(3); // Root level items remain
-      const settingsItem = result.find((item) => item.id === "settings");
+      const settingsItem = result.find((item: NavigationItem) => item.id === core("settings"));
       expect(settingsItem?.children).toBeDefined();
       expect(settingsItem?.children).toHaveLength(1); // One child removed
       expect(
-        settingsItem?.children!.find((item) => item.id === "profile"),
+        settingsItem?.children!.find((item: NavigationItem) => item.id === core("profile")),
       ).toBeUndefined();
       expect(
-        settingsItem?.children!.find((item) => item.id === "account"),
+        settingsItem?.children!.find((item: NavigationItem) => item.id === core("account")),
       ).toBeDefined(); // Other child remains
     });
 
     it("should return the original array if key is not found", () => {
       const originalItems = [...mockMenuItems];
-      const result = helpers.removeItemFromMenu(originalItems, "non-existent");
+      const result = helpers.removeItemFromMenu(originalItems, core("non-existent"));
       expect(result).toBe(originalItems); // Should return the exact same array reference for efficiency
     });
 
@@ -383,18 +385,18 @@ describe("appStore helpers", () => {
       const originalItems = [...mockMenuItems];
       const result = helpers.removeItemFromMenu(
         originalItems,
-        "non-existent-child",
+        core("non-existent-child"),
       );
       expect(result).toBe(originalItems); // Should return the exact same array reference
     });
 
     it("should return a new array if an item is removed from children", () => {
       const originalItems = [...mockMenuItems];
-      const result = helpers.removeItemFromMenu(originalItems, "profile");
+      const result = helpers.removeItemFromMenu(originalItems, core("profile"));
       expect(result).not.toBe(originalItems); // Should return a new array reference
-      const settingsItem = result.find((item) => item.id === "settings");
+      const settingsItem = result.find((item: NavigationItem) => item.id === core("settings"));
       const originalSettingsItem = originalItems.find(
-        (item) => item.id === "settings",
+        (item: NavigationItem) => item.id === core("settings"),
       );
       expect(settingsItem).not.toBe(originalSettingsItem); // The parent should also be a new object
       expect(settingsItem?.children).not.toBe(originalSettingsItem?.children); // The children array should be new

--- a/libs/portal-framework-ui/src/store/appStore.spec.ts
+++ b/libs/portal-framework-ui/src/store/appStore.spec.ts
@@ -1,9 +1,13 @@
+import { createNamespacedId } from "@lumeweb/portal-framework-core";
 import { act } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { storeResetFns } from "@/../__mocks__/zustand"; // Import the reset function set
 
 import { appStore } from "./appStore"; // Import the store
+
+const CORE_NS = "core";
+const core = (name: string) => createNamespacedId(CORE_NS, name);
 
 // Mock the helpers if they had external dependencies or complex side effects.
 // In this case, the helpers seem pure and self-contained, so testing the actions
@@ -61,7 +65,7 @@ describe("appStore", () => {
 
   it("should set routes", () => {
     const routes = [
-      { component: "TestComponent", id: "route1", path: "/test" },
+      { component: "TestComponent", id: createNamespacedId(CORE_NS, "route1"), path: "/test" },
     ];
     act(() => {
       appStore.getState().setRoutes(routes);
@@ -70,7 +74,7 @@ describe("appStore", () => {
   });
 
   it("should add a menu item to the root", () => {
-    const newItem = { id: "item1", label: "Item 1", path: "/item1" };
+    const newItem = { id: core("item1"), label: "Item 1", path: "/item1" };
     act(() => {
       appStore.getState().addMenuItem(newItem);
     });
@@ -82,7 +86,7 @@ describe("appStore", () => {
 
   describe("menu item operations", () => {
     it("should add menu items to store", () => {
-      const item = { id: "test", label: "Test" };
+      const item = { id: core("test"), label: "Test" };
       act(() => {
         appStore.getState().addMenuItem(item);
       });
@@ -93,35 +97,35 @@ describe("appStore", () => {
     });
 
     it("should remove menu items from store", () => {
-      const item = { id: "test", label: "Test" };
+      const item = { id: core("test"), label: "Test" };
       act(() => {
         appStore.getState().addMenuItem(item);
-        appStore.getState().removeMenuItem("test");
+        appStore.getState().removeMenuItem(core("test"));
       });
       expect(appStore.getState().menuItems).not.toContainEqual(
-        expect.objectContaining({ id: "test" }),
+        expect.objectContaining({ id: core("test") }),
       );
     });
 
     it("should batch add menu items", () => {
       const items = [
-        { id: "test1", label: "Test 1" },
-        { id: "test2", label: "Test 2" },
+        { id: core("test1"), label: "Test 1" },
+        { id: core("test2"), label: "Test 2" },
       ];
       act(() => {
         appStore.getState().addMenuItems(items);
       });
       expect(appStore.getState().menuItems).toEqual([
-        expect.objectContaining({ id: "test1" }),
-        expect.objectContaining({ id: "test2" }),
+        expect.objectContaining({ id: core("test1") }),
+        expect.objectContaining({ id: core("test2") }),
       ]);
     });
   });
 
   it("should add multiple menu items to the root", () => {
     const items = [
-      { id: "item1", label: "Item 1" },
-      { id: "item2", label: "Item 2" },
+      { id: core("item1"), label: "Item 1" },
+      { id: core("item2"), label: "Item 2" },
     ];
     act(() => {
       appStore.getState().addMenuItems(items);
@@ -134,10 +138,10 @@ describe("appStore", () => {
 
   describe("adding multiple items", () => {
     it("should add multiple menu items to an existing parent (nested)", () => {
-      const parentItem = { children: [], id: "parent1", label: "Parent 1" };
+      const parentItem = { children: [], id: core("parent1"), label: "Parent 1" };
       const childItems = [
-        { id: "child1", label: "Child 1" },
-        { id: "child2", label: "Child 2" },
+        { id: core("child1"), label: "Child 1" },
+        { id: core("child2"), label: "Child 2" },
       ];
 
       act(() => {
@@ -146,11 +150,11 @@ describe("appStore", () => {
       expect(appStore.getState().menuItems).toHaveLength(1);
 
       act(() => {
-        appStore.getState().addMenuItems(childItems, "parent1");
+        appStore.getState().addMenuItems(childItems, core("parent1"));
       });
       const state = appStore.getState();
       expect(state.menuItems).toHaveLength(1);
-      expect(state.menuItems[0].id).toBe("parent1");
+      expect(state.menuItems[0].id).toBe(core("parent1"));
       expect(state.menuItems[0].children).toBeDefined();
       expect(state.menuItems[0].children).toHaveLength(2);
       expect(state.menuItems[0].children![0]).toEqual({
@@ -164,10 +168,10 @@ describe("appStore", () => {
     });
 
     it("should add multiple menu items with parentId (flat)", () => {
-      const parentItem = { id: "parent1", label: "Parent 1" };
+      const parentItem = { id: core("parent1"), label: "Parent 1" };
       const childItems = [
-        { id: "child1", label: "Child 1", parentId: "parent1" },
-        { id: "child2", label: "Child 2", parentId: "parent1" },
+        { id: core("child1"), label: "Child 1", parentId: core("parent1") },
+        { id: core("child2"), label: "Child 2", parentId: core("parent1") },
       ];
 
       act(() => {
@@ -195,8 +199,8 @@ describe("appStore", () => {
   });
 
   it("should not add duplicate menu items (by id) to the same level when using addMenuItem", () => {
-    const item1 = { id: "item1", label: "Item 1" };
-    const item1Duplicate = { id: "item1", label: "Item 1 Updated" }; // Same ID, different label
+    const item1 = { id: core("item1"), label: "Item 1" };
+    const item1Duplicate = { id: core("item1"), label: "Item 1 Updated" }; // Same ID, different label
 
     act(() => {
       appStore.getState().addMenuItem(item1);
@@ -213,9 +217,9 @@ describe("appStore", () => {
   });
 
   it("should not add duplicate menu items (by id) to the same level when using addMenuItems", () => {
-    const item1 = { id: "item1", label: "Item 1" };
-    const item1Duplicate = { id: "item1", label: "Item 1 Updated" }; // Same ID, different label
-    const item2 = { id: "item2", label: "Item 2" };
+    const item1 = { id: core("item1"), label: "Item 1" };
+    const item1Duplicate = { id: core("item1"), label: "Item 1 Updated" }; // Same ID, different label
+    const item2 = { id: core("item2"), label: "Item 2" };
 
     act(() => {
       appStore.getState().addMenuItems([item1, item2, item1Duplicate]);
@@ -223,16 +227,16 @@ describe("appStore", () => {
     // Expect only item1 and item2 to be added
     expect(appStore.getState().menuItems).toHaveLength(2);
     expect(
-      appStore.getState().menuItems.find((item) => item.id === "item1")?.label,
+      appStore.getState().menuItems.find((item) => item.id === core("item1"))?.label,
     ).toBe("Item 1");
     expect(
-      appStore.getState().menuItems.find((item) => item.id === "item2")?.label,
+      appStore.getState().menuItems.find((item) => item.id === core("item2"))?.label,
     ).toBe("Item 2");
   });
 
   it("should remove a root menu item", () => {
-    const item1 = { id: "item1", label: "Item 1" };
-    const item2 = { id: "item2", label: "Item 2" };
+    const item1 = { id: core("item1"), label: "Item 1" };
+    const item2 = { id: core("item2"), label: "Item 2" };
 
     act(() => {
       appStore.getState().addMenuItems([item1, item2]);
@@ -240,74 +244,74 @@ describe("appStore", () => {
     expect(appStore.getState().menuItems).toHaveLength(2);
 
     act(() => {
-      appStore.getState().removeMenuItem("item1");
+      appStore.getState().removeMenuItem(core("item1"));
     });
     const state = appStore.getState();
     expect(state.menuItems).toHaveLength(1);
-    expect(state.menuItems[0].id).toBe("item2");
+    expect(state.menuItems[0].id).toBe(core("item2"));
   });
 
   it("should remove a child menu item", () => {
-    const parentItem = { children: [], id: "parent1", label: "Parent 1" };
-    const childItem1 = { id: "child1", label: "Child 1" };
-    const childItem2 = { id: "child2", label: "Child 2" };
+    const parentItem = { children: [], id: core("parent1"), label: "Parent 1" };
+    const childItem1 = { id: core("child1"), label: "Child 1" };
+    const childItem2 = { id: core("child2"), label: "Child 2" };
 
     act(() => {
       appStore.getState().addMenuItem(parentItem);
     });
     act(() => {
-      appStore.getState().addMenuItems([childItem1, childItem2], "parent1");
+      appStore.getState().addMenuItems([childItem1, childItem2], core("parent1"));
     });
     // Add check for children before accessing length
     expect(appStore.getState().menuItems[0].children).toBeDefined();
     expect(appStore.getState().menuItems[0].children).toHaveLength(2);
 
     act(() => {
-      appStore.getState().removeMenuItem("child1");
+      appStore.getState().removeMenuItem(core("child1"));
     });
     const state = appStore.getState();
     expect(state.menuItems).toHaveLength(1);
-    expect(state.menuItems[0].id).toBe("parent1");
+    expect(state.menuItems[0].id).toBe(core("parent1"));
     // Add checks for children before accessing index
     expect(state.menuItems[0].children).toBeDefined();
     expect(state.menuItems[0].children).toHaveLength(1);
-    expect(state.menuItems[0].children![0].id).toBe("child2");
+    expect(state.menuItems[0].children![0].id).toBe(core("child2"));
   });
 
   it("should not remove anything if key is not found", () => {
-    const item1 = { id: "item1", label: "Item 1" };
-    const parentItem = { children: [], id: "parent1", label: "Parent 1" };
-    const childItem1 = { id: "child1", label: "Child 1" };
+    const item1 = { id: core("item1"), label: "Item 1" };
+    const parentItem = { children: [], id: core("parent1"), label: "Parent 1" };
+    const childItem1 = { id: core("child1"), label: "Child 1" };
 
     act(() => {
       appStore.getState().addMenuItem(item1);
       appStore.getState().addMenuItem(parentItem);
     });
     act(() => {
-      appStore.getState().addMenuItem(childItem1, "parent1");
+      appStore.getState().addMenuItem(childItem1, core("parent1"));
     });
     const initialState = appStore.getState();
     expect(initialState.menuItems).toHaveLength(2);
     // Add check for children before accessing length
     expect(
-      initialState.menuItems.find((item) => item.id === "parent1")?.children,
+      initialState.menuItems.find((item) => item.id === core("parent1"))?.children,
     ).toBeDefined();
     expect(
-      initialState.menuItems.find((item) => item.id === "parent1")?.children!,
+      initialState.menuItems.find((item) => item.id === core("parent1"))?.children!,
     ).toHaveLength(1);
 
     act(() => {
-      appStore.getState().removeMenuItem("non-existent-key");
+      appStore.getState().removeMenuItem(core("non-existent-key"));
     });
     const stateAfterRemovalAttempt = appStore.getState();
     expect(stateAfterRemovalAttempt.menuItems).toHaveLength(2);
     // Add check for children before accessing length
     expect(
-      stateAfterRemovalAttempt.menuItems.find((item) => item.id === "parent1")
+      stateAfterRemovalAttempt.menuItems.find((item) => item.id === core("parent1"))
         ?.children,
     ).toBeDefined();
     expect(
-      stateAfterRemovalAttempt.menuItems.find((item) => item.id === "parent1")
+      stateAfterRemovalAttempt.menuItems.find((item) => item.id === core("parent1"))
         ?.children!,
     ).toHaveLength(1);
     // Deep equality check to ensure no unintended changes
@@ -315,33 +319,33 @@ describe("appStore", () => {
   });
 
   it("should add a deeply nested menu item", () => {
-    const rootItem = { id: "root", label: "Root" };
-    const child1Item = { id: "child1", label: "Child 1" };
-    const child2Item = { id: "child2", label: "Child 2" };
-    const child3Item = { id: "child3", label: "Child 3", path: "/child3" };
+    const rootItem = { id: core("root"), label: "Root" };
+    const child1Item = { id: core("child1"), label: "Child 1" };
+    const child2Item = { id: core("child2"), label: "Child 2" };
+    const child3Item = { id: core("child3"), label: "Child 3", path: "/child3" };
 
     act(() => {
       appStore.getState().addMenuItem(rootItem);
     });
     act(() => {
-      appStore.getState().addMenuItem(child1Item, "root");
+      appStore.getState().addMenuItem(child1Item, core("root"));
     });
     act(() => {
-      appStore.getState().addMenuItem(child2Item, "child1");
+      appStore.getState().addMenuItem(child2Item, core("child1"));
     });
     act(() => {
-      appStore.getState().addMenuItem(child3Item, "child2");
+      appStore.getState().addMenuItem(child3Item, core("child2"));
     });
 
     const state = appStore.getState();
     expect(state.menuItems).toHaveLength(1);
-    expect(state.menuItems[0].id).toBe("root");
+    expect(state.menuItems[0].id).toBe(core("root"));
     expect(state.menuItems[0].children).toBeDefined();
     expect(state.menuItems[0].children).toHaveLength(1);
-    expect(state.menuItems[0].children![0].id).toBe("child1");
+    expect(state.menuItems[0].children![0].id).toBe(core("child1"));
     expect(state.menuItems[0].children![0].children).toBeDefined();
     expect(state.menuItems[0].children![0].children).toHaveLength(1);
-    expect(state.menuItems[0].children![0].children![0].id).toBe("child2");
+    expect(state.menuItems[0].children![0].children![0].id).toBe(core("child2"));
     expect(state.menuItems[0].children![0].children![0].children).toBeDefined();
     expect(state.menuItems[0].children![0].children![0].children).toHaveLength(
       1,
@@ -353,43 +357,43 @@ describe("appStore", () => {
   });
 
   it("should remove a deeply nested menu item", () => {
-    const rootItem = { id: "root", label: "Root" };
-    const child1Item = { id: "child1", label: "Child 1" };
-    const child2Item = { id: "child2", label: "Child 2" };
-    const child3Item = { id: "child3", label: "Child 3" };
+    const rootItem = { id: core("root"), label: "Root" };
+    const child1Item = { id: core("child1"), label: "Child 1" };
+    const child2Item = { id: core("child2"), label: "Child 2" };
+    const child3Item = { id: core("child3"), label: "Child 3" };
 
     act(() => {
       appStore.getState().addMenuItem(rootItem);
     });
     act(() => {
-      appStore.getState().addMenuItem(child1Item, "root");
+      appStore.getState().addMenuItem(child1Item, core("root"));
     });
     act(() => {
-      appStore.getState().addMenuItem(child2Item, "child1");
+      appStore.getState().addMenuItem(child2Item, core("child1"));
     });
     act(() => {
-      appStore.getState().addMenuItem(child3Item, "child2");
+      appStore.getState().addMenuItem(child3Item, core("child2"));
     });
 
     act(() => {
-      appStore.getState().removeMenuItem("child2");
+      appStore.getState().removeMenuItem(core("child2"));
     });
 
     const state = appStore.getState();
     expect(state.menuItems).toHaveLength(1);
-    expect(state.menuItems[0].id).toBe("root");
+    expect(state.menuItems[0].id).toBe(core("root"));
     expect(state.menuItems[0].children).toBeDefined();
     expect(state.menuItems[0].children).toHaveLength(1);
-    expect(state.menuItems[0].children![0].id).toBe("child1");
+    expect(state.menuItems[0].children![0].id).toBe(core("child1"));
     expect(state.menuItems[0].children![0].children).toBeDefined();
     expect(state.menuItems[0].children![0].children).toHaveLength(0);
   });
 
   it("should handle adding a menu item to a non-existent parent", () => {
-    const newItem = { id: "item1", label: "Item 1", path: "/item1" };
+    const newItem = { id: core("item1"), label: "Item 1", path: "/item1" };
 
     act(() => {
-      appStore.getState().addMenuItem(newItem, "nonExistentParent");
+      appStore.getState().addMenuItem(newItem, core("nonexistent-parent"));
     });
 
     const state = appStore.getState();
@@ -399,12 +403,12 @@ describe("appStore", () => {
 
   it("should handle adding multiple menu items to a non-existent parent", () => {
     const items = [
-      { id: "item1", label: "Item 1" },
-      { id: "item2", label: "Item 2" },
+      { id: core("item1"), label: "Item 1" },
+      { id: core("item2"), label: "Item 2" },
     ];
 
     act(() => {
-      appStore.getState().addMenuItems(items, "nonExistentParent");
+      appStore.getState().addMenuItems(items, core("nonexistent-parent"));
     });
 
     const state = appStore.getState();
@@ -416,38 +420,38 @@ describe("appStore", () => {
   it("should properly handle nested menu items with parent paths", () => {
     const menuItems = [
       {
-        id: "core:",
+        id: core("home"),
         label: "Home",
         order: -1,
         path: "/",
       },
       {
-        id: "core:abuse",
+        id: core("abuse"),
         label: "Abuse",
         path: "/abuse",
       },
       {
-        id: "core:cases",
+        id: core("abuse-cases"),
         label: "Cases",
-        parentId: "core:abuse",
+        parentId: core("abuse"),
         path: "cases",
       },
       {
-        id: "core:reporters",
+        id: core("abuse-reporters"),
         label: "Reporters",
-        parentId: "core:abuse",
+        parentId: core("abuse"),
         path: "reporters",
       },
       {
-        id: "core:subjects",
+        id: core("abuse-subjects"),
         label: "Subjects",
-        parentId: "core:abuse",
+        parentId: core("abuse"),
         path: "subjects",
       },
       {
-        id: "core:blocklist",
+        id: core("abuse-blocklist"),
         label: "Blocklist",
-        parentId: "core:abuse",
+        parentId: core("abuse"),
         path: "blocklist",
       },
     ];
@@ -459,7 +463,7 @@ describe("appStore", () => {
     const state = appStore.getState();
     expect(state.menuItems).toHaveLength(2); // Home and Abuse
 
-    const abuseItem = state.menuItems.find((item) => item.id === "core:abuse");
+    const abuseItem = state.menuItems.find((item) => item.id === core("abuse"));
     expect(abuseItem).toBeDefined();
     expect(abuseItem?.children).toHaveLength(4);
 
@@ -467,19 +471,19 @@ describe("appStore", () => {
     expect(abuseItem?.children).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "core:reporters",
+          id: core("abuse-reporters"),
           path: "/abuse/reporters", // Should be prefixed with parent path
         }),
         expect.objectContaining({
-          id: "core:cases",
+          id: core("abuse-cases"),
           path: "/abuse/cases",
         }),
         expect.objectContaining({
-          id: "core:subjects",
+          id: core("abuse-subjects"),
           path: "/abuse/subjects",
         }),
         expect.objectContaining({
-          id: "core:blocklist",
+          id: core("abuse-blocklist"),
           path: "/abuse/blocklist",
         }),
       ]),

--- a/libs/portal-framework-ui/src/store/appStore.ts
+++ b/libs/portal-framework-ui/src/store/appStore.ts
@@ -1,4 +1,5 @@
 import type {
+  NamespacedId,
   NavigationItem,
   RouteDefinition,
 } from "@lumeweb/portal-framework-core";
@@ -6,9 +7,9 @@ import type {
 import { createStore, useStore } from "zustand";
 
 interface AppActions {
-  addMenuItem: (item: NavigationItem, parentKey?: string) => void;
-  addMenuItems: (items: NavigationItem[], parentKey?: string) => void;
-  removeMenuItem: (key: string) => void;
+  addMenuItem: (item: NavigationItem, parentKey?: NamespacedId) => void;
+  addMenuItems: (items: NavigationItem[], parentKey?: NamespacedId) => void;
+  removeMenuItem: (key: NamespacedId) => void;
   setError: (error: Error | null) => void;
   setIsLoading: (isLoading: boolean) => void;
   setPluginConfigs: (configs: Record<string, any>[]) => void;
@@ -96,7 +97,7 @@ export const helpers = {
   // Helper to find and modify a menu item recursively
   findAndModifyMenuItem: (
     items: NavigationItem[],
-    key: string,
+    key: NamespacedId,
     modifier: (item: NavigationItem) => NavigationItem,
   ): NavigationItem[] => {
     let changed = false;
@@ -136,7 +137,7 @@ export const helpers = {
    */
   findMenuItem: (
     items: NavigationItem[],
-    id: string,
+    id: NamespacedId,
   ): NavigationItem | undefined => {
     for (const item of items) {
       if (item.id === id) {
@@ -155,7 +156,7 @@ export const helpers = {
   // Immutable helper for removing items recursively
   removeItemFromMenu: (
     items: NavigationItem[],
-    key: string,
+    key: NamespacedId,
   ): NavigationItem[] => {
     let removed = false;
 
@@ -186,7 +187,7 @@ export const helpers = {
 };
 
 export const appStore = createStore<AppActions & AppState>((set) => ({
-  addMenuItem: (newItem: NavigationItem, parentKey?: string) =>
+  addMenuItem: (newItem: NavigationItem, parentKey?: NamespacedId) =>
     set((state) => {
       if (parentKey) {
         const parent = helpers.findMenuItem(state.menuItems, parentKey);
@@ -210,7 +211,7 @@ export const appStore = createStore<AppActions & AppState>((set) => ({
       }
     }),
 
-  addMenuItems: (items: NavigationItem[], parentKey?: string) =>
+  addMenuItems: (items: NavigationItem[], parentKey?: NamespacedId) =>
     set((state) => {
       let newMenuItems = [...state.menuItems];
 
@@ -252,7 +253,7 @@ export const appStore = createStore<AppActions & AppState>((set) => ({
   isLoading: false,
   menuItems: [],
   pluginConfigs: [],
-  removeMenuItem: (key: string) =>
+  removeMenuItem: (key: NamespacedId) =>
     set((state) => {
       return { menuItems: helpers.removeItemFromMenu(state.menuItems, key) };
     }),

--- a/libs/portal-plugin-abuse-report/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-abuse-report/src/capabilities/refineConfig.ts
@@ -1,30 +1,27 @@
-import type {
-  BaseRecord,
-  CreateParams,
-  CustomParams,
-  DataProvider,
-  DeleteOneParams,
-  GetListParams,
-  GetListResponse,
-  GetOneParams,
-  MetaQuery,
-  RefineProps,
-  UpdateParams,
-} from "@refinedev/core";
-
-const caseJwtKey = "caseJwtKey";
+import type { RefineProps } from "@refinedev/core";
 
 import { RefineResource } from "@/types";
 import dataProvider from "@lumeweb/advanced-rest-provider";
-import { RefineConfigCapability } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  FRAMEWORK_NS,
+  type NamespacedId,
+  RefineConfigCapability,
+} from "@lumeweb/portal-framework-core";
 
 import { authProvider } from "../providers/auth-provider";
 
 export class Capability implements RefineConfigCapability {
-  dependencies?: string[];
-  readonly id: string = "abuse-report:refine-config";
-  status: "active" | "error" | "inactive";
-  readonly type: "core:refine-config" = "core:refine-config";
+  dependencies?: NamespacedId[];
+  readonly id: NamespacedId = createNamespacedId(
+    "abuse-report",
+    "refine-config",
+  );
+  status: "active" | "error" | "inactive" = "inactive";
+  readonly type: NamespacedId = createNamespacedId(
+    FRAMEWORK_NS,
+    "refine-config",
+  );
 
   async destroy() {
     // No cleanup needed

--- a/libs/portal-plugin-abuse-report/src/index.ts
+++ b/libs/portal-plugin-abuse-report/src/index.ts
@@ -1,4 +1,6 @@
 import {
+  createNamespace,
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -12,16 +14,17 @@ export default function (): Plugin {
     capabilities: [new RefineConfigCapability()],
     dependencies: [
       {
-        id: "core:core",
+        id: createNamespacedId(CORE_NS, "core"),
       },
     ],
     async destroy(_framework: Framework) {
       console.log("Plugin Abuse Report destroyed");
     },
-    id: createNamespacedId("core", "abuse-report"),
+    id: createNamespacedId(CORE_NS, "abuse-report"),
     async initialize(_framework: Framework) {
       console.log("Plugin Abuse Report initialized");
     },
+    namespaces: [createNamespace("abuse-report")],
     routes,
   } satisfies Plugin;
 }

--- a/libs/portal-plugin-abuse-report/src/routes.ts
+++ b/libs/portal-plugin-abuse-report/src/routes.ts
@@ -1,10 +1,10 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 
 const routes = [
   {
-    component: "Layout",
-    id: "root",
-    path: "/",
     children: [
       {
         component: "Index",
@@ -23,6 +23,9 @@ const routes = [
         path: "/case/:id",
       },
     ],
+    component: "Layout",
+    id: createNamespacedId("core", "abuse-report-root"),
+    path: "/",
   },
 ] satisfies RouteDefinition[];
 

--- a/libs/portal-plugin-abuse/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-abuse/src/capabilities/refineConfig.ts
@@ -64,7 +64,7 @@ export class Capability implements RefineConfigCapability {
         {
           name: RefineResource.CaseEvidence,
           meta: {
-            template: "/abuse/cases/:caseId/communications",
+            template: "/abuse/cases/:caseId/evidence",
           },
         },
       ],

--- a/libs/portal-plugin-abuse/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-abuse/src/capabilities/refineConfig.ts
@@ -1,17 +1,20 @@
 import type { RefineProps } from "@refinedev/core";
 
 import {
+  createNamespacedId,
+  type NamespacedId,
   Framework,
+  FRAMEWORK_NS,
   RefineConfigCapability,
 } from "@lumeweb/portal-framework-core";
 import { RefineResource } from "@/types/resources";
 
 export class Capability implements RefineConfigCapability {
-  dependencies = ["core:sdk"];
-  readonly id: string = "abuse:refine-config";
-  metadata: { description: string; name: string; provider: string };
-  status: "active" | "error" | "inactive";
-  readonly type = "core:refine-config";
+  dependencies: NamespacedId[] = [createNamespacedId(FRAMEWORK_NS, "sdk")];
+  readonly id = createNamespacedId("abuse", "refine-config");
+  metadata: { description: string; name: string; provider: string } = { description: "", name: "", provider: "" };
+  status: "active" | "error" | "inactive" = "inactive";
+  readonly type = "framework:refine-config";
   version: string;
 
   async destroy() {}

--- a/libs/portal-plugin-abuse/src/index.ts
+++ b/libs/portal-plugin-abuse/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -13,7 +14,7 @@ export default function (): Plugin {
     async destroy(_framework: Framework) {
       console.log("Plugin Abuse destroyed");
     },
-    id: createNamespacedId("core", "abuse"),
+    id: createNamespacedId(CORE_NS, "abuse"),
     async initialize(_framework: Framework) {
       console.log("Plugin Abuse initialized");
     },

--- a/libs/portal-plugin-abuse/src/routes.ts
+++ b/libs/portal-plugin-abuse/src/routes.ts
@@ -1,9 +1,12 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 
 const routes = [
   {
     component: "AbuseLayout",
-    id: "abuse",
+    id: createNamespacedId("abuse", "root"),
     navigation: {
       label: "Abuse",
     },

--- a/libs/portal-plugin-admin/src/index.ts
+++ b/libs/portal-plugin-admin/src/index.ts
@@ -3,6 +3,7 @@ import {
   SdkCapability,
 } from "@lumeweb/portal-framework-auth";
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -16,7 +17,7 @@ export default function (): Plugin {
     async destroy(_framework: Framework) {
       console.log("Plugin Admin destroyed");
     },
-    id: createNamespacedId("core", "admin"),
+    id: createNamespacedId(CORE_NS, "admin"),
     async initialize(_framework: Framework) {
       console.log("Plugin Admin initialized");
     },

--- a/libs/portal-plugin-admin/src/routes.ts
+++ b/libs/portal-plugin-admin/src/routes.ts
@@ -1,9 +1,12 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 
 const routes = [
   {
     component: "Index",
-    id: "root",
+    id: createNamespacedId("admin", "root"),
     index: false,
     navigation: {
       label: "Home",
@@ -13,13 +16,13 @@ const routes = [
   },
   {
     component: "Dashboard",
-    id: "dashboard",
+    id: createNamespacedId("admin", "dashboard"),
     index: false,
     path: "dashboard",
   },
   {
     component: "Login",
-    id: "login",
+    id: createNamespacedId("admin", "login"),
     index: false,
     path: "/login",
   },

--- a/libs/portal-plugin-billing/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-billing/src/capabilities/refineConfig.ts
@@ -1,8 +1,10 @@
 import type { RefineProps } from "@refinedev/core";
 import {
   Framework,
-  RefineConfigCapability,
   type CapabilityStatus,
+  createNamespacedId,
+  type NamespacedId,
+  RefineConfigCapability,
   mergeRefineConfig,
   syncAuthProviderWithDataProvider,
 } from "@lumeweb/portal-framework-core";
@@ -11,15 +13,15 @@ import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
 import { createNanoEvents, Emitter } from "nanoevents";
 
 export class Capability implements RefineConfigCapability {
-  readonly id: string = "billing:refine-config";
+  readonly id = createNamespacedId("billing", "refine-config");
   status: CapabilityStatus = "active";
-  readonly type = "core:refine-config";
+  readonly type = "framework:refine-config";
   version!: string;
   #apiUrl!: string;
   #authToken: string | null = null;
   #emitter!: Emitter;
   #authUnbind: (() => void) | null = null;
-  dependencies = ["dashboard:refine-config"];
+  dependencies = [createNamespacedId("dashboard", "refine-config")];
 
   getApiUrl(): string {
     return this.#apiUrl;
@@ -94,7 +96,7 @@ export class Capability implements RefineConfigCapability {
     // Get the dashboard refine capability
     const dashboardCapability = await framework.getCapability<
       RefineConfigCapability & { apiUrl: string }
-    >("dashboard:refine-config");
+    >(createNamespacedId("dashboard", "refine-config"));
 
     if (!dashboardCapability) {
       throw new Error("Dashboard refine capability not found");

--- a/libs/portal-plugin-billing/src/hooks/useSubscriptionEventFeed.ts
+++ b/libs/portal-plugin-billing/src/hooks/useSubscriptionEventFeed.ts
@@ -13,7 +13,7 @@ import {
 import { assertNever } from "@/types/subscription";
 import { useEffect, useRef } from "react";
 import { fetchEventSource } from "@microsoft/fetch-event-source";
-import { useCapability } from "@lumeweb/portal-framework-core";
+import { createNamespacedId, useCapability } from "@lumeweb/portal-framework-core";
 import type { Capability } from "@/capabilities/refineConfig";
 import { getAuthHeaders } from "./useSubscriptionStatus";
 import { createNanoEvents, type Emitter } from "nanoevents";
@@ -61,7 +61,7 @@ function dispatchSubscriptionEvent(
 
 export function useSubscriptionEventFeed(): SubscriptionEventEmitter {
   const emitterRef = useRef<SubscriptionEventEmitter>(createNanoEvents<SubscriptionEventFeedEvents>());
-  const { data: capability } = useCapability<Capability>("billing:refine-config");
+  const { data: capability } = useCapability<Capability>(createNamespacedId("billing", "refine-config"));
 
   useEffect(() => {
     const token = capability?.getAuthToken();

--- a/libs/portal-plugin-billing/src/index.ts
+++ b/libs/portal-plugin-billing/src/index.ts
@@ -4,6 +4,7 @@ export * from "./types";
 export * from "./utils";
 
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -13,12 +14,12 @@ import routes from "./routes";
 
 export default function (): Plugin {
   return {
-    dependencies: [{ id: "core:dashboard" }],
+    dependencies: [{ id: createNamespacedId(CORE_NS, "dashboard") }],
     capabilities: [new RefineConfigCapability()],
     async destroy(_framework: Framework) {
       console.log("Plugin Billing destroyed");
     },
-    id: createNamespacedId("core", "billing"),
+    id: createNamespacedId(CORE_NS, "billing"),
     async initialize(_framework: Framework) {
       console.log("Plugin Billing initialized");
     },

--- a/libs/portal-plugin-billing/src/routes.tsx
+++ b/libs/portal-plugin-billing/src/routes.tsx
@@ -1,10 +1,13 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 import { Coins, CreditCard } from "lucide-react";
 
 const routes = [
   {
     component: "account/subscription",
-    id: "account_subscription",
+    id: createNamespacedId("billing", "subscription"),
     navigation: {
       icon: CreditCard,
       label: "Subscription",
@@ -13,7 +16,7 @@ const routes = [
   },
   {
     component: "account/credits",
-    id: "account_credits",
+    id: createNamespacedId("billing", "credits"),
     navigation: {
       icon: Coins,
       label: "Credits",

--- a/libs/portal-plugin-billing/src/ui/components/GatewaySelector.tsx
+++ b/libs/portal-plugin-billing/src/ui/components/GatewaySelector.tsx
@@ -4,12 +4,12 @@ import {
   cn,
   Skeleton,
 } from "@lumeweb/portal-framework-ui-core";
-import { useCapability } from "@lumeweb/portal-framework-core";
+import { createNamespacedId, useCapability } from "@lumeweb/portal-framework-core";
 import type { Capability as BillingRefineConfig } from "@/capabilities/refineConfig";
 import { useEffect, useRef, useState } from "react";
 
 function useBillingApiUrl(): string {
-  const { data: capability } = useCapability<BillingRefineConfig>("billing:refine-config");
+  const { data: capability } = useCapability<BillingRefineConfig>(createNamespacedId("billing", "refine-config"));
   return capability?.getApiUrl() ?? "";
 }
 

--- a/libs/portal-plugin-core/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-core/src/capabilities/refineConfig.ts
@@ -1,21 +1,23 @@
-import dataProvider from "@lumeweb/advanced-rest-provider";
 import {
   CapabilityStatus,
   createNamespacedId,
   env,
   type Framework,
+  FRAMEWORK_NS,
   getApiBaseUrl,
+  type NamespacedId,
   RefineConfigCapability,
 } from "@lumeweb/portal-framework-core";
+import dataProvider from "@lumeweb/advanced-rest-provider";
 import { RefineProps } from "@refinedev/core";
 
 import { notificationProvider } from "@/dataProviders/notificationProvider";
 
 export class Capability implements RefineConfigCapability {
-  dependencies?: string[] | undefined;
-  id = createNamespacedId("core", "refine-config");
+  dependencies?: NamespacedId[] | undefined;
+  id = createNamespacedId(FRAMEWORK_NS, "refine-config");
   status: CapabilityStatus;
-  readonly type: "core:refine-config" = "core:refine-config";
+  readonly type = "framework:refine-config" as const;
   version = "0.1.0";
   #apiUrl: string;
 

--- a/libs/portal-plugin-core/src/features/namespace.spec.ts
+++ b/libs/portal-plugin-core/src/features/namespace.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createNamespace,
+  createNamespaceFeature,
+  createNamespacedId,
+  CORE_NS,
+  NamespaceFeature,
+} from "./namespace";
+
+describe("NamespaceFeature", () => {
+  it("should have a framework-scoped namespaced id", () => {
+    const feature = createNamespaceFeature() as NamespaceFeature;
+
+    expect(feature.id).toBe("framework:namespace");
+  });
+
+  it("should re-export createNamespacedId", () => {
+    const id = createNamespacedId(CORE_NS, "test");
+
+    expect(id).toBe("core:test");
+  });
+});

--- a/libs/portal-plugin-core/src/features/namespace.ts
+++ b/libs/portal-plugin-core/src/features/namespace.ts
@@ -1,0 +1,29 @@
+import {
+  createNamespacedId,
+  CORE_NS,
+  Framework,
+  FrameworkFeature,
+  FRAMEWORK_NS,
+  NamespacedId,
+} from "@lumeweb/portal-framework-core";
+
+// Re-export the factories so consumers can construct branded IDs through plugin-core.
+export { createNamespace, createNamespacedId, CORE_NS, FRAMEWORK_NS } from "@lumeweb/portal-framework-core";
+
+export class NamespaceFeature implements FrameworkFeature {
+  id: NamespacedId = createNamespacedId(FRAMEWORK_NS, "namespace");
+  status = "enabled" as const;
+  version = "0.1.0";
+
+  async destroy(): Promise<void> {
+    // No cleanup required.
+  }
+
+  async initialize(_framework: Framework): Promise<void> {
+    // No initialization required.
+  }
+}
+
+export function createNamespaceFeature(): FrameworkFeature {
+  return new NamespaceFeature();
+}

--- a/libs/portal-plugin-core/src/features/navigation.spec.ts
+++ b/libs/portal-plugin-core/src/features/navigation.spec.ts
@@ -1,22 +1,44 @@
-import { describe, it, expect, vi } from "vitest";
+import {
+  createNamespacedId,
+  type Plugin,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
 import {
   createNavigationFeature,
-  Navigation,
   generateIdFromRoute,
+  Navigation,
 } from "./navigation";
-import type { Plugin, RouteDefinition } from "@lumeweb/portal-framework-core";
-import { createElement } from "react";
+
+const pluginNs = "plugin1";
+const pluginId = createNamespacedId(pluginNs, "test");
+
+function makePlugin(idValue: string, routes: RouteDefinition[]): Plugin {
+  const [ns, name] = idValue.split(":");
+  return {
+    capabilities: [],
+    destroy: vi.fn(),
+    features: [],
+    id: createNamespacedId(ns, name),
+    initialize: vi.fn(),
+    routes,
+  };
+}
 
 describe("generateIdFromRoute", () => {
   it("should use existing ID when available", () => {
-    const route = { id: "plugin1:existing-id" } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const route = {
+      id: createNamespacedId(pluginNs, "existing-id"),
+    } as RouteDefinition;
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:existing-id");
   });
 
   it("should generate ID from path when no ID exists", () => {
     const route = { path: "/test-path" } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:test-path");
   });
 
@@ -24,31 +46,31 @@ describe("generateIdFromRoute", () => {
     const route = {
       path: "/test/path with spaces & symbols!",
     } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:test-path-with-spaces-symbols");
   });
 
   it("should use 'index' for index routes without path", () => {
     const route = { index: true } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:index");
   });
 
   it("should generate ID from component name when no path exists", () => {
     const route = { component: "TestComponent" } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
-    expect(result).toBe("plugin1:TestComponent");
+    const result = generateIdFromRoute(route, pluginId);
+    expect(result).toBe("plugin1:test-component");
   });
 
   it("should extract name from namespaced component ID", () => {
     const route = { component: "plugin2:TestComponent" } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
-    expect(result).toBe("plugin1:TestComponent");
+    const result = generateIdFromRoute(route, pluginId);
+    expect(result).toBe("plugin1:test-component");
   });
 
   it("should generate ID from navigation label when no component exists", () => {
     const route = { navigation: { label: "Test Label" } } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:test-label");
   });
 
@@ -56,26 +78,28 @@ describe("generateIdFromRoute", () => {
     const route = {
       navigation: { label: "Test Label & More!" },
     } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:test-label-more");
   });
 
   it("should use parent reference when parentId exists", () => {
-    const route = { parentId: "plugin1:parent" } as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const route = {
+      parentId: createNamespacedId(pluginNs, "parent"),
+    } as RouteDefinition;
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toBe("plugin1:child");
   });
 
   it("should generate hash-based ID as fallback", () => {
     const route = {} as RouteDefinition;
-    const result = generateIdFromRoute(route, "plugin1:test");
+    const result = generateIdFromRoute(route, pluginId);
     expect(result).toMatch(/^generated:route-[a-z0-9]+$/);
   });
 
   it("should use 'generated' namespace when no pluginId provided", () => {
     const route = { component: "TestComponent" } as RouteDefinition;
     const result = generateIdFromRoute(route, undefined);
-    expect(result).toBe("generated:TestComponent");
+    expect(result).toBe("generated:test-component");
   });
 });
 
@@ -83,36 +107,22 @@ describe("Navigation Feature", () => {
   const navigationFeature = createNavigationFeature() as unknown as Navigation;
   it("should build navigation items from plugins with routes and navigation properties", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:route1",
-            path: "/route1",
-            component: "Component1",
-            navigation: { label: "Route 1" },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
-      {
-        id: "plugin2:admin",
-        routes: [
-          {
-            id: "plugin2:route2",
-            path: "/route2",
-            component: "Component2",
-            navigation: { label: "Route 2" },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "route1"),
+          path: "/route1",
+          component: "Component1",
+          navigation: { label: "Route 1" },
+        },
+      ]),
+      makePlugin("plugin2:admin", [
+        {
+          id: createNamespacedId("plugin2", "route2"),
+          path: "/route2",
+          component: "Component2",
+          navigation: { label: "Route 2" },
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -125,28 +135,21 @@ describe("Navigation Feature", () => {
 
   it("should handle routes with nested paths and construct the correct full path", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:parent",
-            path: "/parent",
-            component: "ParentComponent",
-            navigation: { label: "Parent" },
-            children: [
-              {
-                id: "plugin1:child",
-                path: "child",
-                component: "ChildComponent",
-              },
-            ],
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [],
-        capabilities: [],
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "parent"),
+          path: "/parent",
+          component: "ParentComponent",
+          navigation: { label: "Parent" },
+          children: [
+            {
+              id: createNamespacedId(pluginNs, "child"),
+              path: "child",
+              component: "ChildComponent",
+            },
+          ],
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -158,28 +161,21 @@ describe("Navigation Feature", () => {
 
   it("should handle routes with parentId and construct the correct full path", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:parent",
-            path: "/parent",
-            component: "ParentComponent",
-            navigation: { label: "Parent" },
-          },
-          {
-            id: "plugin1:child",
-            path: "child",
-            component: "ChildComponent",
-            parentId: "plugin1:parent",
-            navigation: { label: "Child" },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [],
-        capabilities: [],
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "parent"),
+          path: "/parent",
+          component: "ParentComponent",
+          navigation: { label: "Parent" },
+        },
+        {
+          id: createNamespacedId(pluginNs, "child"),
+          path: "child",
+          component: "ChildComponent",
+          parentId: createNamespacedId(pluginNs, "parent"),
+          navigation: { label: "Child" },
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -192,27 +188,20 @@ describe("Navigation Feature", () => {
 
   it("should handle routes with index routes and not include them in navigation", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:index",
-            index: true,
-            component: "IndexComponent",
-            navigation: { label: "Index" },
-          },
-          {
-            id: "plugin1:route1",
-            path: "/route1",
-            component: "Component1",
-            navigation: { label: "Route 1" },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "index"),
+          index: true,
+          component: "IndexComponent",
+          navigation: { label: "Index" },
+        },
+        {
+          id: createNamespacedId(pluginNs, "route1"),
+          path: "/route1",
+          component: "Component1",
+          navigation: { label: "Route 1" },
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -224,30 +213,23 @@ describe("Navigation Feature", () => {
 
   it("should handle routes with navigation properties: badge, children, disabled, hidden, icon, order, show", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:route1",
-            path: "/route1",
-            component: "Component1",
-            navigation: {
-              label: "Route 1",
-              badge: { content: "new", variant: "secondary" },
-              children: [],
-              disabled: true,
-              hidden: true,
-              icon: createElement("svg"),
-              order: 1,
-              show: () => true,
-            },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "route1"),
+          path: "/route1",
+          component: "Component1",
+          navigation: {
+            label: "Route 1",
+            badge: { content: "new", variant: "secondary" },
+            children: [],
+            disabled: true,
+            hidden: true,
+            icon: createElement("svg"),
+            order: 1,
+            show: () => true,
           },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [],
-        capabilities: [],
-      },
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -261,7 +243,7 @@ describe("Navigation Feature", () => {
         children: [],
         disabled: true,
         hidden: true,
-        icon: expect.anything(), // Expect any React component
+        icon: expect.anything(),
         order: 1,
         show: expect.any(Function),
       }),
@@ -270,51 +252,30 @@ describe("Navigation Feature", () => {
 
   it("should sort navigation items by order and then by original plugin registration order", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:route2",
-            path: "/route2",
-            component: "Component2",
-            navigation: { label: "Route 2", order: 2 },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
-      {
-        id: "plugin2:admin",
-        routes: [
-          {
-            id: "plugin2:route1",
-            path: "/route1",
-            component: "Component1",
-            navigation: { label: "Route 1", order: 1 },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
-      {
-        id: "plugin3:settings",
-        routes: [
-          {
-            id: "plugin3:route3",
-            path: "/route3",
-            component: "Component3",
-            navigation: { label: "Route 3" },
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "route2"),
+          path: "/route2",
+          component: "Component2",
+          navigation: { label: "Route 2", order: 2 },
+        },
+      ]),
+      makePlugin("plugin2:admin", [
+        {
+          id: createNamespacedId("plugin2", "route1"),
+          path: "/route1",
+          component: "Component1",
+          navigation: { label: "Route 1", order: 1 },
+        },
+      ]),
+      makePlugin("plugin3:settings", [
+        {
+          id: createNamespacedId("plugin3", "route3"),
+          path: "/route3",
+          component: "Component3",
+          navigation: { label: "Route 3" },
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -328,93 +289,79 @@ describe("Navigation Feature", () => {
 
   it("should handle complex menu setups with nested routes, parentIds and index routes", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:dashboard",
-            path: "/dashboard",
-            component: "DashboardComponent",
-            navigation: { label: "Dashboard" },
-            children: [
-              {
-                id: "plugin1:dashboard-index",
-                index: true,
-                component: "DashboardIndex",
-              },
-              {
-                id: "plugin1:dashboard-analytics",
-                path: "analytics",
-                component: "DashboardAnalytics",
-                navigation: { label: "Analytics" },
-              },
-            ],
-          },
-          {
-            id: "plugin1:settings",
-            path: "/settings",
-            component: "SettingsComponent",
-            navigation: { label: "Settings" },
-            children: [
-              {
-                id: "plugin1:settings-index",
-                index: true,
-                component: "SettingsIndex",
-              },
-              {
-                id: "plugin1:profile",
-                path: "profile",
-                component: "ProfileComponent",
-                navigation: { label: "Profile" },
-              },
-              {
-                id: "plugin1:security",
-                path: "security",
-                component: "SecurityComponent",
-                navigation: { label: "Security" },
-              },
-            ],
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [],
-        capabilities: [],
-      },
-      {
-        id: "plugin2:admin",
-        routes: [
-          {
-            id: "plugin2:admin-root",
-            path: "/admin",
-            component: "AdminRootComponent",
-            navigation: { label: "Admin" },
-            children: [
-              {
-                id: "plugin2:admin-index",
-                index: true,
-                component: "AdminIndex",
-              },
-              {
-                id: "plugin2:users",
-                path: "users",
-                component: "UsersComponent",
-                navigation: { label: "Users" },
-              },
-              {
-                id: "plugin2:user-roles",
-                path: "roles",
-                component: "UserRolesComponent",
-                navigation: { label: "Roles" },
-              },
-            ],
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [],
-        capabilities: [],
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "dashboard"),
+          path: "/dashboard",
+          component: "DashboardComponent",
+          navigation: { label: "Dashboard" },
+          children: [
+            {
+              id: createNamespacedId(pluginNs, "dashboard-index"),
+              index: true,
+              component: "DashboardIndex",
+            },
+            {
+              id: createNamespacedId(pluginNs, "dashboard-analytics"),
+              path: "analytics",
+              component: "DashboardAnalytics",
+              navigation: { label: "Analytics" },
+            },
+          ],
+        },
+        {
+          id: createNamespacedId(pluginNs, "settings"),
+          path: "/settings",
+          component: "SettingsComponent",
+          navigation: { label: "Settings" },
+          children: [
+            {
+              id: createNamespacedId(pluginNs, "settings-index"),
+              index: true,
+              component: "SettingsIndex",
+            },
+            {
+              id: createNamespacedId(pluginNs, "profile"),
+              path: "profile",
+              component: "ProfileComponent",
+              navigation: { label: "Profile" },
+            },
+            {
+              id: createNamespacedId(pluginNs, "security"),
+              path: "security",
+              component: "SecurityComponent",
+              navigation: { label: "Security" },
+            },
+          ],
+        },
+      ]),
+      makePlugin("plugin2:admin", [
+        {
+          id: createNamespacedId("plugin2", "admin-root"),
+          path: "/admin",
+          component: "AdminRootComponent",
+          navigation: { label: "Admin" },
+          children: [
+            {
+              id: createNamespacedId("plugin2", "admin-index"),
+              index: true,
+              component: "AdminIndex",
+            },
+            {
+              id: createNamespacedId("plugin2", "users"),
+              path: "users",
+              component: "UsersComponent",
+              navigation: { label: "Users" },
+            },
+            {
+              id: createNamespacedId("plugin2", "user-roles"),
+              path: "roles",
+              component: "UserRolesComponent",
+              navigation: { label: "Roles" },
+            },
+          ],
+        },
+      ]),
     ];
 
     const navigationItems = navigationFeature.buildNavigation(mockPlugins);
@@ -458,20 +405,13 @@ describe("Navigation Feature", () => {
 
   it("should build routes from plugins", async () => {
     const mockPlugins: Plugin[] = [
-      {
-        id: "plugin1:core",
-        routes: [
-          {
-            id: "plugin1:route1",
-            path: "/route1",
-            component: "Component1",
-          },
-        ],
-        destroy: vi.fn(),
-        initialize: vi.fn(),
-        features: [], // Added features
-        capabilities: [], // Added capabilities
-      },
+      makePlugin("plugin1:core", [
+        {
+          id: createNamespacedId(pluginNs, "route1"),
+          path: "/route1",
+          component: "Component1",
+        },
+      ]),
     ];
 
     const routes = await navigationFeature.buildRoutes(mockPlugins);
@@ -480,13 +420,13 @@ describe("Navigation Feature", () => {
       {
         id: "plugin1:route1",
         path: "/route1",
-        component: "plugin1:Component1",
+        component: "Component1",
         caseSensitive: false,
         index: false,
         pluginId: "plugin1:core",
       },
       {
-        component: "core:NotFound",
+        component: "NotFound",
         id: "core:not-found",
         index: false,
         path: "*",
@@ -498,79 +438,54 @@ describe("Navigation Feature", () => {
   it("should build route tree from routes with parent IDs", async () => {
     const routes: RouteDefinition[] = [
       {
-        id: "plugin1:route1",
+        id: createNamespacedId(pluginNs, "route1"),
         path: "/route1",
         component: "Component1",
       },
       {
-        id: "plugin1:route2",
+        id: createNamespacedId(pluginNs, "route2"),
         path: "/route2",
         component: "Component2",
-        parentId: "plugin1:route1",
+        parentId: createNamespacedId(pluginNs, "route1"),
       },
       {
-        id: "plugin1:route3",
+        id: createNamespacedId(pluginNs, "route3"),
         path: "/route3",
         component: "Component3",
-        parentId: "plugin1:route1",
+        parentId: createNamespacedId(pluginNs, "route1"),
       },
       {
-        id: "plugin1:route4",
+        id: createNamespacedId(pluginNs, "route4"),
         path: "/route4",
         component: "Component4",
-        parentId: "plugin1:route2",
+        parentId: createNamespacedId(pluginNs, "route2"),
       },
     ];
 
-    // Mock validateRoute to always return true for simplicity
     vi.spyOn(navigationFeature as any, "validateRoute").mockReturnValue(true);
 
     const routeTree = (navigationFeature as any).buildRouteTree(routes);
 
-    expect(routeTree).toEqual([
-      {
-        id: "plugin1:route1",
-        path: "/route1",
-        component: "Component1",
-      },
-      {
-        id: "plugin1:route2",
-        path: "/route2",
-        component: "Component2",
-        parentId: "plugin1:route1",
-      },
-      {
-        id: "plugin1:route3",
-        path: "/route3",
-        component: "Component3",
-        parentId: "plugin1:route1",
-      },
-      {
-        id: "plugin1:route4",
-        path: "/route4",
-        component: "Component4",
-        parentId: "plugin1:route2",
-      },
-    ]);
+    expect(routeTree).toEqual(routes);
   });
 
   it("should handle duplicate route entries gracefully", async () => {
     const routes: RouteDefinition[] = [
       {
-        id: "plugin1:route1",
+        id: createNamespacedId(pluginNs, "route1"),
         path: "/route1",
         component: "Component1",
       },
       {
-        id: "plugin1:route1", // Duplicate ID
+        id: createNamespacedId(pluginNs, "route1"),
         path: "/route1",
         component: "Component1",
       },
       {
-        id: "plugin1:route2",
+        id: createNamespacedId(pluginNs, "route2"),
         path: "/route2",
         component: "Component2",
-        parentId: "plugin1:route1",
+        parentId: createNamespacedId(pluginNs, "route1"),
       },
     ];
 
@@ -578,23 +493,6 @@ describe("Navigation Feature", () => {
 
     const routeTree = (navigationFeature as any).buildRouteTree(routes);
 
-    expect(routeTree).toEqual([
-      {
-        id: "plugin1:route1",
-        path: "/route1",
-        component: "Component1",
-      },
-      {
-        id: "plugin1:route1",
-        path: "/route1",
-        component: "Component1",
-      },
-      {
-        id: "plugin1:route2",
-        path: "/route2",
-        component: "Component2",
-        parentId: "plugin1:route1",
-      },
-    ]);
+    expect(routeTree).toEqual(routes);
   });
 });

--- a/libs/portal-plugin-core/src/features/navigation.ts
+++ b/libs/portal-plugin-core/src/features/navigation.ts
@@ -1,13 +1,14 @@
 import {
+  CORE_NS,
   createNamespacedId,
   createRemoteComponentLoader,
   defaultRemoteOptions,
   Framework,
+  FRAMEWORK_NS,
   isNamespacedId,
   NamespacedId,
   NavigationFeature,
   NavigationItem,
-  normalizeId,
   parseNamespacedId,
   Plugin,
   RouteDefinition,
@@ -20,6 +21,15 @@ const CHECK_TYPES = {
   DEFINED: Symbol('defined'),
   UNDEFINED_CHECK: Symbol('undefinedCheck')
 } as const;
+
+export function normalizeNameForId(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2") // Convert camelCase/PascalCase to kebab
+    .replace(/[^a-zA-Z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
 
 export function generateIdFromRoute(
   route: RouteDefinition,
@@ -43,25 +53,36 @@ export function generateIdFromRoute(
     if (pluginId) {
       return createNamespacedId(
         parseNamespacedId(pluginId).namespace,
-        sanitizedPath
+        sanitizedPath,
       );
     }
-    return createNamespacedId("generated", sanitizedPath);
+    return createNamespacedId(
+      "generated",
+      sanitizedPath,
+    );
   }
 
   // 3. Try to use component name if available
   if (route.component) {
-    let componentName = route.component;
-    if (isNamespacedId(route.component)) {
-      componentName = parseNamespacedId(route.component).name;
+    let componentName: string;
+    if (route.component.includes(":")) {
+      componentName = parseNamespacedId(
+        route.component as NamespacedId,
+      ).name;
+    } else {
+      componentName = route.component;
     }
+    componentName = normalizeNameForId(componentName);
     if (pluginId) {
       return createNamespacedId(
         parseNamespacedId(pluginId).namespace,
-        componentName
+        componentName,
       );
     }
-    return createNamespacedId("generated", componentName);
+    return createNamespacedId(
+      "generated",
+      componentName,
+    );
   }
 
   // 4. Try to use navigation label if available
@@ -74,10 +95,13 @@ export function generateIdFromRoute(
     if (pluginId) {
       return createNamespacedId(
         parseNamespacedId(pluginId).namespace,
-        label
+        label,
       );
     }
-    return createNamespacedId("generated", label);
+    return createNamespacedId(
+      "generated",
+      label,
+    );
   }
 
   // 5. Use parent reference if available
@@ -102,7 +126,8 @@ export function generateIdFromRoute(
 }
 
 export class Navigation implements NavigationFeature {
-  id: NamespacedId = createNamespacedId("core", "navigation");
+  id: NamespacedId = createNamespacedId(FRAMEWORK_NS, "navigation");
+  status = "enabled" as const;
   version = "0.1.0";
 
   #framework?: Framework;
@@ -131,12 +156,12 @@ export class Navigation implements NavigationFeature {
       id,
       label: route.navigation.label,
       path: route.path ?? "",
-      index: route.index ?? false,
     };
 
     // Define properties and their inclusion criteria
     const propMap = {
       badge: CHECK_TYPES.DEFINED,
+      children: CHECK_TYPES.DEFINED,
       disabled: CHECK_TYPES.UNDEFINED_CHECK,
       hidden: CHECK_TYPES.UNDEFINED_CHECK,
       icon: CHECK_TYPES.DEFINED,
@@ -159,7 +184,7 @@ export class Navigation implements NavigationFeature {
   }
 
   private shouldIncludeRouteInNavigation(route: RouteDefinition): boolean {
-    return !!route.navigation && (!route.index || route.navigation.forceShowInNavigation);
+    return !!route.navigation && (!(route.index ?? false) || !!route.navigation.forceShowInNavigation);
   }
 
   private processRouteForNavigation(route: RouteDefinition, pluginId: NamespacedId): NavigationItem[] {
@@ -221,19 +246,22 @@ export class Navigation implements NavigationFeature {
       route: RouteDefinition,
       plugin: Plugin,
     ): Promise<RouteDefinition> => {
-      const routeId = route.id
-        ? normalizeId(plugin.id, route.id)
-        : createNamespacedId(
-            plugin.id,
-            route.path || (route.index ? "index" : "unnamed-route"),
-          );
+      // Routes are required to define their own namespaced IDs at definition time.
+      // Per the namespace refactor design (Rule 6), we no longer normalize bare IDs here.
+      if (!route.id) {
+        throw new Error(
+          `Route from plugin "${plugin.id}" is missing an id. All route IDs must be valid NamespacedId values defined at registration time.`,
+        );
+      }
 
-      const normalizedComponent = route.component
-        ? normalizeId(plugin.id, route.component)
-        : undefined;
+      const routeId = route.id;
+
+      // Components are bare export names resolved against the plugin's module loader,
+      // not namespaced identifiers.
+      const componentName = route.component;
 
       const componentData = {
-        component: normalizedComponent,
+        component: componentName,
         id: routeId,
         pluginId: plugin.id,
       };
@@ -250,7 +278,7 @@ export class Navigation implements NavigationFeature {
         ...componentData,
         caseSensitive: route.caseSensitive ?? false,
         children: processedChildren,
-        component: normalizedComponent!,
+        component: componentName,
         id: routeId,
         index: route.index ?? false,
         pluginId: plugin.id,
@@ -268,16 +296,16 @@ export class Navigation implements NavigationFeature {
 
     // Add the 404 route
     const notFoundRoute = {
-      component: normalizeId(createNamespacedId("core", "core"), "NotFound"),
-      id: createNamespacedId("core", "not-found"),
+      component: "NotFound",
+      id: createNamespacedId(CORE_NS, "not-found"),
       index: false,
       path: "*",
-      pluginId: createNamespacedId("core", "core"),
+      pluginId: createNamespacedId(CORE_NS, "core"),
     };
 
     /*    const notFoundComponentData = await this.loadRouteComponent({
       ...notFoundRoute,
-      pluginId: createNamespacedId("core", "core"),
+      pluginId: createNamespacedId(CORE_NS, "core"),
     });*/
 
     routes.push({
@@ -318,12 +346,8 @@ export class Navigation implements NavigationFeature {
 
     if (route.component) {
       try {
-        // First normalize the component path if it's not already done
-        const normalizedComponent = isNamespacedId(route.component)
-          ? route.component
-          : normalizeId(route.pluginId, route.component);
-
-        const componentPath = parseNamespacedId(normalizedComponent).name;
+        // Component names are bare export names resolved against the plugin's module loader.
+        const componentPath = route.component;
 
         const Component = await createRemoteComponentLoader(
           {

--- a/libs/portal-plugin-core/src/index.ts
+++ b/libs/portal-plugin-core/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -15,7 +16,7 @@ export default function (): Plugin {
       console.log("Plugin Core destroyed");
     },
     features: [createNavigationFeature()],
-    id: createNamespacedId("core", "core"),
+    id: createNamespacedId(CORE_NS, "core"),
     async initialize(_framework: Framework) {
       console.log("Plugin Core initialized");
     },

--- a/libs/portal-plugin-core/src/widgetRegistrations.ts
+++ b/libs/portal-plugin-core/src/widgetRegistrations.ts
@@ -1,8 +1,12 @@
-import type { WidgetAreaDefinition } from "@lumeweb/portal-framework-core";
+import {
+  CORE_NS,
+  createNamespacedId,
+  type WidgetAreaDefinition,
+} from "@lumeweb/portal-framework-core";
 
 export const widgetAreas: WidgetAreaDefinition[] = [
   {
-    id: "core:desktop-sidebar",
+    id: createNamespacedId(CORE_NS, "desktop-sidebar"),
   },
 ];
 export default {

--- a/libs/portal-plugin-dashboard/src-lib/types/capabilities/protocol.ts
+++ b/libs/portal-plugin-dashboard/src-lib/types/capabilities/protocol.ts
@@ -1,6 +1,16 @@
-import type { BaseCapability } from "@lumeweb/portal-framework-core";
+import {
+  FRAMEWORK_NS,
+  createNamespacedId,
+  type BaseCapability,
+} from "@lumeweb/portal-framework-core";
 
-export interface ProtocolCapability extends BaseCapability<"core:protocol"> {
+export const PROTOCOL_CAPABILITY_TYPE = createNamespacedId(
+  FRAMEWORK_NS,
+  "protocol",
+);
+
+export interface ProtocolCapability
+  extends BaseCapability {
   /**
    * Get the protocol description for display in UI
    */

--- a/libs/portal-plugin-dashboard/src-lib/types/capabilities/upload.ts
+++ b/libs/portal-plugin-dashboard/src-lib/types/capabilities/upload.ts
@@ -1,9 +1,19 @@
-import type { BaseCapability } from "@lumeweb/portal-framework-core";
-
-import type { UploadConfig, UppyPlugin } from "../upload";
+import {
+  FRAMEWORK_NS,
+  createNamespacedId,
+  type BaseCapability,
+} from "@lumeweb/portal-framework-core";
 import type { BasePlugin } from "@uppy/core";
 
-export interface UploadCapability extends BaseCapability<"core:upload"> {
+import type { UploadConfig, UppyPlugin } from "../upload";
+
+export const UPLOAD_CAPABILITY_TYPE = createNamespacedId(
+  FRAMEWORK_NS,
+  "upload",
+);
+
+export interface UploadCapability
+  extends BaseCapability {
   /**
    * Gets the Uppy plugin for large files
    * @returns Uppy plugin class

--- a/libs/portal-plugin-dashboard/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-dashboard/src/capabilities/refineConfig.ts
@@ -1,19 +1,25 @@
 import type { RefineProps } from "@refinedev/core";
 import {
-  Framework,
-  RefineConfigCapability,
+  createNamespacedId,
+  type CapabilityStatus,
+  type Framework,
+  type NamespacedId,
+  type RefineConfigCapability,
 } from "@lumeweb/portal-framework-core";
 import { resolveDashboardApiUrl, setupDataProvider } from "@lib/util";
 import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
 
 export class Capability implements RefineConfigCapability {
-  readonly id: string = "dashboard:refine-config";
-  status;
-  readonly type = "core:refine-config";
-  version: string;
-  #apiUrl: string;
-
-  async destroy() {}
+  readonly id: NamespacedId = createNamespacedId(
+    "dashboard",
+    "refine-config",
+  );
+  status: CapabilityStatus = "active";
+  readonly type = "framework:refine-config";
+  version: string = "0.0.1";
+  // constructor must set; placeholder avoids definite assignment errors
+  #apiUrl: string = "";
+  async destroy(_framework?: Framework) {}
 
   /**
    * Gets the resolved API URL for the dashboard

--- a/libs/portal-plugin-dashboard/src/features/upload/Feature.ts
+++ b/libs/portal-plugin-dashboard/src/features/upload/Feature.ts
@@ -1,16 +1,24 @@
-import type { BaseCapability } from "@lumeweb/portal-framework-core";
-
-import { createLargeFilePlugin, createSmallFilePlugin } from "@lib/util/uppy";
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   FrameworkFeature,
   getSdk,
   NamespacedId,
 } from "@lumeweb/portal-framework-core";
-import { Body, Meta, UppyEventMap } from "@uppy/core";
+
+import type {
+  BaseCapability,
+  FeatureStatus,
+} from "@lumeweb/portal-framework-core";
 
 import type { UploadCapability } from "@lib/types/capabilities/upload";
+import { UPLOAD_CAPABILITY_TYPE } from "@lib/types/capabilities/upload";
+import { PROTOCOL_CAPABILITY_TYPE } from "@lib/types/capabilities/protocol";
+import {
+  createLargeFilePlugin,
+  createSmallFilePlugin,
+} from "@lib/util/uppy";
 
 import { Manager, UppyFileDefault } from "@/features/upload/Manager";
 import {
@@ -21,25 +29,19 @@ import {
   UploadStatusType,
 } from "@/types/upload";
 
-// Capability type constants
-export const PROTOCOL_CAPABILITY_TYPE = "core:protocol";
-export const UPLOAD_CAPABILITY_TYPE = "core:upload";
-
 export class Feature implements FrameworkFeature, IUploadManager {
-  readonly id: NamespacedId = createNamespacedId("dashboard", "upload");
-  status;
+  readonly id: NamespacedId = createNamespacedId(CORE_NS, "dashboard-upload");
+  status: FeatureStatus = "enabled";
   version = "0.1.0";
-  #uploadManager: Manager;
+  // initialized in initialize()
+  #uploadManager!: Manager;
 
-  addEvent<K extends keyof UppyEventMap<Meta, Body>>(
-    event: K,
-    callback: UppyEventMap<Meta, Body>[K],
-  ) {
-    return this.#uploadManager.addEvent(event, callback);
+  addEvent(event: string, callback: (...args: any[]) => void) {
+    return this.#uploadManager.addEvent(event as any, callback as any);
   }
 
   // Expose upload manager methods
-  addFile(file: File, serviceId: string) {
+  addFile(file: File, serviceId?: string) {
     return this.#uploadManager.addFile(file, serviceId);
   }
 
@@ -51,7 +53,7 @@ export class Feature implements FrameworkFeature, IUploadManager {
     return this.#uploadManager.clearErrors();
   }
 
-  async destroy(framework: Framework): Promise<void> {
+  async destroy(_framework: Framework): Promise<void> {
     // Cleanup logic
     this.#uploadManager.reset();
   }
@@ -72,7 +74,7 @@ export class Feature implements FrameworkFeature, IUploadManager {
   ): Promise<BaseCapability[]> {
     const protocols: BaseCapability[] = [];
 
-    // Get all capabilities of type "core:protocol"
+    // Get all capabilities of type framework:protocol
     const protocolCapabilities =
       await framework.getCapabilitiesByType<BaseCapability>(
         PROTOCOL_CAPABILITY_TYPE,
@@ -109,7 +111,7 @@ export class Feature implements FrameworkFeature, IUploadManager {
    */
   async getUploadCapabilitiesForProtocol(
     framework: Framework,
-    protocolId: string,
+    protocolId: NamespacedId,
   ): Promise<BaseCapability[]> {
     const associatedIds = await framework.getAssociatedCapabilities(protocolId);
     const associatedCaps = await Promise.all(

--- a/libs/portal-plugin-dashboard/src/plugin.ts
+++ b/libs/portal-plugin-dashboard/src/plugin.ts
@@ -3,6 +3,8 @@ import {
   SdkCapability,
 } from "@lumeweb/portal-framework-auth";
 import {
+  createNamespace,
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -26,11 +28,12 @@ export default function (): Plugin {
       console.log("Plugin Dashboard destroyed");
     },
     features: [new Feature()],
-    id: createNamespacedId("core", "dashboard"),
+    id: createNamespacedId(CORE_NS, "dashboard"),
     async initialize(_framework: Framework) {
       console.log("Plugin Dashboard initialized");
       registerInput();
     },
+    namespaces: [createNamespace("dashboard")],
     routes,
     widgets: dashboardWidgets,
   } satisfies Plugin;

--- a/libs/portal-plugin-dashboard/src/routes.tsx
+++ b/libs/portal-plugin-dashboard/src/routes.tsx
@@ -1,4 +1,8 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  CORE_NS,
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 
 import {
   Activity,
@@ -9,15 +13,15 @@ import {
   UserCog,
 } from "lucide-react";
 
-const routes = [
+const routes: RouteDefinition[] = [
   {
     component: "index",
-    id: "root",
+    id: createNamespacedId(CORE_NS, "root"),
     path: "/",
   },
   {
     component: "dashboard",
-    id: "dashboard",
+    id: createNamespacedId(CORE_NS, "dashboard"),
     navigation: {
       icon: LayoutDashboard,
       label: "Dashboard",
@@ -27,7 +31,7 @@ const routes = [
   },
   {
     component: "operations",
-    id: "operations",
+    id: createNamespacedId(CORE_NS, "operations"),
     navigation: {
       icon: Activity,
       label: "Operations",
@@ -39,7 +43,7 @@ const routes = [
     children: [
       {
         component: "account/profile",
-        id: "account_index",
+        id: createNamespacedId(CORE_NS, "account-index"),
         index: true,
         navigation: {
           forceShowInNavigation: true,
@@ -50,7 +54,7 @@ const routes = [
       },
       {
         component: "account/security",
-        id: "account_security",
+        id: createNamespacedId(CORE_NS, "account-security"),
         navigation: {
           icon: Shield,
           label: "Security",
@@ -59,7 +63,7 @@ const routes = [
       },
       {
         component: "account/api-keys",
-        id: "account_api_keys",
+        id: createNamespacedId(CORE_NS, "account-api-keys"),
         navigation: {
           icon: Key,
           label: "API Keys",
@@ -68,7 +72,7 @@ const routes = [
       },
     ],
     component: "account/layout",
-    id: "account_layout",
+    id: createNamespacedId(CORE_NS, "account-layout"),
     navigation: {
       icon: UserCog,
       label: "My Account",
@@ -79,42 +83,42 @@ const routes = [
   },
   {
     component: "account/verify",
-    id: "account_verify",
+    id: createNamespacedId(CORE_NS, "account-verify"),
     path: "account/verify",
   },
   {
     component: "loginIndex",
-    id: "login_index",
+    id: createNamespacedId(CORE_NS, "login-index"),
     path: "login",
   },
   {
     component: "registerIndex",
-    id: "register_index",
+    id: createNamespacedId(CORE_NS, "register-index"),
     path: "register",
   },
   {
     children: [
       {
         component: "resetPassword/reset",
-        id: "reset_password_index",
+        id: createNamespacedId(CORE_NS, "reset-password-index"),
         index: true,
         path: "",
       },
       {
         component: "resetPassword/confirm",
-        id: "reset_password_confirm",
+        id: createNamespacedId(CORE_NS, "reset-password-confirm"),
         path: "confirm",
       },
     ],
     component: "resetPassword/layout",
-    id: "reset_password_layout",
+    id: createNamespacedId(CORE_NS, "reset-password-layout"),
     path: "reset-password",
   },
   {
     component: "loginOtp",
-    id: "otp_login",
+    id: createNamespacedId(CORE_NS, "otp-login"),
     path: "otp",
   },
-] satisfies RouteDefinition[];
+] as const satisfies RouteDefinition[];
 
 export default routes;

--- a/libs/portal-plugin-dashboard/src/ui/forms/editProfile.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/editProfile.tsx
@@ -1,4 +1,12 @@
+import {
+  createNamespacedId,
+} from "@lumeweb/portal-framework-core";
 import { type FormConfig, FormFieldType } from "@lumeweb/portal-framework-ui";
+
+const ACCOUNT_EMAIL_FIELD_TYPE = createNamespacedId(
+  "dashboard",
+  "account.email",
+);
 
 export default function editProfileForm(): FormConfig {
   return {
@@ -26,7 +34,7 @@ export default function editProfileForm(): FormConfig {
         className: "col-span-2",
         label: "Email Address",
         name: "email",
-        type: "dashboard:account.email",
+        type: ACCOUNT_EMAIL_FIELD_TYPE,
       },
     ],
     footerClassName: "",

--- a/libs/portal-plugin-dashboard/src/ui/forms/editProfile.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/editProfile.tsx
@@ -5,7 +5,7 @@ import { type FormConfig, FormFieldType } from "@lumeweb/portal-framework-ui";
 
 const ACCOUNT_EMAIL_FIELD_TYPE = createNamespacedId(
   "dashboard",
-  "account.email",
+  "account-email",
 );
 
 export default function editProfileForm(): FormConfig {

--- a/libs/portal-plugin-dashboard/src/ui/forms/fields/AccountEmail.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/fields/AccountEmail.tsx
@@ -14,7 +14,7 @@ import { updateEmailDialogConfig } from "@/ui/dialogs/updateEmail";
 
 const ACCOUNT_EMAIL_FIELD_TYPE = createNamespacedId(
   "dashboard",
-  "account.email",
+  "account-email",
 );
 
 interface AccountEmailProps {

--- a/libs/portal-plugin-dashboard/src/ui/forms/fields/AccountEmail.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/forms/fields/AccountEmail.tsx
@@ -4,12 +4,18 @@ import {
   useDialog,
   useFormContext,
 } from "@lumeweb/portal-framework-ui";
+import { createNamespacedId } from "@lumeweb/portal-framework-core";
 import { Button, cn } from "@lumeweb/portal-framework-ui-core";
 import { useCustomMutation } from "@refinedev/core";
 import { Mail } from "lucide-react";
 import React from "react";
 
 import { updateEmailDialogConfig } from "@/ui/dialogs/updateEmail";
+
+const ACCOUNT_EMAIL_FIELD_TYPE = createNamespacedId(
+  "dashboard",
+  "account.email",
+);
 
 interface AccountEmailProps {
   className?: string;
@@ -58,5 +64,5 @@ const AccountEmail = React.forwardRef<HTMLDivElement, AccountEmailProps>(
 );
 
 export function registerInput() {
-  registerFormComponent("dashboard:account.email", AccountEmail);
+  registerFormComponent(ACCOUNT_EMAIL_FIELD_TYPE, AccountEmail);
 }

--- a/libs/portal-plugin-dashboard/src/ui/hooks/useUploadManager.ts
+++ b/libs/portal-plugin-dashboard/src/ui/hooks/useUploadManager.ts
@@ -1,10 +1,19 @@
-import { useFramework } from "@lumeweb/portal-framework-core";
+import {
+  CORE_NS,
+  createNamespacedId,
+  useFramework,
+} from "@lumeweb/portal-framework-core";
 import { useNotification } from "@refinedev/core";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ProtocolCapability } from "@lib/types/capabilities/protocol";
 import type { Feature } from "@/features/upload";
 import type { UIServiceConfig, UploadStatusType } from "@/types/upload";
+
+const DASHBOARD_UPLOAD_FEATURE_ID = createNamespacedId(
+  CORE_NS,
+  "dashboard-upload",
+);
 
 export interface UseUploadManagerReturn {
   addFile: (file: File, serviceId: string) => Promise<void>;
@@ -36,7 +45,9 @@ export function useUploadManager(): UseUploadManagerReturn {
     }
 
     const feature =
-      await framework.framework.getFeature<Feature>("dashboard:upload");
+      await framework.framework.getFeature<Feature>(
+        DASHBOARD_UPLOAD_FEATURE_ID,
+      );
     if (!feature) {
       throw new Error("Upload feature not found");
     }

--- a/libs/portal-plugin-dashboard/src/ui/routes/account.profile.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/account.profile.tsx
@@ -1,5 +1,10 @@
-import { GridWidgetArea } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  GridWidgetArea,
+} from "@lumeweb/portal-framework-core";
 import { PageHeader } from "@lumeweb/portal-framework-ui";
+
+const DASHBOARD_PROFILE_AREA = createNamespacedId("dashboard", "profile");
 
 export default function AccountProfile() {
   return (
@@ -8,7 +13,7 @@ export default function AccountProfile() {
         description="Manage your account information and preferences"
         title="Profile & Settings"
       />
-      <GridWidgetArea id={"dashboard:profile"} />
+      <GridWidgetArea id={DASHBOARD_PROFILE_AREA} />
     </div>
   );
 }

--- a/libs/portal-plugin-dashboard/src/ui/routes/account.security.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/account.security.tsx
@@ -1,14 +1,19 @@
-import { GridWidgetArea } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  GridWidgetArea,
+} from "@lumeweb/portal-framework-core";
 import { PageHeader } from "@lumeweb/portal-framework-ui";
 
-export default function AccountProfile() {
+const DASHBOARD_SECURITY_AREA = createNamespacedId("dashboard", "security");
+
+export default function AccountSecurity() {
   return (
     <div className="space-y-6">
       <PageHeader
         description="Manage your account security and authentication settings"
         title="Security"
       />
-      <GridWidgetArea id={"dashboard:security"} />
+      <GridWidgetArea id={DASHBOARD_SECURITY_AREA} />
     </div>
   );
 }

--- a/libs/portal-plugin-dashboard/src/ui/routes/dashboard.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/dashboard.tsx
@@ -1,14 +1,19 @@
-import { GridWidgetArea } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  GridWidgetArea,
+} from "@lumeweb/portal-framework-core";
 import { GeneralLayout } from "@lumeweb/portal-framework-ui";
 import { Authenticated } from "@refinedev/core";
 import React from "react";
 import "@lumeweb/portal-framework-ui-core/tailwind-plugin.css";
 
+const DASHBOARD_HEADER_AREA = createNamespacedId("dashboard", "header");
+
 function Dashboard() {
   return (
     <Authenticated key="dashboard" v3LegacyAuthProviderCompatible={false}>
       <GeneralLayout>
-        <GridWidgetArea id={"dashboard:header"} />
+        <GridWidgetArea id={DASHBOARD_HEADER_AREA} />
       </GeneralLayout>
     </Authenticated>
   );

--- a/libs/portal-plugin-dashboard/src/ui/routes/operations.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/operations.tsx
@@ -5,7 +5,6 @@ import {
   GeneralLayout,
   PageHeader,
   ToolbarItemType,
-  ComponentSize,
   Copyable,
 } from "@lumeweb/portal-framework-ui";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -15,7 +14,9 @@ import type { ProtocolCapability } from "@lumeweb/portal-plugin-dashboard";
 import { useCapabilitiesByType } from "@lumeweb/portal-framework-core";
 import { useOperationFilters } from "@/ui/hooks/useOperationFilters";
 import { Authenticated } from "@refinedev/core";
-import { useMemo, createContext, useContext } from "react";
+import React, { useMemo, createContext, useContext } from "react";
+
+import { PROTOCOL_CAPABILITY_TYPE } from "@lib/types/capabilities/protocol";
 
 interface OperationListItem {
   cid?: any;
@@ -317,7 +318,9 @@ const OperationsFilterProvider = ({
   children: React.ReactNode;
 }) => {
   const { data: protocolCapabilities } =
-    useCapabilitiesByType<ProtocolCapability>("core:protocol");
+    useCapabilitiesByType<ProtocolCapability>(
+      PROTOCOL_CAPABILITY_TYPE,
+    );
 
   const { data: filterData, isLoading: isFiltersLoading } =
     useOperationFilters();
@@ -326,7 +329,7 @@ const OperationsFilterProvider = ({
   const protocolCapabilitiesMap = useMemo(() => {
     if (!protocolCapabilities) return new Map();
     return new Map(
-      protocolCapabilities.map((cap) => {
+      protocolCapabilities.map((cap: any) => {
         const key = cap.id.includes(":") ? cap.id.split(":")[0] : cap.id;
         return [key, cap];
       }),

--- a/libs/portal-plugin-dashboard/src/widgetRegistrations.ts
+++ b/libs/portal-plugin-dashboard/src/widgetRegistrations.ts
@@ -1,9 +1,10 @@
-import type {
-  WidgetAreaDefinition,
-  WidgetRegistration,
-} from "@lumeweb/portal-framework-core";
-
 import { Identity } from "@lumeweb/portal-framework-core";
+import {
+  CORE_NS,
+  createNamespacedId,
+  type WidgetAreaDefinition,
+  type WidgetRegistration,
+} from "@lumeweb/portal-framework-core";
 import { useGetIdentity } from "@refinedev/core";
 
 export const widgetAreas: WidgetAreaDefinition[] = [
@@ -13,7 +14,7 @@ export const widgetAreas: WidgetAreaDefinition[] = [
       gap: 16,
       rowHeight: "auto",
     },
-    id: "dashboard:header",
+    id: createNamespacedId("dashboard", "header"),
   },
   {
     grid: {
@@ -21,7 +22,7 @@ export const widgetAreas: WidgetAreaDefinition[] = [
       gap: 16,
       rowHeight: "auto",
     },
-    id: "dashboard:profile",
+    id: createNamespacedId("dashboard", "profile"),
   },
   {
     grid: {
@@ -29,15 +30,15 @@ export const widgetAreas: WidgetAreaDefinition[] = [
       gap: 16,
       rowHeight: "auto",
     },
-    id: "dashboard:security",
+    id: createNamespacedId("dashboard", "security"),
   },
 ];
 
 export const widgetRegistrations: WidgetRegistration[] = [
   {
-    areaId: "dashboard:header",
+    areaId: createNamespacedId("dashboard", "header"),
     componentName: "widgets/account/emailVerificationBanner",
-    id: "dashboard:email-verification",
+    id: createNamespacedId("dashboard", "email-verification"),
     position: {
       size: {
         height: 1,
@@ -54,9 +55,9 @@ export const widgetRegistrations: WidgetRegistration[] = [
     },
   },
   {
-    areaId: "dashboard:profile",
+    areaId: createNamespacedId("dashboard", "profile"),
     componentName: "widgets/account/bio",
-    id: "dashboard:bio",
+    id: createNamespacedId("dashboard", "bio"),
     order: 0,
     position: {
       size: {
@@ -66,9 +67,9 @@ export const widgetRegistrations: WidgetRegistration[] = [
     },
   },
   {
-    areaId: "dashboard:profile",
+    areaId: createNamespacedId("dashboard", "profile"),
     componentName: "widgets/account/profile",
-    id: "dashboard:profile",
+    id: createNamespacedId("dashboard", "profile"),
     order: 1,
     position: {
       size: {
@@ -78,9 +79,9 @@ export const widgetRegistrations: WidgetRegistration[] = [
     },
   },
   {
-    areaId: "dashboard:profile",
+    areaId: createNamespacedId("dashboard", "profile"),
     componentName: "widgets/account/delete",
-    id: "dashboard:delete",
+    id: createNamespacedId("dashboard", "delete"),
     order: 2,
     position: {
       size: {
@@ -90,9 +91,9 @@ export const widgetRegistrations: WidgetRegistration[] = [
     },
   },
   {
-    areaId: "dashboard:security",
+    areaId: createNamespacedId("dashboard", "security"),
     componentName: "widgets/account/password",
-    id: "dashboard:password",
+    id: createNamespacedId("dashboard", "password"),
     position: {
       size: {
         height: 2,
@@ -101,9 +102,9 @@ export const widgetRegistrations: WidgetRegistration[] = [
     },
   },
   {
-    areaId: "dashboard:security",
+    areaId: createNamespacedId("dashboard", "security"),
     componentName: "widgets/account/2fa",
-    id: "dashboard:2fa",
+    id: createNamespacedId("dashboard", "2fa"),
     position: {
       size: {
         height: 2,
@@ -112,9 +113,9 @@ export const widgetRegistrations: WidgetRegistration[] = [
     },
   },
   {
-    areaId: "core:desktop-sidebar",
+    areaId: createNamespacedId(CORE_NS, "desktop-sidebar"),
     componentName: "widgets/upload/button",
-    id: "dashboard:upload-button",
+    id: createNamespacedId("dashboard", "upload-button"),
     position: {
       size: {
         height: 2,

--- a/libs/portal-plugin-ipfs/src-lib/hooks/usePinsCount.ts
+++ b/libs/portal-plugin-ipfs/src-lib/hooks/usePinsCount.ts
@@ -1,5 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { useFeature } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  useFeature,
+} from "@lumeweb/portal-framework-core";
 import type { FrameworkFeature } from "@lumeweb/portal-framework-core";
 
 interface FileManagerLike extends FrameworkFeature {
@@ -23,7 +26,7 @@ export function usePinsCount(enabled = true): UsePinsCountReturn {
     data: feature,
     error: featureError,
     isLoading: featureLoading,
-  } = useFeature<FileManagerLike>("ipfs:file-manager");
+  } = useFeature<FileManagerLike>(createNamespacedId("ipfs", "file-manager"));
 
   const {
     data: pins,

--- a/libs/portal-plugin-ipfs/src/capabilities/ipfsProtocol.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/ipfsProtocol.ts
@@ -1,12 +1,14 @@
 import type { ProtocolCapability } from "@lumeweb/portal-plugin-dashboard";
+import { createNamespacedId } from "@lumeweb/portal-framework-core";
 
 import * as React from "react";
 
 import IpfsIcon from "@/ui/Icon";
 
 export class IpfsProtocol implements ProtocolCapability {
-  readonly id = "ipfs:protocol";
-  readonly type = "core:protocol" as const;
+  readonly id = createNamespacedId("ipfs", "protocol");
+  status: "active" | "error" | "inactive" = "active";
+  readonly type = "framework:protocol" as const;
 
   async destroy() {}
 

--- a/libs/portal-plugin-ipfs/src/capabilities/ipfsUpload.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/ipfsUpload.ts
@@ -6,6 +6,8 @@ import type {
 } from "@lumeweb/portal-plugin-dashboard";
 
 import {
+  createNamespacedId,
+  type NamespacedId,
   cleanTrailingSlashes,
   getApiBaseUrl,
 } from "@lumeweb/portal-framework-core";
@@ -13,8 +15,9 @@ import {
 import CarPreprocessorPlugin from "./carPreprocessor";
 
 export class IpfsUpload implements UploadCapability {
-  readonly id = "ipfs:upload";
-  readonly type = "core:upload" as const;
+  readonly id = createNamespacedId("ipfs", "upload");
+  status: "active" | "error" | "inactive" = "active";
+  readonly type = "framework:upload" as const;
   #tusEndpoint: string;
   #xhrEndpoint: string;
 

--- a/libs/portal-plugin-ipfs/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/refineConfig.ts
@@ -2,6 +2,8 @@ import type { RefineProps } from "@refinedev/core";
 
 import dataProvider from "@lumeweb/advanced-rest-provider";
 import {
+  createNamespacedId,
+  type NamespacedId,
   env,
   Framework,
   getApiBaseUrl,
@@ -15,9 +17,9 @@ const SUBDOMAIN = "ipfs";
 const DATA_PROVIDER_NAME = "ipfs";
 
 export class Capability implements RefineConfigCapability {
-  readonly id: string = "ipfs:refine-config";
+  readonly id = createNamespacedId("ipfs", "refine-config");
   status;
-  readonly type = "core:refine-config";
+  readonly type = "framework:refine-config";
   version: string;
   #apiUrl: string;
   #authToken: string | null = null;

--- a/libs/portal-plugin-ipfs/src/features/fileManager/Feature.ts
+++ b/libs/portal-plugin-ipfs/src/features/fileManager/Feature.ts
@@ -2,9 +2,6 @@ import {
   createNamespacedId,
   Framework,
   FrameworkFeature,
-  getPluginMeta,
-  getApiBaseUrl,
-  env,
   RefineConfigCapability,
 } from "@lumeweb/portal-framework-core";
 import HeliaService from "../../helia";
@@ -24,7 +21,7 @@ export class FileManagerFeature implements FrameworkFeature {
 
   async initialize(framework: Framework): Promise<void> {
     // Get the IPFS RefineConfigCapability to access its API URL
-    const refineConfigCapability = await framework.getCapability<RefineConfigCapability>("ipfs:refine-config");
+    const refineConfigCapability = await framework.getCapability<RefineConfigCapability>(createNamespacedId("ipfs", "refine-config"));
     
     if (!refineConfigCapability) {
       throw new Error("Failed to get IPFS RefineConfig capability");

--- a/libs/portal-plugin-ipfs/src/index.ts
+++ b/libs/portal-plugin-ipfs/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -19,15 +20,15 @@ export default function (): Plugin {
     ],
     capabilityAssociations: [
       {
-        associated: ["ipfs:upload"],
-        primary: "ipfs:protocol",
+        associated: [createNamespacedId("ipfs", "upload")],
+        primary: createNamespacedId("ipfs", "protocol"),
       },
     ],
     features: [new FileManagerFeature()],
     async destroy(_framework: Framework) {
       console.log("Plugin IPFS destroyed");
     },
-    id: createNamespacedId("core", "ipfs"),
+    id: createNamespacedId(CORE_NS, "ipfs"),
     async initialize(_framework: Framework) {
       console.log("Plugin IPFS initialized");
     },

--- a/libs/portal-plugin-ipfs/src/routes.tsx
+++ b/libs/portal-plugin-ipfs/src/routes.tsx
@@ -1,11 +1,14 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 import { Folder } from "lucide-react";
 
 const routes = [
   {
     path: "/files",
     component: "file-manager",
-    id: "ipfs:file-manager",
+    id: createNamespacedId("ipfs", "file-manager"),
     navigation: {
       label: "File Manager",
       icon: Folder,

--- a/libs/portal-plugin-ipfs/src/ui/hooks/useFileManagerFeature.ts
+++ b/libs/portal-plugin-ipfs/src/ui/hooks/useFileManagerFeature.ts
@@ -1,4 +1,4 @@
-import { useFeature } from "@lumeweb/portal-framework-core";
+import { createNamespacedId, useFeature } from "@lumeweb/portal-framework-core";
 import { useCallback } from "react";
 import { FileManagerFeature } from "@/features/fileManager/Feature";
 import type { HeliaService } from "@/helia";
@@ -16,7 +16,7 @@ export function useFileManagerFeature(): UseFileManagerFeatureReturn {
     data: feature,
     error,
     isLoading,
-  } = useFeature<FileManagerFeature>("ipfs:file-manager");
+  } = useFeature<FileManagerFeature>(createNamespacedId("ipfs", "file-manager"));
 
   const getHeliaService = useCallback(() => {
     if (!feature) {

--- a/libs/portal-plugin-lbry/src/capabilities/lbryProtocol.ts
+++ b/libs/portal-plugin-lbry/src/capabilities/lbryProtocol.ts
@@ -3,12 +3,16 @@ import type { ProtocolCapability } from "@lumeweb/portal-plugin-dashboard";
 import * as React from "react";
 
 import LbryIcon from "@/ui/components/LbryIcon";
-import { type CapabilityStatus } from "@lumeweb/portal-framework-core";
+import {
+  type CapabilityStatus,
+  FRAMEWORK_NS,
+  createNamespacedId,
+} from "@lumeweb/portal-framework-core";
 
 export class LbryProtocol implements ProtocolCapability {
-  readonly id = "lbry:protocol";
-  readonly type = "core:protocol" as const;
+  readonly id = createNamespacedId("lbry", "protocol");
   readonly status: CapabilityStatus;
+  readonly type = createNamespacedId(FRAMEWORK_NS, "protocol");
 
   async destroy() {}
 

--- a/libs/portal-plugin-lbry/src/capabilities/lbryUpload.ts
+++ b/libs/portal-plugin-lbry/src/capabilities/lbryUpload.ts
@@ -6,14 +6,16 @@ import type {
 import {
   CapabilityStatus,
   cleanTrailingSlashes,
+  FRAMEWORK_NS,
+  createNamespacedId,
   Framework,
   getApiBaseUrl,
 } from "@lumeweb/portal-framework-core";
 
 export class LbryUpload implements UploadCapability {
-  readonly id = "lbry:upload";
-  readonly type = "core:upload" as const;
+  readonly id = createNamespacedId("lbry", "upload");
   readonly status: CapabilityStatus;
+  readonly type = createNamespacedId(FRAMEWORK_NS, "upload");
   #tusEndpoint: string;
   #xhrEndpoint: string;
 

--- a/libs/portal-plugin-lbry/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-lbry/src/capabilities/refineConfig.ts
@@ -2,6 +2,8 @@ import type { RefineProps } from "@refinedev/core";
 
 import dataProvider from "@lumeweb/advanced-rest-provider";
 import {
+  FRAMEWORK_NS,
+  createNamespacedId,
   env,
   Framework,
   getApiBaseUrl,
@@ -14,9 +16,9 @@ const SUBDOMAIN = "lbry";
 export const DATA_PROVIDER_NAME = "lbry";
 
 export class RefineConfig implements RefineConfigCapability {
-  readonly id = "lbry:refine-config";
+  readonly id = createNamespacedId("lbry", "refine-config");
   readonly status = "inactive";
-  readonly type = "core:refine-config" as const;
+  readonly type = createNamespacedId(FRAMEWORK_NS, "refine-config");
   #apiUrl: string;
 
   async destroy() {}

--- a/libs/portal-plugin-lbry/src/index.ts
+++ b/libs/portal-plugin-lbry/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -18,14 +19,14 @@ export default function (): Plugin {
     ],
     capabilityAssociations: [
       {
-        associated: ["lbry:upload"],
-        primary: "lbry:protocol",
+        associated: [createNamespacedId("lbry", "upload")],
+        primary: createNamespacedId("lbry", "protocol"),
       },
     ],
     async destroy(_framework: Framework) {
       console.log("Plugin LBRY destroyed");
     },
-    id: createNamespacedId("core", "lbry"),
+    id: createNamespacedId(CORE_NS, "lbry"),
     async initialize(_framework: Framework) {
       console.log("Plugin LBRY initialized");
     },

--- a/libs/portal-plugin-lbry/src/routes.tsx
+++ b/libs/portal-plugin-lbry/src/routes.tsx
@@ -1,11 +1,15 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  CORE_NS,
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 import { Anchor, Monitor } from "lucide-react";
 
 const routes = [
   {
     path: "/lbry/devices",
     component: "devices",
-    id: "lbry_devices",
+    id: createNamespacedId(CORE_NS, "lbry-devices"),
     navigation: {
       label: "Devices",
       icon: Monitor,
@@ -15,7 +19,7 @@ const routes = [
   {
     path: "/lbry/streams",
     component: "streams",
-    id: "lbry_streams",
+    id: createNamespacedId(CORE_NS, "lbry-streams"),
     navigation: {
       label: "Streams",
       icon: Anchor,

--- a/libs/portal-plugin-onboarding/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-onboarding/src/capabilities/refineConfig.ts
@@ -1,5 +1,6 @@
 import type { RefineProps } from "@refinedev/core";
 import {
+  createNamespacedId,
   Framework,
   mergeRefineConfig,
   RefineConfigCapability,
@@ -9,13 +10,13 @@ import {
 const DATA_PROVIDER_NAME = "ipfs";
 
 export class Capability implements RefineConfigCapability {
-  readonly id: string = "onboarding:refine-config";
+  readonly id = createNamespacedId("onboarding", "refine-config");
   status: CapabilityStatus = "active";
-  readonly type = "core:refine-config";
+  readonly type = "framework:refine-config";
   version!: string;
   #apiUrl!: string;
 
-  dependencies = ["ipfs:refine-config"];
+  dependencies = [createNamespacedId("ipfs", "refine-config")];
 
   getApiUrl(): string {
     return this.#apiUrl;
@@ -41,7 +42,7 @@ export class Capability implements RefineConfigCapability {
   async initialize(framework: Framework) {
     const ipfsCapability = await framework.getCapability<
       RefineConfigCapability & { getApiUrl(): string }
-    >("ipfs:refine-config");
+    >(createNamespacedId("ipfs", "refine-config"));
 
     if (!ipfsCapability) {
       throw new Error("IPFS refine capability not found");

--- a/libs/portal-plugin-onboarding/src/index.ts
+++ b/libs/portal-plugin-onboarding/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -22,14 +23,14 @@ export default function (): Plugin {
   return {
     capabilities: [new RefineConfigCapability()],
     dependencies: [
-      { id: "core:dashboard" },
-      { id: "core:billing" },
-      { id: "core:ipfs" },
-      { id: "ipfs:refine-config" },
+      { id: createNamespacedId(CORE_NS, "dashboard") },
+      { id: createNamespacedId(CORE_NS, "billing") },
+      { id: createNamespacedId(CORE_NS, "ipfs") },
+      { id: createNamespacedId("ipfs", "refine-config") },
     ],
     async destroy(_framework: Framework) {
     },
-    id: createNamespacedId("core", "onboarding"),
+    id: createNamespacedId(CORE_NS, "onboarding"),
     async initialize(_framework: Framework) {
     },
     queryParamConfig: QUERY_PARAM_CONFIG,

--- a/libs/portal-plugin-onboarding/src/widgetRegistrations.ts
+++ b/libs/portal-plugin-onboarding/src/widgetRegistrations.ts
@@ -1,12 +1,15 @@
-import type { WidgetRegistration } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type WidgetRegistration,
+} from "@lumeweb/portal-framework-core";
 
 import { useOnboardingStatus } from "@/hooks";
 
 export const widgetRegistrations: WidgetRegistration[] = [
   {
-    areaId: "dashboard:header",
+    areaId: createNamespacedId("dashboard", "header"),
     componentName: "widgets/onboarding/checklist",
-    id: "onboarding:checklist",
+    id: createNamespacedId("onboarding", "checklist"),
     order: -1,
     position: {
       size: {

--- a/libs/portal-plugin-quota/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-quota/src/capabilities/refineConfig.ts
@@ -1,5 +1,6 @@
 import type { RefineProps } from "@refinedev/core";
 import {
+  createNamespacedId,
   Framework,
   RefineConfigCapability,
   type CapabilityStatus,
@@ -11,15 +12,15 @@ import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
 import { createNanoEvents, Emitter } from "nanoevents";
 
 export class Capability implements RefineConfigCapability {
-  readonly id: string = "quota:refine-config";
+  readonly id = createNamespacedId("quota", "refine-config");
   status: CapabilityStatus = "active";
-  readonly type = "core:refine-config";
+  readonly type = "framework:refine-config";
   version!: string;
   #apiUrl!: string;
   #authToken: string | null = null;
   #emitter!: Emitter;
   #authUnbind: (() => void) | null = null;
-  dependencies = ["dashboard:refine-config"];
+  dependencies = [createNamespacedId("dashboard", "refine-config")];
 
   getApiUrl(): string {
     return this.#apiUrl;
@@ -79,7 +80,7 @@ export class Capability implements RefineConfigCapability {
 
     const dashboardCapability = await framework.getCapability<
       RefineConfigCapability & { apiUrl: string }
-    >("dashboard:refine-config");
+    >(createNamespacedId("dashboard", "refine-config"));
 
     if (!dashboardCapability) {
       throw new Error("Dashboard refine capability not found");

--- a/libs/portal-plugin-quota/src/index.ts
+++ b/libs/portal-plugin-quota/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -11,10 +12,10 @@ import widgets from "./widgetRegistrations";
 export default function (): Plugin {
   return {
     capabilities: [new RefineConfigCapability()],
-    dependencies: [{ id: "core:dashboard" }],
+    dependencies: [{ id: createNamespacedId(CORE_NS, "dashboard") }],
     async destroy(_framework: Framework) {
     },
-    id: createNamespacedId("core", "quota"),
+    id: createNamespacedId(CORE_NS, "quota"),
     async initialize(_framework: Framework) {
     },
     routes,

--- a/libs/portal-plugin-quota/src/widgetRegistrations.ts
+++ b/libs/portal-plugin-quota/src/widgetRegistrations.ts
@@ -1,12 +1,13 @@
-import type {
-  WidgetRegistration,
+import {
+  createNamespacedId,
+  type WidgetRegistration,
 } from "@lumeweb/portal-framework-core";
 
 export const widgetRegistrations: WidgetRegistration[] = [
   {
-    areaId: "dashboard:header",
+    areaId: createNamespacedId("dashboard", "header"),
     componentName: "widgets/quota",
-    id: "quota:usage",
+    id: createNamespacedId("quota", "usage"),
     position: {
       size: {
         height: 1,

--- a/libs/portal-plugin-template/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-template/src/capabilities/refineConfig.ts
@@ -1,4 +1,5 @@
 import {
+  createNamespacedId,
   RefineConfigCapability,
   mergeRefineConfig,
 } from "@lumeweb/portal-framework-core";
@@ -6,8 +7,9 @@ import type { RefineProps } from "@refinedev/core";
 import { Framework } from "@lumeweb/portal-framework-core";
 
 export class Capability implements RefineConfigCapability {
-  readonly id: string = "template:refine-config";
-  readonly type = "core:refine-config";
+  readonly id = createNamespacedId("template", "refine-config");
+  status: "active" | "error" | "inactive" = "active";
+  readonly type = "framework:refine-config";
 
   async initialize(_framework: Framework) {
     // Initialize capability

--- a/libs/portal-plugin-template/src/features/template/Feature.ts
+++ b/libs/portal-plugin-template/src/features/template/Feature.ts
@@ -6,6 +6,7 @@ import {
 
 export class Feature implements FrameworkFeature {
   readonly id = createNamespacedId("template", "main");
+  status: "disabled" | "enabled" | "error" = "enabled";
 
   async initialize(framework: Framework): Promise<void> {
     // Initialize the template feature

--- a/libs/portal-plugin-template/src/index.ts
+++ b/libs/portal-plugin-template/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  CORE_NS,
   createNamespacedId,
   Framework,
   type Plugin,
@@ -16,7 +17,7 @@ export default function (): Plugin {
       console.log("Plugin Template destroyed");
     },
     features: [new TemplateFeature()],
-    id: createNamespacedId("core", "template"),
+    id: createNamespacedId(CORE_NS, "template"),
     async initialize(_framework: Framework) {
       console.log("Plugin Template initialized");
     },

--- a/libs/portal-plugin-template/src/routes.tsx
+++ b/libs/portal-plugin-template/src/routes.tsx
@@ -1,11 +1,14 @@
-import type { RouteDefinition } from "@lumeweb/portal-framework-core";
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
 import { Home, Settings } from "lucide-react";
 
 const routes = [
   {
     path: "/template",
     component: "./dashboard",
-    id: "template-dashboard",
+    id: createNamespacedId("template", "dashboard"),
     navigation: {
       label: "Template Dashboard",
       icon: Home,
@@ -15,7 +18,7 @@ const routes = [
   {
     path: "/template/settings",
     component: "./settings",
-    id: "template-settings",
+    id: createNamespacedId("template", "settings"),
     navigation: {
       label: "Template Settings",
       icon: Settings,


### PR DESCRIPTION
## Summary
Replace bare string identifiers for capabilities, features, routes, plugins, and dependencies with `NamespacedId` branded type across all 14 framework and plugin packages.

### Core changes (`portal-framework-core`)
- Add `Namespace` and `NamespacedId` branded types (`types/namespace.ts`)
- Add `NamespaceRegistry` class for plugin namespace management (`plugins/namespaceRegistry.ts`)
- `createNamespacedId` accepts plain string namespace — no `createNamespace()` wrapping needed
- Export `CORE_NS` and `FRAMEWORK_NS` constants for well-known namespaces
- Relax `BaseCapability` generic to string defaults for branded ID compatibility
- Update `Plugin`, `Navigation`, `Widget`, and `Capability` types to use `NamespacedId`
- Rewrite plugin manager to resolve plugins and capabilities via `NamespacedId`
- Fix `getPrimaryCapability` signature to accept and return `NamespacedId`

### Plugin-core (`portal-plugin-core`)
- Add `NamespaceFeature` class for plugin namespace registration
- Rewrite navigation feature to use `createNamespacedId` for menu items and routes
- Type dependencies as `NamespacedId[]` instead of `string[]`

### Per-plugin changes (11 plugins)
- Replace bare string capability/feature/route IDs with `createNamespacedId`
- Migrate capability types from `core:refine-config` to `framework:refine-config`
- Add `status` field to capability implementations (`IpfsProtocol`, `IpfsUpload`, `LbryProtocol`, `LbryUpload`, `RefineConfig`, etc.)
- Replace inline `as import()` type cast in abuse plugin with proper `NamespacedId` type import
- Type dependency arrays as `NamespacedId[]` instead of `string[]`
- Export `PROTOCOL_CAPABILITY_TYPE` and `UPLOAD_CAPABILITY_TYPE` as namespaced constants (dashboard)

### Framework UI (`portal-framework-ui`)
- Use `CORE_NS` and `FRAMEWORK_NS` constants in `AppComponent` and `DesktopSidebar`
- Replace string capability type lookups with `createNamespacedId` calls

### Framework auth (`portal-framework-auth`)
- Replace bare string IDs with `createNamespacedId` + `FRAMEWORK_NS` in sdk and refineConfig capabilities
- Fix `JSX.Element` to `React.JSX.Element` in `OtpForm` for React 19 compatibility

## Test Plan
- [x] framework-core namespace tests pass
- [x] framework-ui tests pass
- [x] plugin-core tests pass
- [x] Typecheck clean on all 14 packages

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR introduces a comprehensive namespaced ID system across the entire portal framework and all plugins, replacing ad-hoc string-based identifiers with validated, branded types and a centralized namespace registry.

### Key Changes

**Branded Type System**
- Introduces `Namespace` and `NamespacedId` as branded types (using unique symbols) that distinguish validated identifiers from plain strings at the type level, preventing accidental misuse of unvalidated strings.
- Adds `CORE_NS` and `FRAMEWORK_NS` constants for the two reserved namespaces.

**Namespace Registry**
- Adds a new `NamespaceRegistry` class that tracks which plugin owns which namespace. The `core` and `framework` namespaces are reserved and can only be claimed by core plugins. Two different plugins cannot claim the same namespace. Namespaces are automatically claimed during plugin registration and released on destruction.
- Plugins can now declare additional namespaces beyond their ID namespace via a new `namespaces?: Namespace[]` field on the `Plugin` interface.

**Stricter Validation**
- Namespace and name segments must be lowercase alphanumeric with hyphens (matching a regex pattern). Multi-colon strings, empty segments, uppercase characters, and spaces are now rejected.
- `normalizeId` no longer silently passes through invalid multi-colon strings — it throws.
- Route IDs are now **required** at definition time. The previous auto-generation of route IDs from paths has been removed; routes without a valid namespaced ID will throw an error at registration.
- Component names in routes are now treated as bare export names (resolved against the plugin's module loader) rather than namespaced identifiers.

**Capability Type Migration**
- `BaseCapability` now uses `NamespacedId` for IDs and dependencies.
- Capability types previously hardcoded as `"core:refine-config"`, `"core:sdk"`, `"core:protocol"`, and `"core:upload"` are migrated to `"framework:refine-config"`, `"framework:sdk"`, `"framework:protocol"`, and `"framework:upload"` respectively.
- `RefineConfigCapability` and `SdkCapability` interfaces are generalized to accept any string type rather than being locked to specific literal types.

**Framework-Wide Plugin Migration**
- All plugins (core, dashboard, billing, abuse, abuse-report, admin, IPFS, LBRY, onboarding, quota, template) have been updated to use `createNamespacedId()` for plugin IDs, route IDs, capability IDs, capability dependencies, capability associations, widget area IDs, widget IDs, and feature IDs.
- All `"core:"` prefixed plugin IDs now use the `CORE_NS` constant.
- The navigation feature ID changed from `core:navigation` to `framework:navigation`.

**New NamespaceFeature**
- Adds a `NamespaceFeature` in the core plugin that re-exports namespace utility functions (`createNamespace`, `createNamespacedId`, `CORE_NS`, `FRAMEWORK_NS`) for plugin consumers.

**UI Store Updates**
- The app store's menu item operations (`addMenuItem`, `addMenuItems`, `removeMenuItem`, `findMenuItem`, `findAndModifyMenuItem`, `removeItemFromMenu`) now use `NamespacedId` instead of plain `string` for keys and parent keys.

**Miscellaneous**
- Adds `docs/`, `.worktrees/`, and `apps/*/devtools-output/` to `.gitignore`.
- Fixes a `return` to `continue` in the framework's plugin loading loop, allowing subsequent plugins to load even when one fails to resolve a remote module.
<!-- kody-pr-summary:end -->