### PR TITLE
fix(portal-plugin-sia): use framework:refine-config type

### DIFF
--- a/libs/portal-plugin-sia/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-sia/src/capabilities/refineConfig.ts
@@ -16,7 +16,7 @@ export const DATA_PROVIDER_NAME = "sia";
 export class RefineConfig implements RefineConfigCapability {
   readonly id = "sia:refine-config";
   readonly status = "inactive";
-  readonly type = "core:refine-config" as const;
+  readonly type = "framework:refine-config" as const;
   #apiUrl: string;
 
   async destroy() {}


### PR DESCRIPTION
## Summary
- Change the Sia refine-config capability type from `core:refine-config` to `framework:refine-config` to match what the framework looks up

---

<!-- kody-pr-summary:start -->
This pull request updates the capability type identifier for the SIA refine configuration in the `portal-plugin-sia` package. Specifically, it changes the `type` property of the `RefineConfig` class from `"core:refine-config"` to `"framework:refine-config"`. This ensures the SIA plugin's refine configuration is correctly recognized by the framework's capability system.
<!-- kody-pr-summary:end -->