### PR TITLE
fix(core/vite): remove dead stripNonCriticalPreloadsPlugin

### DIFF
--- a/libs/portal-framework-core/src/vite/vite-config.ts
+++ b/libs/portal-framework-core/src/vite/vite-config.ts
@@ -61,39 +61,6 @@ function extractBase64ImagesPlugin(): Plugin {
   };
 }
 
-/**
- * MF injects modulepreload links for ALL shared modules into index.html,
- * including ones not needed on initial load (uppy, otpauth, qrcode, etc).
- * This plugin strips preloads for non-critical shared chunks so they only
- * load on-demand when their routes/components are actually visited.
- * Critical chunks (framework-core, react-dom, refinedev, etc.) are kept
- * because they're statically imported by the entry chunk anyway.
- */
-function stripNonCriticalPreloadsPlugin(): Plugin {
-  const NON_CRITICAL = [
-    "uppy",
-    "otpauth",
-    "qrcode",
-    "tanstack_mf_1_react_mf_2_table",
-    "refinedev_mf_1_react_mf_2_router",
-  ];
-  return {
-    name: "strip-non-critical-preloads",
-    enforce: "post",
-    generateBundle(_options, bundle) {
-      const html = bundle["index.html"];
-      if (!html || html.type !== "asset") return;
-      let source = typeof html.source === "string" ? html.source : new TextDecoder().decode(html.source as Uint8Array);
-      source = source.replace(
-        /<link\s+rel="modulepreload"[^>]*href="([^"]+)"[^>]*>/g,
-        (match, href: string) =>
-          NON_CRITICAL.some((p) => href.includes(p)) ? "" : match,
-      );
-      (html as any).source = source;
-    },
-  };
-}
-
 /** Shared build config fields for both host and plugin */
 function createBuildConfig(opts: ConfigOptions) {
   return {
@@ -166,7 +133,6 @@ function createHostConfig(opts: ConfigOptions) {
     createHostFederationConfig(opts, resolvedRuntimePlugins),
     localhostAccessPlugin(),
     extractBase64ImagesPlugin(),
-    stripNonCriticalPreloadsPlugin(),
     ...(opts.plugins?.map((plugin) =>
       createPluginFederationConfig(
         plugin,


### PR DESCRIPTION
## Summary

Remove `stripNonCriticalPreloadsPlugin` from `vite-config.ts`.

The plugin was dead code. It matched against generated chunk names like `uppy`, `otpauth`, `qrcode`, `tanstack_mf_1_react_mf_2_table`, and `refinedev_mf_1_react_mf_2_router`, but the actual MF modulepreload link filenames use MF's internal naming convention (`_virtual_mf___mfe_internal__dashboard__loadShare__...`). None of the `NON_CRITICAL` patterns matched any of the 11 actual preloads in the built output, so the plugin was stripping zero links.

## Test Plan
- [x] Build passes: 40/40 turbo tasks, 44.9s
- [x] Verified 11 modulepreload links in built `index.html` — none matched the plugin's `NON_CRITICAL` patterns

---

<!-- kody-pr-summary:start -->
## Description

This PR removes the `stripNonCriticalPreloadsPlugin` from the Vite configuration, which was previously responsible for stripping modulepreload links for non-critical shared chunks (such as uppy, otpauth, qrcode, etc.) from the generated `index.html` during the build process.

The plugin was designed to prevent unnecessary preloading of shared modules that aren't needed on initial load, allowing them to load on-demand when their routes/components are actually visited. However, this code is being removed as it is no longer needed (dead code).

**Changes:**
- Removed the `stripNonCriticalPreloadsPlugin` function definition
- Removed the plugin from the host Vite configuration pipeline in `createHostConfig`

This simplifies the build configuration by eliminating a custom Vite plugin that is no longer serving its intended purpose.
<!-- kody-pr-summary:end -->