### PR TITLE
fix: use strictDepBuilds instead of dangerouslyAllowAllBuilds

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
 
       - name: Update lockfile
-        run: pnpm install --no-frozen-lockfile --config.dangerouslyAllowAllBuilds=true
+        run: pnpm install --no-frozen-lockfile
         shell: bash
 
       - name: Create Pull Request

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -182,6 +182,8 @@ minimumReleaseAge: 720
 minimumReleaseAgeExclude:
   - vocs
 
+strictDepBuilds: false
+
 gitChecks: false
 
 publishBranch: develop


### PR DESCRIPTION
## Summary
- Add `strictDepBuilds: false` to `pnpm-workspace.yaml` to downgrade `ERR_PNPM_IGNORED_BUILDS` from fatal error to warning (exit code 0)
- Remove `--config.dangerouslyAllowAllBuilds=true` from workflow — it conflicts with `onlyBuiltDependencies` causing `ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES`

Verified locally: `pnpm install --no-frozen-lockfile` exits 0 with `strictDepBuilds: false`.

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR replaces the use of `dangerouslyAllowAllBuilds` with `strictDepBuilds` configuration for handling dependency builds.

**Changes:**
- Removed the `--config.dangerouslyAllowAllBuilds=true` flag from the `pnpm install` command in the dependency update workflow
- Added `strictDepBuilds: false` to the pnpm workspace configuration

**Purpose:**
The change moves from using a potentially unsafe CLI flag (`dangerouslyAllowAllBuilds`) to a more appropriate workspace-level configuration (`strictDepBuilds: false`) for controlling how dependency builds are handled during installation. This provides a safer and more maintainable approach to managing dependency build behavior across the workspace.
<!-- kody-pr-summary:end -->