### PR TITLE
ci: add changeset workflow

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,43 @@
+name: Changeset
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changeset:
+    name: Generate Changeset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup JS
+        uses: LumeWeb/workflows/.github/actions/setup-js@develop
+
+      - name: Install Knope
+        uses: knope-dev/action@v2.1.2
+
+      - name: Generate changesets
+        run: node scripts/generate-changesets-from-release.js
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore changeset"
+          title: "chore: changeset"
+          body: ""
+          branch: chore/changeset
+          base: develop
+          delete-branch: true
+          labels: |
+            chore


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/changeset.yml` — runs on manual dispatch
- Executes `scripts/generate-changesets-from-release.js` to generate changeset files
- Uses `peter-evans/create-pull-request@v8` to open a PR against `develop` from the `chore/changeset` branch with commit message `chore changeset`

---

<!-- kody-pr-summary:start -->
## Description

This PR adds a new GitHub Actions workflow (`.github/workflows/changeset.yml`) that automates changeset generation for the repository.

### What it does

The workflow runs on a **daily schedule** (10:00 AM UTC) or can be **triggered manually** via `workflow_dispatch`. It performs the following steps:

1. Checks out the repository with full git history
2. Sets up the JavaScript environment using LumeWeb's custom setup action
3. Installs **Knope** (a release/versioning tool)
4. Executes a custom script (`scripts/generate-changesets-from-release.js`) to generate changesets from release data
5. Creates a pull request (targeting `develop`) with the generated changesets, using the `chore/changeset` branch

### Key details

- **Concurrency control** is configured to prevent overlapping workflow runs on the same branch
- The workflow requires **write permissions** for repository contents and pull requests
- The generated PR is labeled as `chore` and the branch is automatically deleted after merge (`delete-branch: true`)

### Purpose

This automates the maintenance of changesets, ensuring release notes and version bumps are kept up to date without manual intervention.
<!-- kody-pr-summary:end -->