### PR TITLE
feat: add configurable loading messages to brand schema

### DIFF
--- a/apps/portal-app-shell/src/loader.ts
+++ b/apps/portal-app-shell/src/loader.ts
@@ -18,7 +18,9 @@ class AppLoader {
   #loadingMessage: HTMLElement = document.querySelector(".loading-message")!;
   #loadingOverlay: HTMLElement = document.querySelector(".loading-overlay")!;
   #messageInterval: null | ReturnType<typeof setInterval> = null;
-  #messages = env.VITE_PORTAL_BRAND?.loadingMessages ?? DEFAULT_MESSAGES;
+  #messages = env.VITE_PORTAL_BRAND?.loadingMessages?.length
+    ? env.VITE_PORTAL_BRAND.loadingMessages
+    : DEFAULT_MESSAGES;
   #previousMessageIndex: number | null = null;
   constructor() {
     this.#init();

--- a/apps/portal-app-shell/src/loader.ts
+++ b/apps/portal-app-shell/src/loader.ts
@@ -1,20 +1,24 @@
+import { env } from "@lumeweb/portal-framework-core";
+
+const DEFAULT_MESSAGES = [
+  "Securing decentralized storage...",
+  "Verifying cryptographic keys...",
+  "Establishing privacy-first connections...",
+  "Loading distributed network protocols...",
+  "Encrypting user data workspace...",
+  "Initializing zero-knowledge architecture...",
+  "Configuring censorship-resistant services...",
+  "Setting up peer-to-peer infrastructure...",
+  "Preparing blockchain-verified storage...",
+  "Finalizing privacy-preserving setup...",
+];
+
 class AppLoader {
   #isComplete = false;
   #loadingMessage: HTMLElement = document.querySelector(".loading-message")!;
   #loadingOverlay: HTMLElement = document.querySelector(".loading-overlay")!;
   #messageInterval: null | ReturnType<typeof setInterval> = null;
-  #messages = [
-    "Securing decentralized storage...",
-    "Verifying cryptographic keys...",
-    "Establishing privacy-first connections...",
-    "Loading distributed network protocols...",
-    "Encrypting user data workspace...",
-    "Initializing zero-knowledge architecture...",
-    "Configuring censorship-resistant services...",
-    "Setting up peer-to-peer infrastructure...",
-    "Preparing blockchain-verified storage...",
-    "Finalizing privacy-preserving setup...",
-  ];
+  #messages = env.VITE_PORTAL_BRAND?.loadingMessages ?? DEFAULT_MESSAGES;
   #previousMessageIndex: number | null = null;
   constructor() {
     this.#init();

--- a/libs/portal-framework-core/src/env.ts
+++ b/libs/portal-framework-core/src/env.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 
 const brandSchema = z.object({
   faviconUrl: z.string().optional(),
+  loadingMessages: z.array(z.string()).optional(),
   logoUrl: z.string().optional(),
-  tagline: z.string().optional(),
   siteUrl: z.string().url().optional(),
   social: z
     .object({
@@ -13,6 +13,7 @@ const brandSchema = z.object({
       github: z.string().optional(),
     })
     .optional(),
+  tagline: z.string().optional(),
   values: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
- Add `loadingMessages` string array to the brand schema in `portal-framework-core`
- Update the app shell loader to read `loadingMessages` from the T3 env pipeline instead of raw `window.VITE_PORTAL_BRAND`, falling back to built-in defaults when not configured

---

<!-- kody-pr-summary:start -->
This PR adds the ability to configure custom loading screen messages through the brand environment configuration.

Previously, the loading messages displayed during app initialization were hardcoded within the `AppLoader` class. These messages are now extracted as default fallback values, and the loader reads from the `VITE_PORTAL_BRAND.loadingMessages` environment variable first, falling back to the defaults if not specified.

The brand schema in the portal framework core has been updated to include an optional `loadingMessages` field (an array of strings), allowing deployments to customize the loading messages to match their branding without modifying application code.
<!-- kody-pr-summary:end -->