### PR TITLE
fix(docs.pinner.xyz): copy patches directory before pnpm install

### DIFF
--- a/apps/docs.pinner.xyz/Dockerfile
+++ b/apps/docs.pinner.xyz/Dockerfile
@@ -23,8 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends golang-go && rm
 
 WORKDIR /build
 
-# Copy workspace manifests first (layer cache)
+# Copy workspace manifests and patches first (layer cache)
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY patches/ patches/
 COPY apps/docs.pinner.xyz/package.json apps/docs.pinner.xyz/
 
 # Install all dependencies


### PR DESCRIPTION
## Summary
- Add `COPY patches/ patches/` to Dockerfile before `pnpm install --frozen-lockfile`
- The `pnpm-workspace.yaml` declares 8 patchedDependencies referencing files in `patches/` that were never copied into the build context, causing ENOENT errors during Coolify builds

---

<!-- kody-pr-summary:start -->
The Dockerfile for `docs.pinner.xyz` has been updated to copy the `patches/` directory into the build container before running `pnpm install`. Previously, only the workspace manifests (`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `package.json`) and the app-specific `package.json` were copied before the dependency installation step. This caused the build to fail when pnpm attempted to apply patched dependencies, as the required patch files were not yet available in the container. Adding the `COPY patches/ patches/` instruction ensures all patch files are present before dependency installation begins.
<!-- kody-pr-summary:end -->