### PR TITLE
feat: add Go module for portal-plugin-sia

### DIFF
--- a/go/portal-plugin-sia/go.mod
+++ b/go/portal-plugin-sia/go.mod
@@ -1,0 +1,3 @@
+module go.lumeweb.com/web/go/portal-plugin-sia
+
+go 1.26

--- a/go/portal-plugin-sia/handler.go
+++ b/go/portal-plugin-sia/handler.go
@@ -1,0 +1,15 @@
+package portal_plugin_sia
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:build/*
+var appFs embed.FS
+
+func GetFS() fs.FS {
+	appFiles, _ := fs.Sub(appFs, "build")
+
+	return appFiles
+}


### PR DESCRIPTION
## Summary
- Add go.mod and handler.go for the sia plugin, matching the pattern used by all other portal plugins (dashboard, onboarding, etc.)

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds a new Go module for the `portal-plugin-sia` plugin. The module embeds the plugin's build artifacts using Go's `embed` package and exposes a `GetFS()` function that provides access to the embedded files as a standard `fs.FS` filesystem interface. This allows the built plugin assets to be served directly from the Go binary without external file dependencies.
<!-- kody-pr-summary:end -->