### PR TITLE
fix(docs.pinner.xyz): install ca-certificates for go install HTTPS

### DIFF
--- a/apps/docs.pinner.xyz/Dockerfile
+++ b/apps/docs.pinner.xyz/Dockerfile
@@ -19,7 +19,7 @@ FROM node:22-slim AS builder
 
 # Install pnpm + Go (for pinner-cli)
 RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN apt-get update && apt-get install -y --no-install-recommends golang-go && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates golang-go && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- Add `ca-certificates` to the apt-get install line in the Dockerfile
- `node:22-slim` does not include CA certificates, causing x509 certificate errors when `go install` fetches modules from `proxy.golang.org` over HTTPS

---

<!-- kody-pr-summary:start -->
## Description

This PR fixes the `docs.pinner.xyz` Docker build by adding `ca-certificates` to the installed system packages. The CA certificates package is required for `go install` to successfully fetch Go packages over HTTPS, as without it, TLS certificate verification would fail during the build process.
<!-- kody-pr-summary:end -->