### PR TITLE
fix(docs.pinner.xyz): use multi-stage golang build for pinner-cli

### DIFF
--- a/apps/docs.pinner.xyz/Dockerfile
+++ b/apps/docs.pinner.xyz/Dockerfile
@@ -14,12 +14,15 @@
 # vocs.config.js is placed one dir above server/ because the
 # config resolver does: path.resolve(import.meta.dirname, "../vocs.config.js")
 
-# ── Stage 1: Build ─────────────────────────────────────────────────────────
+# ── Stage 1a: Build pinner-cli ────────────────────────────────────────────
+FROM golang:1.26 AS pinner-cli
+RUN go install go.lumeweb.com/pinner-cli/cmd/pinner@latest
+
+# ── Stage 1b: Build docs ──────────────────────────────────────────────────
 FROM node:22-slim AS builder
 
-# Install pnpm + Go (for pinner-cli)
+# Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates golang-go && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
@@ -31,9 +34,8 @@ COPY apps/docs.pinner.xyz/package.json apps/docs.pinner.xyz/
 # Install all dependencies
 RUN pnpm install --frozen-lockfile
 
-# Install pinner-cli (provides `pinner generate-docs json` for CLI ref generation)
-RUN go install go.lumeweb.com/pinner-cli/cmd/pinner@latest
-ENV PATH="/root/go/bin:${PATH}"
+# Copy pinner-cli binary from golang stage
+COPY --from=pinner-cli /go/bin/pinner /usr/local/bin/pinner
 
 # Copy source and build
 COPY apps/docs.pinner.xyz/ apps/docs.pinner.xyz/


### PR DESCRIPTION
- Add `golang:1.26` stage that compiles pinner-cli, copy binary into node builder
- Removes apt `golang-go` and `ca-certificates` (no longer needed)
- Fixes Go 1.26.0 requirement in pinner-cli go.mod

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR refactors the Docker build for the `docs.pinner.xyz` application to use a multi-stage build for the `pinner-cli` tool.

**Key changes:**
- Introduces a dedicated build stage using the official `golang:1.26` image to compile `pinner-cli`, replacing the previous approach of installing Go via `apt-get` within the Node.js builder stage.
- The compiled `pinner` binary is copied from the Go stage into the Node.js builder stage, eliminating the need to install Go system packages in the Node.js image.

**Functional impact:**
- Pins the Go version to 1.26 for building `pinner-cli`, ensuring a consistent and controlled Go version rather than relying on the version provided by the Debian package manager.
- Simplifies the Node.js builder stage by removing the Go installation dependency, resulting in a cleaner build process.
<!-- kody-pr-summary:end -->