### PR TITLE
feat: add navigation sections, descriptions, and route reorganization

### DIFF
--- a/libs/portal-framework-core/src/index.ts
+++ b/libs/portal-framework-core/src/index.ts
@@ -41,7 +41,7 @@ export {
 export { MockFrameworkProvider } from "./testing/MockFrameworkProvider";
 
 // Types
-export type { FeatureStatus, FrameworkFeature } from "./types/api";
+export type { FeatureDependency, FeatureStatus, FrameworkFeature } from "./types/api";
 export type {
   BaseCapability,
   CapabilityStatus,
@@ -50,6 +50,7 @@ export type {
 } from "./types/capabilities";
 export type { NavigationFeature } from "./types/features";
 export type {
+  NavigationBadge,
   NavigationItem,
   NavigationItemIconProps,
   RouteDefinition,

--- a/libs/portal-framework-core/src/types/navigation.ts
+++ b/libs/portal-framework-core/src/types/navigation.ts
@@ -23,6 +23,10 @@ export interface NavigationItem {
    */
   disabled?: boolean;
   /**
+   * Optional description shown as a tooltip on hover
+   */
+  description?: string;
+  /**
    * If true, will force this item to appear in navigation even if it's an index route
    */
   forceShowInNavigation?: boolean;
@@ -54,6 +58,12 @@ export interface NavigationItem {
    * Sort order relative to sibling items (lower numbers come first)
    */
   order?: number;
+  /**
+   * Section name for visual grouping in the navigation sidebar.
+   * Items with the same section are grouped together under a header.
+   * Omit for the default (unlabeled) section.
+   */
+  section?: string;
   /**
    * ID of parent navigation item for hierarchical structures
    */

--- a/libs/portal-framework-ui/src/components/MainNavigation.tsx
+++ b/libs/portal-framework-ui/src/components/MainNavigation.tsx
@@ -28,16 +28,29 @@ export const MainNavigation: React.FC<MenuProps> = ({
   const resetKey = typeof onItemClick === "function" ? pathname : undefined;
 
   const renderSection = (group: NavigationGroup, sectionIndex: number) => {
-    if (group.section === null) {
+    // Suppress section header when the section is the single item (section name
+    // matches the item's id suffix, e.g. section "Private Data" with id
+    // "core:private-data" — the item IS the section, header would be redundant).
+    const suppressHeader =
+      group.section === null ||
+      (group.items.length === 1 &&
+        group.items[0].id != null &&
+        group.items[0].id.split(":").pop() ===
+          group.section.toLowerCase().replace(/\s/g, "-"));
+    if (suppressHeader) {
       return (
-        <NavigationTreeRenderer
-          indent={false}
-          isOpen={isOpen}
+        <li
+          className={sectionIndex > 0 ? "mt-4" : undefined}
           key={`section-${sectionIndex}`}
-          onItemClick={onItemClick}
-          resetKey={resetKey}
-          tree={group.items}
-        />
+        >
+          <NavigationTreeRenderer
+            indent={false}
+            isOpen={isOpen}
+            onItemClick={onItemClick}
+            resetKey={resetKey}
+            tree={group.items}
+          />
+        </li>
       );
     }
 

--- a/libs/portal-framework-ui/src/components/NavigationTreeRenderer.spec.tsx
+++ b/libs/portal-framework-ui/src/components/NavigationTreeRenderer.spec.tsx
@@ -23,6 +23,10 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   TooltipContent: () => null,
   TooltipProvider: ({ children }: any) => <>{children}</>,
   TooltipTrigger: ({ children }: any) => <>{children}</>,
+  Popover: ({ children }: any) => <>{children}</>,
+  PopoverContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  PopoverTrigger: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  lazyIcon: () => () => null,
   cn: (...args: any[]) => args.filter(Boolean).join(" "),
 }));
 

--- a/libs/portal-framework-ui/src/components/NavigationTreeRenderer.tsx
+++ b/libs/portal-framework-ui/src/components/NavigationTreeRenderer.tsx
@@ -121,24 +121,33 @@ const NavItemContent: React.FC<BaseNavItemProps> = ({
 );
 
 /**
- * Tooltip wrapper for nav items. Always shows a tooltip — when collapsed
- * (labels hidden) it shows the full label, when expanded it shows the
- * tooltip on hover for any label that might be truncated.
+ * Tooltip wrapper for nav items. When collapsed (labels hidden) it shows
+ * the full label. When expanded, it shows the description on hover if one
+ * is available; otherwise shows the label for potential truncation.
  */
 const NavTooltip: React.FC<{
   label: string;
+  description?: string;
   isCollapsed: boolean;
   children: React.ReactElement;
-}> = ({ label, isCollapsed, children }) => (
-  <TooltipProvider delayDuration={isCollapsed ? 300 : 700}>
-    <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent side="right" className="font-medium">
-        {label}
-      </TooltipContent>
-    </Tooltip>
-  </TooltipProvider>
-);
+}> = ({ label, description, isCollapsed, children }) => {
+  // When collapsed, always show label. When expanded, only show tooltip
+  // if there's a description (for rich hover text) — label truncation
+  // tooltips are still useful so keep the label as fallback.
+  const content = isCollapsed ? label : (description ?? label);
+  return (
+    <TooltipProvider delayDuration={isCollapsed ? 300 : 700}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="block w-full">{children}</span>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="font-medium">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
 
 const LinkableNavItem: React.FC<BaseNavItemProps> = ({
   active,
@@ -207,7 +216,7 @@ const LeafNavItem: React.FC<{
 
   return (
     <li ref={ref}>
-      <NavTooltip isCollapsed={!isOpen} label={item.label}>
+      <NavTooltip isCollapsed={!isOpen} label={item.label} description={item.description}>
         {item.linkable !== false && Boolean(item.path) ? (
           <LinkableNavItem
             active={active}
@@ -433,37 +442,52 @@ const CollapseMenuRecursive: React.FC<{
       onOpenChange={setIsSectionOpen}
       open={isSectionOpen}
     >
-      <CollapsibleTrigger
-        asChild
-        className="mb-1 [&[data-state=open]>div>div>svg]:rotate-180"
-      >
-        <Button
-          className="h-9 w-full justify-start"
-          variant={active || childActive ? "secondary" : "ghost"}
+      <NavTooltip isCollapsed={!isOpen} label={node.label} description={node.description}>
+        <CollapsibleTrigger
+          asChild
+          className="mb-1 [&[data-state=open]>div>div>svg]:rotate-180"
         >
-          <div className="flex w-full items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-center">
-              {IconComponent && (
-                <span className="mr-2 shrink-0">
-                  <IconComponent size={18} />
-                </span>
-              )}
-              {headerHref && node.linkable !== false ? (
-                <Link
-                  aria-label={node.label}
-                  onClick={(e) => e.stopPropagation()}
-                  onKeyDown={(e) => {
-                    if (e.key === " ") {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }
-                    if (e.key === "Enter") {
-                      e.stopPropagation();
-                    }
-                  }}
-                  to={headerHref}
-                >
+          <Button
+            className="h-9 w-full justify-start"
+            variant={active || childActive ? "secondary" : "ghost"}
+          >
+            <div className="flex w-full items-center justify-between gap-2">
+              <div className="flex min-w-0 flex-1 items-center">
+                {IconComponent && (
+                  <span className="mr-2 shrink-0">
+                    <IconComponent size={18} />
+                  </span>
+                )}
+                {headerHref && node.linkable !== false ? (
+                  <Link
+                    aria-label={node.label}
+                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                      if (e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }
+                      if (e.key === "Enter") {
+                        e.stopPropagation();
+                      }
+                    }}
+                    to={headerHref}
+                  >
+                    <span
+                      className={cn(
+                        "truncate",
+                        {
+                          "-translate-x-96 opacity-0": !isOpen,
+                          "translate-x-0 opacity-100": isOpen,
+                        },
+                      )}
+                    >
+                      {node.label}
+                    </span>
+                  </Link>
+                ) : (
                   <span
+                    aria-disabled="true"
                     className={cn(
                       "truncate",
                       {
@@ -474,34 +498,21 @@ const CollapseMenuRecursive: React.FC<{
                   >
                     {node.label}
                   </span>
-                </Link>
-              ) : (
-                <span
-                  aria-disabled="true"
-                  className={cn(
-                    "truncate",
-                    {
-                      "-translate-x-96 opacity-0": !isOpen,
-                      "translate-x-0 opacity-100": isOpen,
-                    },
-                  )}
-                >
-                  {node.label}
-                </span>
-              )}
+                )}
+              </div>
+              <ChevronDown
+                className={cn(
+                  "shrink-0 transition-transform duration-200",
+                  isOpen
+                    ? "translate-x-0 opacity-100"
+                    : "-translate-x-96 opacity-0",
+                )}
+                size={18}
+              />
             </div>
-            <ChevronDown
-              className={cn(
-                "shrink-0 transition-transform duration-200",
-                isOpen
-                  ? "translate-x-0 opacity-100"
-                  : "-translate-x-96 opacity-0",
-              )}
-              size={18}
-            />
-          </div>
-        </Button>
-      </CollapsibleTrigger>
+          </Button>
+        </CollapsibleTrigger>
+      </NavTooltip>
       <CollapsibleContent className="data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down overflow-hidden">
         <NavigationTreeRenderer
           depth={depth + 1}
@@ -540,7 +551,7 @@ const NavigationTreeItem: React.FC<{
   if (useFlyout && !hasChildren) {
     return (
       <li>
-        <NavTooltip isCollapsed={!isOpen} label={node.label}>
+        <NavTooltip isCollapsed={!isOpen} label={node.label} description={node.description}>
           <div>
             <FlyoutNavItem
               depth={depth}
@@ -558,17 +569,13 @@ const NavigationTreeItem: React.FC<{
   if (hasChildren) {
     return (
       <li>
-        <NavTooltip isCollapsed={!isOpen} label={node.label}>
-          <div>
-            <CollapseMenuRecursive
-              depth={depth}
-              isOpen={isOpen}
-              node={node}
-              onItemClick={onItemClick}
-              resetKey={resetKey}
-            />
-          </div>
-        </NavTooltip>
+        <CollapseMenuRecursive
+          depth={depth}
+          isOpen={isOpen}
+          node={node}
+          onItemClick={onItemClick}
+          resetKey={resetKey}
+        />
       </li>
     );
   }

--- a/libs/portal-framework-ui/src/hooks/useNavigationTree.spec.ts
+++ b/libs/portal-framework-ui/src/hooks/useNavigationTree.spec.ts
@@ -57,9 +57,9 @@ describe("groupBySection", () => {
     ];
     const result = groupBySection(list);
     expect(Object.keys(result)).toEqual([
+      "default",
       "Appearance",
       "Settings",
-      "default",
     ]);
     expect(result["default"]).toHaveLength(1);
     expect(result["Settings"]).toHaveLength(2);
@@ -95,7 +95,7 @@ describe("groupBySection", () => {
       { id: core("c"), label: "C", order: 1 },
     ];
     const result = groupBySection(list);
-    expect(Object.keys(result)).toEqual(["Alpha", "Beta", "default"]);
+    expect(Object.keys(result)).toEqual(["default", "Alpha", "Beta"]);
   });
 });
 
@@ -265,5 +265,74 @@ describe("buildTree — N-level nesting", () => {
 
     const tree = buildTree(flat);
     expect(tree.map((n) => n.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("cross-plugin parentId children nest under parent and sort by order", () => {
+    // Simulates the real My Account layout: dashboard plugin defines the
+    // parent with inline children; billing plugin adds children via parentId.
+    const navItems = [
+      // Parent with inline children (dashboard plugin)
+      {
+        id: "core:account-layout",
+        label: "My Account",
+        path: "/account",
+        order: 3,
+        section: "Account",
+        children: [
+          { id: "core:profile", label: "Profile", path: "/account", order: 0 },
+          { id: "core:security", label: "Security", path: "/account/security", order: 1 },
+          { id: "core:api-keys", label: "API Keys", path: "/account/api-keys", order: 2 },
+        ],
+      },
+      // Cross-plugin children via parentId (billing plugin)
+      {
+        id: "billing:subscription",
+        label: "Subscription",
+        path: "/account/subscription",
+        parentId: "core:account-layout",
+        order: 3,
+        section: "Account",
+      },
+      {
+        id: "billing:credits",
+        label: "Credits",
+        path: "/account/credits",
+        parentId: "core:account-layout",
+        order: 4,
+        section: "Account",
+      },
+    ] as NavigationItem[];
+
+    const tree = buildTree(navItems);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe("core:account-layout");
+    const children = tree[0].children.map((c) => c.id);
+    // Children sorted by order: Profile(0), Security(1), API Keys(2), Subscription(3), Credits(4)
+    expect(children).toEqual([
+      "core:profile",
+      "core:security",
+      "core:api-keys",
+      "billing:subscription",
+      "billing:credits",
+    ]);
+  });
+
+  it("default section sorts first, then named sections by order", () => {
+    // Simulates real nav: Dashboard/Operations (no section) before
+    // ACCOUNT section, before PUBLIC DATA section.
+    const list: TestItem[] = [
+      { id: core("dashboard"), label: "Dashboard", order: 0 },
+      { id: core("operations"), label: "Operations", order: 2 },
+      { id: core("account-layout"), label: "My Account", order: 3, section: "Account" },
+      { id: core("ipfs-files"), label: "Files", order: 10, section: "Public Data" },
+      { id: core("private-data"), label: "Private Data", order: 20, section: "Private Data" },
+    ];
+    const result = groupBySection(list);
+    expect(Object.keys(result)).toEqual([
+      "default",
+      "Account",
+      "Public Data",
+      "Private Data",
+    ]);
   });
 });

--- a/libs/portal-framework-ui/src/hooks/useNavigationTree.ts
+++ b/libs/portal-framework-ui/src/hooks/useNavigationTree.ts
@@ -59,8 +59,9 @@ export function groupBySection(
   const sortedKeys = [...sectionMap.keys()].sort((a, b) => {
     const aIsDefault = a === "default";
     const bIsDefault = b === "default";
-    if (aIsDefault && !bIsDefault) return 1;
-    if (!aIsDefault && bIsDefault) return -1;
+    // Default section (no section name) sorts first
+    if (aIsDefault && !bIsDefault) return -1;
+    if (!aIsDefault && bIsDefault) return 1;
     const aOrder = sectionMap.get(a)![0]?.order ?? Infinity;
     const bOrder = sectionMap.get(b)![0]?.order ?? Infinity;
     if (aOrder !== bOrder) return aOrder - bOrder;

--- a/libs/portal-plugin-billing/src/routes.tsx
+++ b/libs/portal-plugin-billing/src/routes.tsx
@@ -6,7 +6,6 @@ import { lazyIcon } from "@lumeweb/portal-framework-ui-core";
 const Coins = lazyIcon("Coins");
 const CreditCard = lazyIcon("CreditCard");
 
-
 const routes = [
   {
     component: "account/subscription",
@@ -14,6 +13,10 @@ const routes = [
     navigation: {
       icon: CreditCard,
       label: "Subscription",
+      description: "Manage your subscription plan",
+      parentId: "core:account-layout",
+      order: 3,
+      section: "Account",
     },
     path: "/account/subscription",
   },
@@ -23,8 +26,12 @@ const routes = [
     navigation: {
       icon: Coins,
       label: "Credits",
+      description: "View and purchase credits",
+      parentId: "core:account-layout",
+      order: 4,
+      section: "Account",
     },
-    path: "/credits",
+    path: "/account/credits",
   },
 ] satisfies RouteDefinition[];
 

--- a/libs/portal-plugin-core/src/features/navigation.ts
+++ b/libs/portal-plugin-core/src/features/navigation.ts
@@ -163,11 +163,14 @@ export class Navigation implements NavigationFeature {
     const propMap = {
       badge: CHECK_TYPES.DEFINED,
       children: CHECK_TYPES.DEFINED,
+      description: CHECK_TYPES.UNDEFINED_CHECK,
       disabled: CHECK_TYPES.UNDEFINED_CHECK,
       hidden: CHECK_TYPES.UNDEFINED_CHECK,
       icon: CHECK_TYPES.DEFINED,
       order: CHECK_TYPES.UNDEFINED_CHECK,
       linkable: CHECK_TYPES.UNDEFINED_CHECK,
+      parentId: CHECK_TYPES.UNDEFINED_CHECK,
+      section: CHECK_TYPES.UNDEFINED_CHECK,
       show: CHECK_TYPES.DEFINED
     } as const;
 
@@ -188,8 +191,16 @@ export class Navigation implements NavigationFeature {
     return !!route.navigation && (!(route.index ?? false) || !!route.navigation.forceShowInNavigation);
   }
 
-  private processRouteForNavigation(route: RouteDefinition, pluginId: NamespacedId, parentPath = "", parentId?: NamespacedId): NavigationItem[] {
-    const item = this.createNavigationItem(route, pluginId, parentPath, parentId);
+  private processRouteForNavigation(route: RouteDefinition, pluginId: NamespacedId, parentPath = "", parentId?: NamespacedId, inheritedSection?: string): NavigationItem[] {
+    const shouldInclude = this.shouldIncludeRouteInNavigation(route);
+    const item = shouldInclude ? this.createNavigationItem(route, pluginId, parentPath, parentId) : null;
+
+    // Inherit section from parent if the route doesn't define its own
+    if (item && !item.section && inheritedSection) {
+      item.section = inheritedSection;
+    }
+
+    const effectiveSection = item?.section ?? inheritedSection;
 
     // Route has no navigation itself — but it may have children that do
     // (e.g. a layout route). Process children without creating a nav item
@@ -197,17 +208,15 @@ export class Navigation implements NavigationFeature {
     if (!item) {
       const childPath = resolveFullPath(parentPath, route.path ?? "");
       return route.children
-        ?.filter((child) => this.shouldIncludeRouteInNavigation(child))
-        .flatMap((child) =>
-          this.processRouteForNavigation(child, pluginId, childPath, parentId),
+        ?.flatMap((child) =>
+          this.processRouteForNavigation(child, pluginId, childPath, parentId, effectiveSection),
         ) ?? [];
     }
 
     const childItems =
       route.children
-        ?.filter((child) => this.shouldIncludeRouteInNavigation(child))
-        .flatMap((child) =>
-          this.processRouteForNavigation(child, pluginId, item.path, item.id),
+        ?.flatMap((child) =>
+          this.processRouteForNavigation(child, pluginId, item.path, item.id, effectiveSection),
         ) ?? [];
 
     return [item, ...childItems];
@@ -218,8 +227,7 @@ export class Navigation implements NavigationFeature {
       .flatMap(
         (plugin) =>
           plugin.routes
-            ?.filter((route) => this.shouldIncludeRouteInNavigation(route))
-            .flatMap((route) =>
+            ?.flatMap((route) =>
               this.processRouteForNavigation(route, plugin.id),
             ) ?? [],
       )

--- a/libs/portal-plugin-dashboard/src/routes.tsx
+++ b/libs/portal-plugin-dashboard/src/routes.tsx
@@ -25,6 +25,7 @@ const routes: RouteDefinition[] = [
     navigation: {
       icon: LayoutDashboard,
       label: "Dashboard",
+      description: "Overview of your account and services",
       order: 0,
     },
     path: "/dashboard",
@@ -35,6 +36,7 @@ const routes: RouteDefinition[] = [
     navigation: {
       icon: Activity,
       label: "Operations",
+      description: "Monitor and manage running operations",
       order: 2,
     },
     path: "/operations",
@@ -49,6 +51,8 @@ const routes: RouteDefinition[] = [
           forceShowInNavigation: true,
           icon: User,
           label: "Profile",
+          description: "View and edit your profile information",
+          order: 0,
         },
         path: "",
       },
@@ -58,6 +62,8 @@ const routes: RouteDefinition[] = [
         navigation: {
           icon: Shield,
           label: "Security",
+          description: "Manage passwords, 2FA, and sessions",
+          order: 1,
         },
         path: "security",
       },
@@ -67,6 +73,8 @@ const routes: RouteDefinition[] = [
         navigation: {
           icon: Key,
           label: "API Keys",
+          description: "Create and manage API access keys",
+          order: 2,
         },
         path: "api-keys",
       },
@@ -76,8 +84,10 @@ const routes: RouteDefinition[] = [
     navigation: {
       icon: UserCog,
       label: "My Account",
+      description: "Manage your account settings",
       linkable: false,
       order: 3,
+      section: "Account",
     },
     path: "/account",
   },

--- a/libs/portal-plugin-ipfs/src/routes.tsx
+++ b/libs/portal-plugin-ipfs/src/routes.tsx
@@ -8,13 +8,15 @@ const Folder = lazyIcon("Folder");
 
 const routes = [
   {
-    path: "/files",
+    path: "/services/ipfs/files",
     component: "file-manager",
     id: createNamespacedId("ipfs", "file-manager"),
     navigation: {
-      label: "File Manager",
+      label: "Files",
+      description: "Browse and manage IPFS files",
       icon: Folder,
-      order: 1,
+      order: 10,
+      section: "Public Data",
     },
   },
 ] satisfies RouteDefinition[];

--- a/libs/portal-plugin-lbry/src/routes.tsx
+++ b/libs/portal-plugin-lbry/src/routes.tsx
@@ -10,23 +10,27 @@ const Monitor = lazyIcon("Monitor");
 
 const routes = [
   {
-    path: "/lbry/devices",
+    path: "/services/lbry/devices",
     component: "devices",
     id: createNamespacedId(CORE_NS, "lbry-devices"),
     navigation: {
       label: "Devices",
+      description: "Manage LBRY streaming devices",
       icon: Monitor,
-      order: 3,
+      order: 11,
+      section: "Public Data",
     },
   },
   {
-    path: "/lbry/streams",
+    path: "/services/lbry/streams",
     component: "streams",
     id: createNamespacedId(CORE_NS, "lbry-streams"),
     navigation: {
       label: "Streams",
+      description: "Browse LBRY content streams",
       icon: Anchor,
-      order: 4,
+      order: 12,
+      section: "Public Data",
     },
   },
 ] satisfies RouteDefinition[];

--- a/libs/portal-plugin-onboarding/src/__tests__/components/OnboardingChecklist.test.tsx
+++ b/libs/portal-plugin-onboarding/src/__tests__/components/OnboardingChecklist.test.tsx
@@ -7,7 +7,7 @@ import { OnboardingChecklist } from "@/ui/components/OnboardingChecklist";
 const mockStepsPinning = [
   { id: "cli", isComplete: false, label: "Install CLI", description: "Copy the command below, paste it into your terminal, and run it to install the Pinner CLI", ctaLabel: "Copy install command", ctaRoute: null },
   { id: "subscribe", isComplete: false, label: "Subscribe", description: "Choose a plan to start pinning content to the IPFS network", ctaLabel: "View plans", ctaRoute: "/account/subscription" },
-  { id: "upload", isComplete: false, label: "Upload Content", description: "Pin your first file or directory to IPFS", ctaLabel: "Upload files", ctaRoute: "/files" },
+  { id: "upload", isComplete: false, label: "Upload Content", description: "Pin your first file or directory to IPFS", ctaLabel: "Upload files", ctaRoute: "/services/ipfs/files" },
 ];
 
 const mockStepsHosting = [
@@ -19,7 +19,7 @@ const mockStepsHosting = [
 const mockStepsComplete = [
   { id: "cli", isComplete: true, label: "Install CLI", description: "Copy the command below, paste it into your terminal, and run it to install the Pinner CLI", ctaLabel: "Copy install command", ctaRoute: null },
   { id: "subscribe", isComplete: true, label: "Subscribe", description: "Choose a plan to start pinning content to the IPFS network", ctaLabel: "View plans", ctaRoute: "/account/subscription" },
-  { id: "upload", isComplete: true, label: "Upload Content", description: "Pin your first file or directory to IPFS", ctaLabel: "Upload files", ctaRoute: "/files" },
+  { id: "upload", isComplete: true, label: "Upload Content", description: "Pin your first file or directory to IPFS", ctaLabel: "Upload files", ctaRoute: "/services/ipfs/files" },
 ];
 
 vi.mock("@/hooks", () => ({

--- a/libs/portal-plugin-onboarding/src/__tests__/hooks/useOnboardingStatus.test.ts
+++ b/libs/portal-plugin-onboarding/src/__tests__/hooks/useOnboardingStatus.test.ts
@@ -62,7 +62,7 @@ describe("useOnboardingStatus", () => {
       expect(result.current.steps[2].id).toBe("upload");
       expect(result.current.steps[2].label).toBe("Upload Content");
       expect(result.current.steps[2].ctaLabel).toBe("Upload files");
-      expect(result.current.steps[2].ctaRoute).toBe("/files");
+      expect(result.current.steps[2].ctaRoute).toBe("/services/ipfs/files");
     });
 
     it("uses hasPins for upload step completion when intent is null", async () => {
@@ -185,7 +185,7 @@ describe("useOnboardingStatus", () => {
       expect(result.current.steps[2].id).toBe("upload");
       expect(result.current.steps[2].label).toBe("Upload Content");
       expect(result.current.steps[2].ctaLabel).toBe("Upload files");
-      expect(result.current.steps[2].ctaRoute).toBe("/files");
+      expect(result.current.steps[2].ctaRoute).toBe("/services/ipfs/files");
     });
 
     it("uses hasPins for upload step completion", async () => {

--- a/libs/portal-plugin-onboarding/src/__tests__/intents/intentConfigs.test.ts
+++ b/libs/portal-plugin-onboarding/src/__tests__/intents/intentConfigs.test.ts
@@ -22,7 +22,7 @@ describe("PINNING_STEPS", () => {
   });
 
   it("upload step navigates to /files", () => {
-    expect(PINNING_STEPS[2].ctaRoute).toBe("/files");
+    expect(PINNING_STEPS[2].ctaRoute).toBe("/services/ipfs/files");
     expect(PINNING_STEPS[2].ctaLabel).toBe("Upload files");
   });
 });

--- a/libs/portal-plugin-onboarding/src/intents/pinning.ts
+++ b/libs/portal-plugin-onboarding/src/intents/pinning.ts
@@ -26,7 +26,7 @@ export const PINNING_STEPS: IntentStepConfig[] = [
     label: "Upload Content",
     description: "Pin your first file or directory to IPFS",
     ctaLabel: "Upload files",
-    ctaRoute: "/files",
+    ctaRoute: "/services/ipfs/files",
     docsUrl: DOCS_URL,
   },
 ];

--- a/libs/portal-plugin-sia/src/routes.tsx
+++ b/libs/portal-plugin-sia/src/routes.tsx
@@ -8,13 +8,15 @@ const HardDrive = lazyIcon("HardDrive");
 
 const routes = [
   {
-    path: "/sia/apps",
+    path: "/services/sia/apps",
     component: "apps",
-    id: createNamespacedId("core", "sia-apps"),
+    id: createNamespacedId("core", "private-data"),
     navigation: {
-      label: "My Apps",
+      label: "Private Data",
+      description: "Secure private storage on Sia",
       icon: HardDrive,
-      order: 5,
+      order: 20,
+      section: "Private Data",
     },
   },
 ] satisfies RouteDefinition[];


### PR DESCRIPTION
## Summary
- Add `section` and `description` fields to `NavigationItem` type for visual grouping and tooltip hover text
- Propagate `section` and `parentId` through `NavigationFeature` so children inherit section from parent layout routes
- Default section sorts first in the sidebar, then named sections by order; suppress redundant headers for single-item sections
- Reorganize plugin routes under `/services/` paths with descriptions and section assignments (Public Data, Private Data, Account)
- Attach billing routes to the account-layout parent via `parentId` and move credits from `/credits` to `/account/credits`
- Update onboarding CTA route to match the new IPFS path

---

<!-- kody-pr-summary:start -->
## Description

This PR introduces navigation sections, item descriptions, and a route reorganization across plugins to create a more structured sidebar navigation.

### Navigation Sections
- Adds a `section` property to `NavigationItem` allowing items to be visually grouped under named headers in the sidebar.
- The default (unlabeled) section now sorts **first** in the navigation, followed by named sections ordered by their item `order` values.
- Section headers are automatically suppressed when a section contains only a single item whose ID matches the section name, avoiding redundant headers.
- Child routes inherit the section from their parent route if they don't define their own, enabling cross-plugin items to join the correct section.

### Navigation Item Descriptions
- Adds an optional `description` property to navigation items, displayed as tooltip content on hover when the sidebar is expanded. When collapsed, the tooltip shows the item label as before.
- Descriptions are added to all core and plugin navigation items (Dashboard, Operations, Profile, Security, API Keys, My Account, Subscription, Credits, Files, Devices, Streams, Private Data).

### Route Reorganization
- **IPFS**: Path changed from `/files` to `/services/ipfs/files`; label changed from "File Manager" to "Files"; moved to "Public Data" section.
- **LBRY**: Paths changed from `/lbry/devices` and `/lbry/streams` to `/services/lbry/devices` and `/services/lbry/streams`; moved to "Public Data" section.
- **Sia**: Path changed from `/sia/apps` to `/services/sia/apps`; label changed from "My Apps" to "Private Data"; ID changed to `private-data`; moved to "Private Data" section.
- **Billing**: Credits path changed from `/credits` to `/account/credits`; Subscription and Credits now nest under the "My Account" parent via `parentId` and join the "Account" section.
- **Onboarding**: All references to the old `/files` route updated to `/services/ipfs/files`.

### Framework Core Changes
- Exports `NavigationBadge` type and `FeatureDependency` type from the core package.
- Navigation route processing no longer pre-filters routes by navigation inclusion at the top level, allowing layout routes (without their own nav items) to still process and contribute child navigation items.
<!-- kody-pr-summary:end -->