### PR TITLE
chore: relax minimumReleaseAge to 720 minutes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -176,6 +176,8 @@ onlyBuiltDependencies:
   - sharp
   - workerd
 
+minimumReleaseAge: 720
+
 gitChecks: false
 
 publishBranch: develop


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge: 720` (12 hours) in `pnpm-workspace.yaml`
- vocs@2.2.1 was published ~23h before the CI run, landing just inside the default 1440-minute (24h) cutoff, causing `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
- 720 minutes keeps supply-chain protection while giving enough margin for newly published versions

---

<!-- kody-pr-summary:start -->
## Description

This PR relaxes the `minimumReleaseAge` setting in the pnpm workspace configuration to 720 minutes (12 hours). This setting controls how long a package must have been published before pnpm will allow it to be installed, serving as a safeguard against newly published (potentially compromised or buggy) packages. The change reduces the waiting period, allowing dependencies to be installed sooner after their release.
<!-- kody-pr-summary:end -->