### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/beige-sails-boil.md
+++ b/.changeset/beige-sails-boil.md
@@ -1,0 +1,19 @@
+---
+@lumeweb/portal-framework-ui: minor
+---
+
+## Features
+
+- navigation system refactor with N-level nesting
+- cascading flyout nav, sidebar auto-resize, tooltips, and theme switcher
+- add section grouping, header suppression, and description tooltips to navigation
+
+## Fixes
+
+- merge refine options instead of overwriting
+- export AppActions and AppState for dts generation
+- add @types/react to devDependencies and rename step-control spec to .tsx
+- sync framework.meta to appStore so usePluginMeta works
+- wire usePortalUrl into GeneralLayout to populate meta store
+- restore portalUrl env default, framework sync, and stable action refs
+- address Kody review findings

--- a/.changeset/bumpy-terms-fold.md
+++ b/.changeset/bumpy-terms-fold.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/portal-plugin-billing: minor
+---
+
+## Features
+
+- add descriptions, Account section, and parentId to routes
+
+## Fixes
+
+- kill stale dev processes and remove hardcoded billing devPort

--- a/.changeset/chubby-eggs-rescue.md
+++ b/.changeset/chubby-eggs-rescue.md
@@ -1,0 +1,16 @@
+---
+@lumeweb/portal-plugin-core: minor
+---
+
+## Features
+
+- refactor navigation feature for N-level nesting
+- propagate section and parentId in NavigationFeature
+
+## Fixes
+
+- add @types/react to devDependencies and rename step-control spec to .tsx
+- use CORE_NS for navigation feature ID
+- recurse into nested route children for navigation tree
+- recurse into nested route children for navigation tree
+- restore portalUrl env default, framework sync, and stable action refs

--- a/.changeset/eight-sloths-call.md
+++ b/.changeset/eight-sloths-call.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/pinner: patch
+---
+
+## Fixes
+
+- migrate from createHeliaHTTP to createHelia for @helia/http v4
+- migrate from createHeliaHTTP to createHelia for @helia/http v4

--- a/.changeset/flat-areas-guess.md
+++ b/.changeset/flat-areas-guess.md
@@ -1,0 +1,23 @@
+---
+@lumeweb/portal-framework-core: minor
+---
+
+## Features
+
+- add ignore flag for excluding plugins from /api/meta
+- add navigation type tests
+- add values field to BrandConfig schema
+- make favicon configurable via brand.faviconUrl
+- add loadingMessages to brand schema
+- add section and description fields to NavigationItem type
+- export NavigationBadge and FeatureDependency types
+
+## Fixes
+
+- kill stale dev processes and remove hardcoded billing devPort
+- patch @module-federation/vite for deferred shared exports
+- resolve TypeScript errors and StrictMode double-init in framework.tsx
+- defer to framework ErrorDisplay on boot failure
+- add @types/react to devDependencies and rename step-control spec to .tsx
+- respect minifyMangle config option and move calendar icon declarations to module scope
+- remove dead stripNonCriticalPreloadsPlugin

--- a/.changeset/gentle-dryers-argue.md
+++ b/.changeset/gentle-dryers-argue.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-framework-auth: patch
+---
+
+## Fixes
+
+- align capability types with core namespace

--- a/.changeset/good-bars-think.md
+++ b/.changeset/good-bars-think.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-admin: patch
+---
+
+## Fixes
+
+- remove duplicate Home nav label from root route

--- a/.changeset/nice-ravens-show.md
+++ b/.changeset/nice-ravens-show.md
@@ -1,0 +1,11 @@
+---
+@lumeweb/portal-plugin-dashboard: minor
+---
+
+## Features
+
+- add descriptions and Account section to routes
+
+## Fixes
+
+- use hyphenated name in createNamespacedId

--- a/.changeset/old-knives-love.md
+++ b/.changeset/old-knives-love.md
@@ -1,0 +1,12 @@
+---
+@lumeweb/portal-app-shell: minor
+---
+
+## Features
+
+- read loadingMessages from env in loader
+
+## Fixes
+
+- defer to framework ErrorDisplay on boot failure
+- fall back to default messages when loadingMessages is empty

--- a/.changeset/purple-mangos-shop.md
+++ b/.changeset/purple-mangos-shop.md
@@ -1,0 +1,13 @@
+---
+@lumeweb/portal-plugin-ipfs: minor
+---
+
+## Features
+
+- reorganize routes under /services/ with descriptions and Public Data section
+- reorganize routes under /services/ with descriptions and Public Data section
+
+## Fixes
+
+- migrate from createHeliaHTTP to createHelia for @helia/http v4
+- migrate from createHeliaHTTP to createHelia for @helia/http v4

--- a/.changeset/rich-carpets-prove.md
+++ b/.changeset/rich-carpets-prove.md
@@ -1,0 +1,7 @@
+---
+@lumeweb/portal-plugin-quota: minor
+---
+
+## Features
+
+- add Sia storage management plugin

--- a/.changeset/thin-showers-invite.md
+++ b/.changeset/thin-showers-invite.md
@@ -1,0 +1,15 @@
+---
+@lumeweb/portal-framework-ui-core: minor
+---
+
+## Features
+
+- cascading flyout nav, sidebar auto-resize, tooltips, and theme switcher
+- add lazy loading stubs for heavy UI components
+- add lazy icon registry with React.lazy per icon
+- add Sia storage management plugin
+
+## Fixes
+
+- add @types/react to devDependencies and rename step-control spec to .tsx
+- respect minifyMangle config option and move calendar icon declarations to module scope


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR adds changeset files documenting version bumps and changelog entries across multiple packages in the LumeWeb portal monorepo. The changesets capture a broad set of features and fixes that were implemented across the codebase.

### Key Changes Documented

**Navigation System Refactor:**
- N-level nesting support across `portal-framework-ui`, `portal-framework-core`, and `portal-plugin-core`
- Cascading flyout nav, sidebar auto-resize, tooltips, and theme switcher in UI packages
- Section grouping, header suppression, description tooltips, and `parentId` propagation in navigation items

**Brand & Configuration:**
- Configurable favicon via `brand.faviconUrl`
- `loadingMessages` added to brand schema and read from env in the app shell loader
- `values` field added to `BrandConfig` schema

**New Plugin:**
- Sia storage management plugin added to `portal-plugin-quota` and `portal-framework-ui-core`

**Route Organization:**
- Routes reorganized with descriptions, Account sections, and Public Data sections across billing, dashboard, and IPFS plugins

**Helia Migration:**
- Migrated from `createHeliaHTTP` to `createHelia` for `@helia/http` v4 in `pinner` and `portal-plugin-ipfs`

**Bug Fixes:**
- Merged refine options instead of overwriting; synced `framework.meta` to appStore; wired `usePortalUrl` into `GeneralLayout`; restored `portalUrl` env default; deferred to framework `ErrorDisplay` on boot failure; removed duplicate Home nav label; aligned auth capability types with core namespace; patched `@module-federation/vite` for deferred shared exports; and various TypeScript and build configuration fixes

### Affected Packages
`portal-framework-ui`, `portal-framework-core`, `portal-framework-ui-core`, `portal-framework-auth`, `portal-app-shell`, `portal-plugin-core`, `portal-plugin-billing`, `portal-plugin-dashboard`, `portal-plugin-ipfs`, `portal-plugin-admin`, `portal-plugin-quota`, `pinner`
<!-- kody-pr-summary:end -->