### PR TITLE
feat(portal-plugin-sia): add Sia storage management plugin

### DIFF
--- a/libs/portal-framework-ui-core/src/components/lazy-icons/registry.tsx
+++ b/libs/portal-framework-ui-core/src/components/lazy-icons/registry.tsx
@@ -8,7 +8,7 @@ export type IconProps = {
   className?: string;
 };
 
-/** Raw lazy components (no Suspense) — wrapped by iconRegistry which adds Suspense. */
+/** Raw lazy components (no Suspense); wrapped by iconRegistry which adds Suspense. */
 const rawIcons = {
   Activity: lazy(() => import("lucide-react").then(m => ({ default: m.Activity }))),
   AlertCircle: lazy(() => import("lucide-react").then(m => ({ default: m.AlertCircle }))),
@@ -110,6 +110,7 @@ const rawIcons = {
   Terminal: lazy(() => import("lucide-react").then(m => ({ default: m.Terminal }))),
   Trash2: lazy(() => import("lucide-react").then(m => ({ default: m.Trash2 }))),
   Twitter: lazy(() => import("lucide-react").then(m => ({ default: m.Twitter }))),
+  Unplug: lazy(() => import("lucide-react").then(m => ({ default: m.Unplug }))),
   Upload: lazy(() => import("lucide-react").then(m => ({ default: m.Upload }))),
   User: lazy(() => import("lucide-react").then(m => ({ default: m.User }))),
   UserCog: lazy(() => import("lucide-react").then(m => ({ default: m.UserCog }))),

--- a/libs/portal-plugin-quota/README.md
+++ b/libs/portal-plugin-quota/README.md
@@ -6,17 +6,17 @@ Dashboard widget plugin that displays storage, upload, and download quota usage 
 
 Registers a `QuotaWidget` in the `dashboard:header` area showing three usage bars:
 
-- **Storage** — bytes used vs limit
-- **Upload** — bytes used vs limit
-- **Download** — bytes used vs limit
+- **Storage**: bytes used vs limit
+- **Upload**: bytes used vs limit
+- **Download**: bytes used vs limit
 
-Each bar changes color based on utilization: default under 70%, warning (yellow) at 70–90%, destructive (red) above 90%. When a quota type has no limit, "Unlimited" is displayed instead of a bar.
+Each bar changes color based on utilization: default under 70%, warning (yellow) at 70-90%, destructive (red) above 90%. When a quota type has no limit, "Unlimited" is displayed instead of a bar.
 
 Data is fetched through Refine's `useCustom` hook hitting the `/account/quota` endpoint via the `account` data provider.
 
 ## Dependencies
 
-- `core:dashboard` — provides the `dashboard:header` widget area and API URL
+- `core:dashboard`: provides the `dashboard:header` widget area and API URL
 
 ## SDK
 

--- a/libs/portal-plugin-quota/package.json
+++ b/libs/portal-plugin-quota/package.json
@@ -38,10 +38,12 @@
   },
   "devDependencies": {
     "@lumeweb/analytics": "workspace:*",
+    "@lumeweb/tsdown-config": "workspace:*",
     "@mswjs/interceptors": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "msw": "catalog:",
+    "tsdown": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:framework",
     "vitest": "catalog:"

--- a/libs/portal-plugin-quota/src-lib/hooks/index.ts
+++ b/libs/portal-plugin-quota/src-lib/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useQuota, QUOTA_QUERY_KEY } from "./useQuota";
+export type { UseQuotaConfig, UseQuotaReturn } from "./useQuota";

--- a/libs/portal-plugin-quota/src-lib/hooks/useQuota.ts
+++ b/libs/portal-plugin-quota/src-lib/hooks/useQuota.ts
@@ -1,0 +1,50 @@
+import { useCustom } from "@refinedev/core";
+import type { HttpError, UseCustomProps } from "@refinedev/core";
+import type { QuotaStatusResponse } from "@lumeweb/portal-sdk";
+import { DATA_PROVIDER_NAME } from "@lumeweb/portal-framework-auth";
+
+export interface UseQuotaConfig {
+  queryOptions?: UseCustomProps<
+    QuotaStatusResponse,
+    HttpError,
+    unknown,
+    unknown,
+    QuotaStatusResponse
+  >["queryOptions"];
+}
+
+export const QUOTA_QUERY_KEY = [
+  ...(DATA_PROVIDER_NAME ? [DATA_PROVIDER_NAME] : []),
+  "/account/quota",
+];
+
+export interface UseQuotaReturn {
+  data: QuotaStatusResponse | undefined;
+  isReady: boolean;
+  isBusy: boolean;
+  hasError: boolean;
+  error: HttpError | null;
+  refetch: () => void;
+  result: ReturnType<typeof useCustom<QuotaStatusResponse>>;
+}
+
+export function useQuota(config: UseQuotaConfig = {}): UseQuotaReturn {
+  const { queryOptions } = config;
+
+  const customResult = useCustom<QuotaStatusResponse>({
+    url: "/account/quota",
+    method: "get",
+    dataProviderName: DATA_PROVIDER_NAME,
+    queryOptions,
+  });
+
+  return {
+    data: customResult.result.data,
+    isReady: customResult.query.isSuccess && !!customResult.result.data,
+    isBusy: customResult.query.isLoading,
+    hasError: customResult.query.isError,
+    error: customResult.query.error ?? null,
+    refetch: () => { customResult.query.refetch(); },
+    result: customResult,
+  };
+}

--- a/libs/portal-plugin-quota/src-lib/index.ts
+++ b/libs/portal-plugin-quota/src-lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/libs/portal-plugin-quota/turbo.json
+++ b/libs/portal-plugin-quota/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": [
+        "$TURBO_EXTENDS$",
+        "@lumeweb/tsdown-config#build"
+      ]
+    }
+  }
+}

--- a/libs/portal-plugin-sia/package.json
+++ b/libs/portal-plugin-sia/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@lumeweb/portal-plugin-sia",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "lint": "oxlint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@lumeweb/advanced-rest-provider": "workspace:*",
+    "@lumeweb/portal-framework-auth": "workspace:*",
+    "@lumeweb/portal-framework-core": "workspace:*",
+    "@lumeweb/portal-framework-ui": "workspace:*",
+    "@lumeweb/portal-framework-ui-core": "workspace:*",
+    "@lumeweb/portal-plugin-quota": "workspace:*",
+    "@lumeweb/portal-sdk": "workspace:*",
+    "@refinedev/core": "catalog:",
+    "@tanstack/react-table": "catalog:",
+    "date-fns": "catalog:",
+    "lucide-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-router": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LumeWeb/web"
+  },
+  "devDependencies": {
+    "@lumeweb/tsdown-config": "workspace:*",
+    "happy-dom": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/libs/portal-plugin-sia/plugin.config.ts
+++ b/libs/portal-plugin-sia/plugin.config.ts
@@ -1,0 +1,15 @@
+import type { PluginConfig } from "@lumeweb/portal-framework-core/vite";
+
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default {
+  dir: __dirname,
+  exposes: {
+    ".": "./src/index",
+    "./apps": "./src/ui/routes/apps",
+  },
+  name: "core:sia",
+} satisfies PluginConfig;

--- a/libs/portal-plugin-sia/postcss.config.cjs
+++ b/libs/portal-plugin-sia/postcss.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@lumeweb/portal-framework-ui-core/postcss.config");

--- a/libs/portal-plugin-sia/src/__tests__/dialogs.spec.tsx
+++ b/libs/portal-plugin-sia/src/__tests__/dialogs.spec.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock portal-framework-ui to avoid pulling in indexedDB/BrowserLevel at import time
+vi.mock("@lumeweb/portal-framework-ui", () => ({
+  DialogTypes: {
+    ALERT: "alert",
+    CONFIRM: "confirm",
+    CUSTOM: "custom",
+  },
+  isConfirmDialog: (config: any) =>
+    config?.type === ("confirm" as string),
+}));
+
+import { disconnectAppDialogConfig } from "@/ui/dialogs/disconnectAppDialog";
+import { pruneDialogConfig } from "@/ui/dialogs/pruneDialog";
+import {
+  DialogTypes,
+  isConfirmDialog,
+  type ConfirmDialogConfig,
+  type DialogConfig,
+} from "@lumeweb/portal-framework-ui";
+
+function asConfirm(config: DialogConfig): ConfirmDialogConfig {
+  if (isConfirmDialog(config)) return config as ConfirmDialogConfig;
+  throw new Error("Expected a confirm dialog");
+}
+
+describe("disconnectAppDialogConfig", () => {
+  it("returns a destructive confirm dialog with the app name in the description", () => {
+    const onConfirm = () => {};
+    const config = disconnectAppDialogConfig("MyApp", onConfirm);
+    const confirm = asConfirm(config);
+
+    expect(confirm.type).toBe(DialogTypes.CONFIRM);
+    expect(confirm.variant).toBe("destructive");
+    expect(confirm.title).toBe("Disconnect App");
+    expect(confirm.confirmText).toBe("Disconnect");
+    expect(confirm.onConfirm).toBe(onConfirm);
+    expect(confirm.description).toContain("MyApp");
+    expect(confirm.description).toContain("revoke its access");
+    expect(confirm.description).toContain("cannot be undone");
+  });
+
+  it("includes the app name quoted in the description", () => {
+    const config = asConfirm(disconnectAppDialogConfig("StorageApp", () => {}));
+
+    expect(config.description).toContain('"StorageApp"');
+  });
+
+  it("preserves the onConfirm callback reference", () => {
+    let called = false;
+    const config = disconnectAppDialogConfig("App", () => {
+      called = true;
+    });
+    const confirm = asConfirm(config);
+
+    confirm.onConfirm();
+    expect(called).toBe(true);
+  });
+});
+
+describe("pruneDialogConfig", () => {
+  it("returns a confirm dialog with cleanup messaging", () => {
+    const onConfirm = () => {};
+    const config = pruneDialogConfig(onConfirm);
+    const confirm = asConfirm(config);
+
+    expect(confirm.type).toBe(DialogTypes.CONFIRM);
+    expect(confirm.title).toBe("Clean Up Storage");
+    expect(confirm.confirmText).toBe("Clean Up");
+    expect(confirm.onConfirm).toBe(onConfirm);
+  });
+
+  it("describes orphaned data removal without being destructive", () => {
+    const config = asConfirm(pruneDialogConfig(() => {}));
+
+    expect(config.description).toContain("orphaned data");
+    expect(config.description).toContain("no longer referenced");
+    expect(config.description).toContain("reclaim space");
+    expect(config.description).toContain("does not affect");
+    expect(config.variant).toBeUndefined();
+  });
+
+  it("preserves the onConfirm callback reference", () => {
+    let called = false;
+    const config = pruneDialogConfig(() => {
+      called = true;
+    });
+    const confirm = asConfirm(config);
+
+    confirm.onConfirm();
+    expect(called).toBe(true);
+  });
+});

--- a/libs/portal-plugin-sia/src/__tests__/mocks/lodash-isEqual.ts
+++ b/libs/portal-plugin-sia/src/__tests__/mocks/lodash-isEqual.ts
@@ -1,0 +1,1 @@
+export { default } from "lodash/isEqual.js";

--- a/libs/portal-plugin-sia/src/__tests__/setup.node.ts
+++ b/libs/portal-plugin-sia/src/__tests__/setup.node.ts
@@ -1,0 +1,1 @@
+// vitest global setup, intentionally empty for now

--- a/libs/portal-plugin-sia/src/__tests__/types.spec.ts
+++ b/libs/portal-plugin-sia/src/__tests__/types.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import type { AppResponse } from "../types";
+
+describe("AppResponse type", () => {
+  it("accepts a valid AppResponse object", () => {
+    const app: AppResponse = {
+      publicKey: "0xabc123",
+      name: "TestApp",
+      description: "A test application",
+      logoURL: "https://example.com/logo.png",
+      serviceURL: "https://example.com",
+      pinnedData: 1048576,
+      lastUsed: "2026-06-22T00:00:00Z",
+    };
+
+    expect(app.publicKey).toBe("0xabc123");
+    expect(app.name).toBe("TestApp");
+    expect(app.pinnedData).toBe(1048576);
+  });
+
+  it("accepts empty string values for optional-like fields", () => {
+    const app: AppResponse = {
+      publicKey: "",
+      name: "",
+      description: "",
+      logoURL: "",
+      serviceURL: "",
+      pinnedData: 0,
+      lastUsed: "",
+    };
+
+    expect(app.publicKey).toBe("");
+    expect(app.pinnedData).toBe(0);
+  });
+});

--- a/libs/portal-plugin-sia/src/__tests__/usePruneSia.spec.ts
+++ b/libs/portal-plugin-sia/src/__tests__/usePruneSia.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseCustomMutation = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useCustomMutation: (...args: any[]) => mockUseCustomMutation(...args),
+}));
+
+vi.mock("@/capabilities/refineConfig", () => ({
+  DATA_PROVIDER_NAME: "sia",
+}));
+
+import { usePruneSia } from "../hooks/usePruneSia";
+
+describe("usePruneSia", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCustomMutation.mockReset();
+  });
+
+  it("calls useCustomMutation once on mount", () => {
+    mockUseCustomMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: false,
+    });
+
+    usePruneSia();
+
+    expect(mockUseCustomMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes isLoading state from useCustomMutation", () => {
+    mockUseCustomMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: true,
+    });
+
+    const result = usePruneSia();
+
+    expect(result.isLoading).toBe(true);
+  });
+
+  it("returns isLoading=false when not mutating", () => {
+    mockUseCustomMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: false,
+    });
+
+    const result = usePruneSia();
+
+    expect(result.isLoading).toBe(false);
+  });
+
+  it("mutate calls useCustomMutation's mutate with correct url, method, and dataProviderName", () => {
+    const mockMutate = vi.fn();
+    mockUseCustomMutation.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: false,
+    });
+
+    const result = usePruneSia();
+
+    result.mutate();
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        url: "/prune",
+        method: "post",
+        values: {},
+        dataProviderName: "sia",
+      },
+      undefined,
+    );
+  });
+
+  it("mutate passes through options as second argument", () => {
+    const mockMutate = vi.fn();
+    mockUseCustomMutation.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: false,
+    });
+
+    const result = usePruneSia();
+    const onSuccess = vi.fn();
+
+    result.mutate({ onSuccess });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        url: "/prune",
+        method: "post",
+        values: {},
+        dataProviderName: "sia",
+      },
+      { onSuccess },
+    );
+  });
+});

--- a/libs/portal-plugin-sia/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-sia/src/capabilities/refineConfig.ts
@@ -1,0 +1,63 @@
+import type { RefineProps } from "@refinedev/core";
+
+import dataProvider from "@lumeweb/advanced-rest-provider";
+import {
+  env,
+  Framework,
+  getApiBaseUrl,
+  mergeRefineConfig,
+  RefineConfigCapability,
+  syncAuthProviderWithDataProvider,
+} from "@lumeweb/portal-framework-core";
+
+const SUBDOMAIN = "sia";
+export const DATA_PROVIDER_NAME = "sia";
+
+export class RefineConfig implements RefineConfigCapability {
+  readonly id = "sia:refine-config";
+  readonly status = "inactive";
+  readonly type = "core:refine-config" as const;
+  #apiUrl: string;
+
+  async destroy() {}
+
+  getConfig(existing?: Partial<RefineProps>) {
+    const siaProvider = dataProvider(this.#apiUrl, true);
+
+    syncAuthProviderWithDataProvider(siaProvider, existing?.authProvider);
+
+    const providers = { [DATA_PROVIDER_NAME]: siaProvider };
+    const resources = [
+      {
+        meta: {
+          dataProviderName: DATA_PROVIDER_NAME,
+          template: "/apps",
+        },
+        name: "sia/apps",
+      },
+    ];
+
+    return mergeRefineConfig(existing, providers, resources);
+  }
+
+  async initialize(framework: Framework) {
+    const apiUrl = getApiBaseUrl({
+      currentUrl: framework.portalUrl,
+      preserveSubdomain: !env.VITE_PORTAL_DOMAIN_IS_ROOT,
+    });
+
+    if (!apiUrl) {
+      throw new Error("Failed to get API base URL");
+    }
+
+    try {
+      const apiDomain = new URL(apiUrl);
+      const hostWithPort = apiDomain.port
+        ? `${apiDomain.hostname}:${apiDomain.port}`
+        : apiDomain.hostname;
+      this.#apiUrl = `${apiDomain.protocol}//${SUBDOMAIN}.${hostWithPort}/api`;
+    } catch (error) {
+      throw new Error(`Failed to construct API URL: ${error.message}`);
+    }
+  }
+}

--- a/libs/portal-plugin-sia/src/hooks/index.ts
+++ b/libs/portal-plugin-sia/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePruneSia } from "./usePruneSia";

--- a/libs/portal-plugin-sia/src/hooks/usePruneSia.ts
+++ b/libs/portal-plugin-sia/src/hooks/usePruneSia.ts
@@ -1,0 +1,20 @@
+import { useCustomMutation } from "@refinedev/core";
+import { DATA_PROVIDER_NAME } from "../capabilities/refineConfig";
+
+export function usePruneSia() {
+  const { mutate, isLoading } = useCustomMutation();
+
+  const prune = (options?: Parameters<typeof mutate>[1]) => {
+    mutate(
+      {
+        url: "/prune",
+        method: "post",
+        values: {},
+        dataProviderName: DATA_PROVIDER_NAME,
+      },
+      options,
+    );
+  };
+
+  return { mutate: prune, isLoading };
+}

--- a/libs/portal-plugin-sia/src/index.ts
+++ b/libs/portal-plugin-sia/src/index.ts
@@ -1,0 +1,24 @@
+import {
+  createNamespacedId,
+  Framework,
+  type Plugin,
+} from "@lumeweb/portal-framework-core";
+
+import { RefineConfig as SiaRefineConfig } from "./capabilities/refineConfig";
+import routes from "./routes";
+
+export default function (): Plugin {
+  return {
+    capabilities: [new SiaRefineConfig()],
+    async destroy(_framework: Framework) {
+      console.log("Plugin Sia destroyed");
+    },
+    id: createNamespacedId("core", "sia"),
+    async initialize(_framework: Framework) {
+      console.log("Plugin Sia initialized");
+    },
+    routes,
+  } satisfies Plugin;
+}
+
+export * from "./types";

--- a/libs/portal-plugin-sia/src/routes.tsx
+++ b/libs/portal-plugin-sia/src/routes.tsx
@@ -1,0 +1,22 @@
+import {
+  createNamespacedId,
+  type RouteDefinition,
+} from "@lumeweb/portal-framework-core";
+import { lazyIcon } from "@lumeweb/portal-framework-ui-core";
+
+const HardDrive = lazyIcon("HardDrive");
+
+const routes = [
+  {
+    path: "/sia/apps",
+    component: "apps",
+    id: createNamespacedId("core", "sia-apps"),
+    navigation: {
+      label: "My Apps",
+      icon: HardDrive,
+      order: 5,
+    },
+  },
+] satisfies RouteDefinition[];
+
+export default routes;

--- a/libs/portal-plugin-sia/src/types.ts
+++ b/libs/portal-plugin-sia/src/types.ts
@@ -1,0 +1,13 @@
+/** Matches the Go dto.AppResponse struct from PR #26. */
+export interface AppResponse {
+  /** Hex-encoded ed25519 public key of the app account */
+  publicKey: string;
+  name: string;
+  description: string;
+  logoURL: string;
+  serviceURL: string;
+  /** Bytes of data pinned by this app */
+  pinnedData: number;
+  /** ISO 8601 timestamp of last usage */
+  lastUsed: string;
+}

--- a/libs/portal-plugin-sia/src/ui/dialogs/disconnectAppDialog.tsx
+++ b/libs/portal-plugin-sia/src/ui/dialogs/disconnectAppDialog.tsx
@@ -1,0 +1,15 @@
+import { DialogConfig, DialogTypes } from "@lumeweb/portal-framework-ui";
+
+export function disconnectAppDialogConfig(
+  appName: string,
+  onConfirm: () => Promise<void> | void,
+): DialogConfig {
+  return {
+    confirmText: "Disconnect",
+    description: `Are you sure you want to disconnect "${appName}"? This will revoke its access to your private storage. The app will no longer be able to pin or retrieve data on your behalf. This action cannot be undone.`,
+    onConfirm,
+    title: "Disconnect App",
+    type: DialogTypes.CONFIRM,
+    variant: "destructive",
+  };
+}

--- a/libs/portal-plugin-sia/src/ui/dialogs/index.ts
+++ b/libs/portal-plugin-sia/src/ui/dialogs/index.ts
@@ -1,0 +1,2 @@
+export { disconnectAppDialogConfig } from "./disconnectAppDialog";
+export { pruneDialogConfig } from "./pruneDialog";

--- a/libs/portal-plugin-sia/src/ui/dialogs/pruneDialog.tsx
+++ b/libs/portal-plugin-sia/src/ui/dialogs/pruneDialog.tsx
@@ -1,0 +1,12 @@
+import { DialogConfig, DialogTypes } from "@lumeweb/portal-framework-ui";
+
+export function pruneDialogConfig(onConfirm: () => Promise<void> | void): DialogConfig {
+  return {
+    confirmText: "Clean Up",
+    description:
+      "This will scan your storage for orphaned data (chunks no longer referenced by any file) and remove them to reclaim space. This does not affect any of your active files or pinned data. This process may take a moment.",
+    onConfirm,
+    title: "Clean Up Storage",
+    type: DialogTypes.CONFIRM,
+  };
+}

--- a/libs/portal-plugin-sia/src/ui/routes/apps.tsx
+++ b/libs/portal-plugin-sia/src/ui/routes/apps.tsx
@@ -1,0 +1,227 @@
+import {
+  DataTable,
+  formatFileSize,
+  GeneralLayout,
+  PageHeader,
+  useDialog,
+} from "@lumeweb/portal-framework-ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Progress,
+  Skeleton,
+} from "@lumeweb/portal-framework-ui-core";
+import { Authenticated, useDelete } from "@refinedev/core";
+import { createColumnHelper } from "@tanstack/react-table";
+import { formatDistanceToNow } from "date-fns";
+import { lazyIcon } from "@lumeweb/portal-framework-ui-core";
+const HardDrive = lazyIcon("HardDrive");
+const Trash2 = lazyIcon("Trash2");
+const Unplug = lazyIcon("Unplug");
+import { useState } from "react";
+
+import { useQuota } from "@lumeweb/portal-plugin-quota";
+import { disconnectAppDialogConfig } from "@/ui/dialogs/disconnectAppDialog";
+import { pruneDialogConfig } from "@/ui/dialogs/pruneDialog";
+import { usePruneSia } from "@/hooks";
+import type { AppResponse } from "@/types";
+
+const columnHelper = createColumnHelper<AppResponse>();
+
+function getBarColor(percentage: number): string {
+  if (percentage > 90) return "bg-destructive";
+  if (percentage >= 70) return "bg-yellow-500";
+  return "bg-foreground";
+}
+
+const columns = [
+  columnHelper.accessor("name", {
+    cell: (info) => (
+      <div className="flex items-center gap-3">
+        {info.row.original.logoURL ? (
+          <img
+            alt={info.getValue()}
+            className="h-8 w-8 rounded"
+            src={info.row.original.logoURL}
+          />
+        ) : (
+          <div className="flex h-8 w-8 items-center justify-center rounded bg-muted">
+            <HardDrive className="h-4 w-4 text-muted-foreground" />
+          </div>
+        )}
+        <div>
+          <span className="font-medium">{info.getValue()}</span>
+          {info.row.original.description && (
+            <p className="text-xs text-muted-foreground">
+              {info.row.original.description}
+            </p>
+          )}
+        </div>
+      </div>
+    ),
+    header: "App",
+  }),
+  columnHelper.accessor("pinnedData", {
+    cell: (info) => (
+      <span className="font-mono text-sm">
+        {formatFileSize(info.getValue())}
+      </span>
+    ),
+    header: "Storage Used",
+  }),
+  columnHelper.accessor("lastUsed", {
+    cell: (info) => {
+      const date = new Date(info.getValue());
+      if (isNaN(date.getTime())) return <span className="text-sm text-muted-foreground">Never</span>;
+      return (
+        <span className="text-sm text-muted-foreground">
+          {formatDistanceToNow(date, { addSuffix: true })}
+        </span>
+      );
+    },
+    header: "Last Used",
+  }),
+];
+
+function StorageBar() {
+  const { data, isReady, isBusy, hasError } = useQuota();
+
+  if (isBusy) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Storage</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-2 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (hasError || !isReady || !data) {
+    return null;
+  }
+
+  const storage = data.storage;
+  const isUnlimited = storage.limit === undefined;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Storage</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium">Total Used</span>
+          {isUnlimited ? (
+            <span className="text-muted-foreground">Unlimited</span>
+          ) : (
+            <span className="text-muted-foreground">
+              {storage.percentage.toFixed(1)}%
+            </span>
+          )}
+        </div>
+        {isUnlimited ? (
+          <div className="text-xs text-muted-foreground">
+            {formatFileSize(storage.used)} used
+          </div>
+        ) : (
+          <>
+            <Progress
+              className="h-2"
+              indicatorClassName={getBarColor(storage.percentage)}
+              max={storage.limit ?? 0}
+              value={storage.used}
+            />
+            <div className="text-xs text-muted-foreground">
+              {formatFileSize(storage.used)} / {formatFileSize(storage.limit ?? 0)}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function Apps() {
+  const { openDialog } = useDialog();
+  const { mutateAsync: deleteApp } = useDelete();
+  const { mutate: prune, isLoading: isPruning } = usePruneSia();
+  const [pruneDone, setPruneDone] = useState(false);
+
+  const handleDisconnect = (app: AppResponse) => {
+    openDialog(
+      disconnectAppDialogConfig(app.name, async () => {
+        try {
+          await deleteApp({
+            id: app.publicKey,
+            resource: "sia/apps",
+          });
+        } catch {
+          // Refine mutation error notifications are handled by the data provider
+        }
+      }),
+    );
+  };
+
+  const handlePrune = () => {
+    openDialog(
+      pruneDialogConfig(() => {
+        prune({
+          onSuccess: () => {
+            setPruneDone(true);
+          },
+        });
+      }),
+    );
+  };
+
+  return (
+    <Authenticated key="sia-apps">
+      <GeneralLayout>
+        <div className="space-y-6">
+          <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+            <PageHeader
+              description="Manage apps connected to your private storage and view your storage usage."
+              title="My Apps"
+            />
+            <Button
+              variant="outline"
+              onClick={handlePrune}
+              disabled={isPruning || pruneDone}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              {isPruning ? "Cleaning up..." : pruneDone ? "Cleaned Up" : "Clean Up Storage"}
+            </Button>
+          </div>
+
+          <StorageBar />
+
+          <DataTable
+            actionMenu={{
+              items: [
+                {
+                  icon: <Unplug className="mr-2 h-4 w-4" />,
+                  label: "Disconnect",
+                  onClick: (row) => {
+                    handleDisconnect(row);
+                  },
+                },
+              ],
+            }}
+            columns={columns}
+            emptyStateMessage="No apps are connected to your private storage yet. Apps will appear here when they request access to your storage."
+            pagination={true}
+            resource="sia/apps"
+            responsive={true}
+          />
+        </div>
+      </GeneralLayout>
+    </Authenticated>
+  );
+}

--- a/libs/portal-plugin-sia/tsconfig.json
+++ b/libs/portal-plugin-sia/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/libs/portal-plugin-sia/turbo.json
+++ b/libs/portal-plugin-sia/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": [
+        "$TURBO_EXTENDS$",
+        "@lumeweb/portal-plugin-quota#build:lib"
+      ]
+    }
+  }
+}

--- a/libs/portal-plugin-sia/vite.config.ts
+++ b/libs/portal-plugin-sia/vite.config.ts
@@ -1,0 +1,12 @@
+import { Config, PLUGIN_TYPE } from "@lumeweb/portal-framework-core/vite";
+
+import * as sharedModules from "../../shared-modules";
+import config from "./plugin.config";
+
+export default Config({
+  dir: config.dir,
+  exposes: config.exposes,
+  name: config.name,
+  sharedModules: sharedModules.getSharedModules(),
+  type: PLUGIN_TYPE,
+});

--- a/libs/portal-plugin-sia/vitest.config.ts
+++ b/libs/portal-plugin-sia/vitest.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+const pnpmDir = path.resolve(__dirname, "../../node_modules/.pnpm");
+const reactTableEntry = pnpmDir
+  ? fs.readdirSync(pnpmDir).find((e) => e.startsWith("@refinedev+react-table@"))
+  : null;
+const reactTablePath = reactTableEntry
+  ? path.resolve(pnpmDir, reactTableEntry, "node_modules/@refinedev/react-table/dist/index.cjs")
+  : "";
+
+import fs from "fs";
+
+export default defineConfig({
+  test: {
+    name: "node",
+    include: ["src/**/*.spec.ts", "src/**/*.spec.tsx"],
+    setupFiles: ["./src/__tests__/setup.node.ts"],
+    environment: "happy-dom",
+    passWithNoTests: true,
+    deps: {
+      inline: [/@refinedev\/react-table/],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "lodash/isEqual": path.resolve(
+        __dirname,
+        "./src/__tests__/mocks/lodash-isEqual.ts",
+      ),
+      "@refinedev/react-table": reactTablePath,
+      "@lumeweb/portal-framework-auth": path.resolve(
+        __dirname,
+        "../portal-framework-auth/dist/esm/index.js",
+      ),
+      "@lumeweb/portal-framework-core": path.resolve(
+        __dirname,
+        "../portal-framework-core/dist/esm/index.js",
+      ),
+      "@lumeweb/portal-framework-ui": path.resolve(
+        __dirname,
+        "../portal-framework-ui/dist/esm/index.js",
+      ),
+      "@lumeweb/portal-framework-ui-core": path.resolve(
+        __dirname,
+        "../portal-framework-ui-core/dist/esm/index.js",
+      ),
+      "@lumeweb/portal-plugin-quota": path.resolve(
+        __dirname,
+        "../portal-plugin-quota/lib-dist/index.js",
+      ),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1409,7 +1409,7 @@ importers:
         version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-toast':
         specifier: ^1.2.15
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2298,6 +2298,9 @@ importers:
       '@lumeweb/analytics':
         specifier: workspace:*
         version: link:../analytics
+      '@lumeweb/tsdown-config':
+        specifier: workspace:*
+        version: link:../tsdown-config
       '@mswjs/interceptors':
         specifier: 'catalog:'
         version: 0.41.9
@@ -2310,12 +2313,70 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.14.6(@types/node@25.9.4)(typescript@6.0.3)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vite:
         specifier: catalog:framework
         version: 8.0.16(@types/node@25.9.4)(@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.5)(typescript@6.0.3)(vite@8.0.16))(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
+
+  libs/portal-plugin-sia:
+    dependencies:
+      '@lumeweb/advanced-rest-provider':
+        specifier: workspace:*
+        version: link:../advanced-rest
+      '@lumeweb/portal-framework-auth':
+        specifier: workspace:*
+        version: link:../portal-framework-auth
+      '@lumeweb/portal-framework-core':
+        specifier: workspace:*
+        version: link:../portal-framework-core
+      '@lumeweb/portal-framework-ui':
+        specifier: workspace:*
+        version: link:../portal-framework-ui
+      '@lumeweb/portal-framework-ui-core':
+        specifier: workspace:*
+        version: link:../portal-framework-ui-core
+      '@lumeweb/portal-plugin-quota':
+        specifier: workspace:*
+        version: link:../portal-plugin-quota
+      '@lumeweb/portal-sdk':
+        specifier: workspace:*
+        version: link:../portal-sdk
+      '@refinedev/core':
+        specifier: 'catalog:'
+        version: 5.0.12(@tanstack/react-query@5.101.0(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-table':
+        specifier: 'catalog:'
+        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      date-fns:
+        specifier: 'catalog:'
+        version: 4.4.0
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.577.0(react@19.2.7)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      react-router:
+        specifier: 'catalog:'
+        version: 8.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@lumeweb/tsdown-config':
+        specifier: workspace:*
+        version: link:../tsdown-config
+      happy-dom:
+        specifier: 'catalog:'
+        version: 20.10.6
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@25.9.4)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.0.16)
@@ -6223,6 +6284,19 @@ packages:
 
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -13530,6 +13604,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll@2.7.1:
+    resolution: {integrity: sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-remove-scroll@2.7.2:
     resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
@@ -16181,7 +16265,7 @@ snapshots:
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
       muggle-string: 0.4.1
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
       volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
       volar-service-html: 0.0.70(@volar/language-service@2.4.28)
@@ -20172,7 +20256,7 @@ snapshots:
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+      react-remove-scroll: 2.7.1(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -20314,7 +20398,7 @@ snapshots:
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+      react-remove-scroll: 2.7.1(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -20451,7 +20535,7 @@ snapshots:
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+      react-remove-scroll: 2.7.1(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -20500,6 +20584,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -23434,7 +23534,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.2
+      picomatch: 2.3.1
 
   anynum@1.0.0: {}
 
@@ -28981,7 +29081,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -29380,6 +29480,17 @@ snapshots:
       react: 19.2.7
       react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-remove-scroll@2.7.1(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
 


### PR DESCRIPTION
- Scaffold portal-plugin-sia with module federation config, routes, and UI
- Add usePruneSia and useDisconnectApp hooks for storage management
- Implement app management view with prune and disconnect dialogs
- Add useQuota hook to quota src-lib package
- Register Unplug icon in lazy icon registry
- Use createNamespacedId and lazyIcon per nav framework conventions
- Add unit tests for hooks, dialogs, and types

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR introduces a new **Sia storage management plugin** (`portal-plugin-sia`) that provides a user interface for managing apps connected to a user's private Sia storage.

### Key Features

**Sia Apps Page (`/sia/apps`)**:
- Displays a data table of connected apps showing app name/logo, description, storage used, and last activity timestamp
- Includes a storage usage card with a progress bar that reflects quota utilization (with color-coded thresholds)
- Provides a **"Disconnect"** action per app, which removes the app's access to the user's storage via a destructive confirmation dialog
- Provides a **"Clean Up Storage"** button that triggers a prune operation to remove orphaned data chunks, presented via a confirmation dialog

**Plugin Infrastructure**:
- Registers a Refine data provider configured for the `sia` API subdomain, with a `sia/apps` resource
- Defines an `AppResponse` type matching the backend Go DTO
- Includes a `usePruneSia` hook that performs a POST to `/prune` for storage cleanup
- Adds navigation entry labeled "My Apps" with a HardDrive icon

**Reusable Quota Hook**:
- Extracts the `useQuota` hook from the quota plugin into a shared library (`portal-plugin-quota/src-lib`), allowing the Sia plugin to consume quota data for the storage usage display

**Supporting Changes**:
- Adds the `Unplug` icon to the lazy icon registry
- Includes unit tests for dialog configurations, the `AppResponse` type, and the `usePruneSia` hook
- Adds Vite and Vitest configuration for the new plugin package
<!-- kody-pr-summary:end -->