### PR TITLE
fix(docs.pinner.xyz): copy static frontend assets to runtime image

### DIFF
--- a/apps/docs.pinner.xyz/Dockerfile
+++ b/apps/docs.pinner.xyz/Dockerfile
@@ -75,6 +75,12 @@ COPY --from=builder /build/apps/docs.pinner.xyz/dist/server/vocs.config.js /app/
 # Vocs config definition module (imported by vocs.config.js)
 COPY --from=builder /build/apps/docs.pinner.xyz/dist/server/assets/ /app/assets/
 
+# Static frontend assets
+# fetchMarkdown: distDir = dirname(import.meta.url)/.. = /app, reads /app/public/
+# serveStatic: config.distDir ("dist") + "public" relative to CWD = /app/server/dist/public/
+COPY --from=builder /build/apps/docs.pinner.xyz/dist/public/ /app/public/
+RUN mkdir -p /app/server/dist && ln -s /app/public /app/server/dist/public
+
 RUN chown -R app:app /app
 
 USER app


### PR DESCRIPTION
- Copy dist/public/ to /app/public/ for fetchMarkdown filesystem reads
- Symlink /app/public/ to /app/server/dist/public/ for serveStatic
- Resolves `serveStatic: root path 'dist/public' is not found` runtime error
- Resolves fetchMarkdown ECONNREFUSED fallback when fs read fails

---

<!-- kody-pr-summary:start -->
This pull request fixes an issue in the `docs.pinner.xyz` Docker runtime image where static frontend assets were missing, causing the documentation site to not serve these files correctly.

The changes copy the built static assets into the appropriate directory (`/app/public/`) and create a symbolic link (`/app/server/dist/public`) to ensure compatibility with both the `fetchMarkdown` and `serveStatic` functions, which expect assets in different paths. This ensures the documentation site loads with all necessary styles, scripts, and other static resources in production.
<!-- kody-pr-summary:end -->