### PR TITLE
feat(portal-plugin-abuse): add descriptions to abuse routes

### DIFF
--- a/libs/portal-plugin-abuse/src/routes.ts
+++ b/libs/portal-plugin-abuse/src/routes.ts
@@ -9,6 +9,7 @@ const routes = [
     id: createNamespacedId("abuse", "root"),
     navigation: {
       label: "Abuse",
+      description: "Abuse management and moderation",
     },
     path: "/abuse",
     children: [
@@ -31,6 +32,7 @@ const routes = [
         path: "cases",
         navigation: {
           label: "Cases",
+          description: "Review and manage abuse cases",
         },
       },
       {
@@ -48,6 +50,7 @@ const routes = [
         path: "reporters",
         navigation: {
           label: "Reporters",
+          description: "View abuse reporters",
         },
       },
       {
@@ -65,6 +68,7 @@ const routes = [
         path: "subjects",
         navigation: {
           label: "Subjects",
+          description: "View reported subjects",
         },
       },
       {
@@ -82,6 +86,7 @@ const routes = [
         path: "blocklist",
         navigation: {
           label: "Blocklist",
+          description: "Manage blocked entities",
         },
       },
     ],


### PR DESCRIPTION
## Summary
- Add description text to Abuse, Cases, Reporters, Subjects, and Blocklist nav items

---

<!-- kody-pr-summary:start -->
## Description

This pull request adds descriptive text to the navigation configuration of all abuse plugin routes. Specifically, it introduces a `description` field to the `navigation` object of the following routes:

- **Abuse (root)**: "Abuse management and moderation"
- **Cases**: "Review and manage abuse cases"
- **Reporters**: "View abuse reporters"
- **Subjects**: "View reported subjects"
- **Blocklist**: "Manage blocked entities"

These descriptions provide contextual information for each abuse-related route, likely to be surfaced in the UI for navigation, tooltips, or page headers, improving clarity around the purpose of each section within the abuse management area.
<!-- kody-pr-summary:end -->