### PR TITLE
feat: make favicon configurable via brand.faviconUrl

### DIFF
--- a/libs/portal-framework-core/src/env.ts
+++ b/libs/portal-framework-core/src/env.ts
@@ -2,6 +2,7 @@ import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
 const brandSchema = z.object({
+  faviconUrl: z.string().optional(),
   logoUrl: z.string().optional(),
   tagline: z.string().optional(),
   siteUrl: z.string().url().optional(),

--- a/libs/portal-framework-core/src/vite/__tests__/localhost-plugin.spec.ts
+++ b/libs/portal-framework-core/src/vite/__tests__/localhost-plugin.spec.ts
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { localhostAccessPlugin } from "../localhost-plugin";
 
-function callTransformIndexHtml(plugin: ReturnType<typeof localhostAccessPlugin>) {
-  return (plugin.transformIndexHtml as () => HtmlTagDescriptor[])();
+function callTransformIndexHtml(plugin: ReturnType<typeof localhostAccessPlugin>, html = "") {
+  return (plugin.transformIndexHtml as (html: string) => HtmlTagDescriptor[] | { html: string; tags: HtmlTagDescriptor[] })(html);
 }
 
 describe("localhostAccessPlugin", () => {
@@ -110,5 +110,54 @@ describe("localhostAccessPlugin", () => {
     for (const script of result) {
       expect(script.tag).toBe("script");
     }
+  });
+
+  it("replaces favicon href when brand.faviconUrl is set", () => {
+    const html =
+      '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />';
+    vi.stubEnv(
+      "VITE_PORTAL_BRAND",
+      JSON.stringify({ faviconUrl: "/custom-favicon.png" }),
+    );
+    const plugin = localhostAccessPlugin();
+    const result = callTransformIndexHtml(plugin, html);
+
+    expect(result).toHaveProperty("html");
+    expect((result as { html: string }).html).toContain(
+      'href="/custom-favicon.png"',
+    );
+    expect((result as { html: string }).html).not.toContain(
+      "/favicon.svg",
+    );
+  });
+
+  it("replaces both logo and favicon when both are set", () => {
+    const html =
+      '<link rel="icon" type="image/svg+xml" href="/favicon.svg" /><div data-loader-logo></div>';
+    vi.stubEnv(
+      "VITE_PORTAL_BRAND",
+      JSON.stringify({
+        faviconUrl: "/custom-favicon.png",
+        logoUrl: "/logo.png",
+      }),
+    );
+    const plugin = localhostAccessPlugin();
+    const result = callTransformIndexHtml(plugin, html);
+
+    expect(result).toHaveProperty("html");
+    const html2 = (result as { html: string }).html;
+    expect(html2).toContain('href="/custom-favicon.png"');
+    expect(html2).toContain('src="/logo.png"');
+  });
+
+  it("does not modify favicon when brand.faviconUrl is not set", () => {
+    const html =
+      '<link rel="icon" type="image/svg+xml" href="/favicon.svg" />';
+    vi.stubEnv("VITE_PORTAL_BRAND", JSON.stringify({}));
+    const plugin = localhostAccessPlugin();
+    const result = callTransformIndexHtml(plugin, html);
+
+    // No html modifications, only tags returned
+    expect(Array.isArray(result)).toBe(true);
   });
 });

--- a/libs/portal-framework-core/src/vite/localhost-plugin.ts
+++ b/libs/portal-framework-core/src/vite/localhost-plugin.ts
@@ -38,11 +38,23 @@ export function localhostAccessPlugin(): Plugin {
             ? JSON.parse(process.env.VITE_PORTAL_BRAND)
             : process.env.VITE_PORTAL_BRAND;
 
+        let updatedHtml = html;
+
         if (brand?.logoUrl) {
-          const updatedHtml = html.replace(
+          updatedHtml = updatedHtml.replace(
             /(<div\s+data-loader-logo\s+[^>]*>)([\s\S]*?)(<\/div>)/,
             `$1<img alt="Logo" src="${brand.logoUrl}" />$3`,
           );
+        }
+
+        if (brand?.faviconUrl) {
+          updatedHtml = updatedHtml.replace(
+            /(<link\s+rel=["']icon["'][^>]*\shref=["'])([^"']*)(["'])/,
+            `$1${brand.faviconUrl}$3`,
+          );
+        }
+
+        if (updatedHtml !== html) {
           return { html: updatedHtml, tags };
         }
       }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds the ability to configure the favicon URL through the brand configuration (`brand.faviconUrl`), complementing the existing logo URL configurability.

**Changes:**

- **Brand schema**: Added an optional `faviconUrl` field to the brand environment configuration, allowing it to be set via `VITE_PORTAL_BRAND`.

- **Vite localhost plugin**: Extended the HTML transformation logic to replace the `href` attribute of `<link rel="icon">` tags in the HTML with the configured `faviconUrl` when provided. The return logic was also refactored so that the modified HTML is returned whenever either the logo or favicon is changed.

- **Tests**: Added test coverage for favicon replacement, including scenarios where only the favicon is set, both logo and favicon are set, and neither is set (ensuring no unintended modifications). The test helper was also updated to accept an HTML string parameter.
<!-- kody-pr-summary:end -->