### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/good-suits-sleep.md
+++ b/.changeset/good-suits-sleep.md
@@ -1,0 +1,8 @@
+---
+@lumeweb/portal-framework-auth: patch
+---
+
+## Fixes
+
+- support cross-subdomain redirects via 'to' param
+- compare origins in isExternalRedirect

--- a/.changeset/young-wolves-strive.md
+++ b/.changeset/young-wolves-strive.md
@@ -1,0 +1,16 @@
+---
+@lumeweb/docs.pinner.xyz: minor
+---
+
+## Features
+
+- build Docker image in CI and remove railpack.toml
+
+## Fixes
+
+- copy patches directory before pnpm install
+- install ca-certificates for go install HTTPS
+- use multi-stage golang build for pinner-cli
+- inline build steps to bypass pnpm runDepsStatusCheck
+- add tsdown to devDependencies for npx resolution
+- copy static frontend assets to runtime image


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds changeset files to document upcoming releases for two packages.

For `@lumeweb/portal-framework-auth` (patch), it records fixes to support cross-subdomain redirects via the 'to' parameter and to compare origins when checking for external redirects.

For `@lumeweb/docs.pinner.xyz` (minor), it records the addition of Docker image building in CI (replacing railpack.toml) and several build/deployment fixes, including handling the patches directory, installing ca-certificates for Go, using a multi-stage Golang build for pinner-cli, bypassing pnpm dependency checks, adding tsdown to devDependencies, and copying static frontend assets to the runtime image.
<!-- kody-pr-summary:end -->