### PR TITLE
fix(docs.pinner.xyz): bypass pnpm runDepsStatusCheck

### DIFF
--- a/apps/docs.pinner.xyz/Dockerfile
+++ b/apps/docs.pinner.xyz/Dockerfile
@@ -42,12 +42,23 @@ COPY apps/docs.pinner.xyz/ apps/docs.pinner.xyz/
 COPY libs/pinner/src/ libs/pinner/src/
 COPY libs/pinner/tsconfig.json libs/pinner/tsconfig.json
 COPY libs/pinner/tsconfig.typedoc.json libs/pinner/tsconfig.typedoc.json
+COPY tsconfig.base.json tsconfig.base.json
 
-# build script runs generate (TypeDoc + CLI ref) then vocs build
-RUN pnpm --filter @lumeweb/docs.pinner.xyz build
+# Build: inline the build chain to avoid pnpm's runDepsStatusCheck
+# (pnpm v11 re-runs install before every pnpm script invocation, which
+# fails on workspace-level unused patches)
+# pinner binary is already copied from the golang stage, so setup-pinner-cli.sh
+# is a no-op (it exits early when pinner is on PATH)
+WORKDIR /build/apps/docs.pinner.xyz
+RUN mkdir -p reference-sources \
+    && pinner generate-docs json > reference-sources/cli-ref.json \
+    && npx tsx scripts/generate-cli-ref.ts \
+    && npx typedoc \
+    && npx tsx scripts/generate-sdk-ref.ts \
+    && npx vocs build
 
 # Bundle the server with tsdown/Rolldown
-RUN pnpm --filter @lumeweb/docs.pinner.xyz exec tsdown
+RUN npx tsdown
 
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────
 FROM node:22-slim AS runtime

--- a/apps/docs.pinner.xyz/package.json
+++ b/apps/docs.pinner.xyz/package.json
@@ -29,6 +29,7 @@
     "clsx": "catalog:",
     "tailwindcss": "catalog:websites",
     "tsx": "^4.22.4",
+    "tsdown": "catalog:",
     "typedoc": "^0.28.19"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
       tailwindcss:
         specifier: catalog:websites
         version: 4.2.4
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4


### PR DESCRIPTION
- Inline build chain steps with `npx` instead of `pnpm run` to avoid pnpm v11's `runDepsStatusCheck`
- pnpm v11 re-runs install (without `--frozen-lockfile`) before every script invocation, failing with `ERR_PNPM_UNUSED_PATCH` on workspace-level patches (`better-sse`, `@uppy/core`) not used by this filter
- Add `COPY tsconfig.base.json` (required by typedoc)

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR fixes the Docker build for the `docs.pinner.xyz` documentation site by bypassing pnpm v11's `runDepsStatusCheck` behavior, which re-runs install before every pnpm script invocation and fails on workspace-level unused patches.

### Changes

- **Inlined the build chain** in the Dockerfile, replacing the single `pnpm --filter @lumeweb/docs.pinner.xyz build` command with individual `npx`-based steps (CLI ref generation, TypeDoc, SDK ref generation, and Vocs build). This avoids triggering pnpm's dependency status check on each script invocation.
- **Changed the bundling step** from `pnpm --filter ... exec tsdown` to `npx tsdown` for the same reason.
- **Added `tsconfig.base.json`** to the copied files, which is required by the build process.
- Added a comment noting that the pinner binary is already available from the golang build stage, so `setup-pinner-cli.sh` exits early as a no-op.

### Functional Impact

The documentation site's Docker build was failing due to pnpm v11's aggressive dependency re-checking. By invoking build tools directly via `npx` instead of through pnpm scripts, the build completes successfully without triggering the problematic check.
<!-- kody-pr-summary:end -->