### PR TITLE
chore: set minimumReleaseAgeStrict to false

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -177,6 +177,7 @@ onlyBuiltDependencies:
   - workerd
 
 minimumReleaseAge: 720
+minimumReleaseAgeStrict: false
 
 gitChecks: false
 


### PR DESCRIPTION
## Summary
- Sets `minimumReleaseAgeStrict: false` alongside the existing `minimumReleaseAge: 720`
- When `minimumReleaseAge` is explicitly configured, strict mode defaults to true, hard-failing install if no version satisfies the age constraint
- With `strict: false`, pnpm falls back to a newer version that doesn't meet the age constraint so install succeeds
- Prevents the `update-dependencies` workflow from failing when `taze` bumps to a version published less than 720 minutes ago

---

<!-- kody-pr-summary:start -->
## Description

This PR configures `minimumReleaseAgeStrict` to `false` in the pnpm workspace configuration. 

While the existing `minimumReleaseAge: 720` setting prefers dependencies that have been published for at least 720 minutes (12 hours), setting `minimumReleaseAgeStrict` to `false` makes this a non-blocking preference rather than a hard requirement. This allows installation to proceed even when a dependency hasn't yet met the minimum release age threshold, preventing build failures while still favoring more mature package releases.
<!-- kody-pr-summary:end -->