### PR TITLE
fix(portal-plugin-sia): polish delete notification and prune button UX

### DIFF
--- a/libs/portal-plugin-sia/src/ui/routes/apps.tsx
+++ b/libs/portal-plugin-sia/src/ui/routes/apps.tsx
@@ -172,7 +172,6 @@ export default function Apps() {
   const { openDialog } = useDialog();
   const { mutateAsync: deleteApp } = useDelete();
   const { mutate: prune, isLoading: isPruning } = usePruneSia();
-  const [pruneDone, setPruneDone] = useState(false);
 
   const handleDisconnect = (app: AppResponse) => {
     openDialog(
@@ -181,6 +180,11 @@ export default function Apps() {
           await deleteApp({
             id: app.publicKey,
             resource: "sia/apps",
+            successNotification: () => ({
+              description: `The app "${app.name}" has been disconnected.`,
+              message: "App Disconnected",
+              type: "success",
+            }),
           });
         } catch {
           // Refine mutation error notifications are handled by the data provider
@@ -192,11 +196,7 @@ export default function Apps() {
   const handlePrune = () => {
     openDialog(
       pruneDialogConfig(() => {
-        prune({
-          onSuccess: () => {
-            setPruneDone(true);
-          },
-        });
+        prune();
       }),
     );
   };
@@ -213,10 +213,10 @@ export default function Apps() {
             <Button
               variant="outline"
               onClick={handlePrune}
-              disabled={isPruning || pruneDone}
+              disabled={isPruning}
             >
               <Trash2 className="mr-2 h-4 w-4" />
-              {isPruning ? "Cleaning up..." : pruneDone ? "Cleaned Up" : "Clean Up Storage"}
+              {isPruning ? "Cleaning up..." : "Clean Up Storage"}
             </Button>
           </div>
 


### PR DESCRIPTION
- Add `successNotification` to the app delete mutation, showing the app name and a clean "App Disconnected" message instead of the raw default toast
- Remove `pruneDone` state that permanently disabled the Clean Up button after first use; button now only disables while pruning is in progress

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR improves the user experience for the Sia apps management page in two ways:

1. **Added success notification for app disconnection**: When a user disconnects an app, a success notification is now displayed confirming the action, showing the message "App Disconnected" with a description indicating which app was disconnected.

2. **Simplified prune button behavior**: Removed the "prune done" state that previously permanently disabled the "Clean Up Storage" button after a single prune operation. The button now only shows a loading state ("Cleaning up...") while the prune operation is in progress, and returns to its normal state once complete, allowing users to prune again if needed.
<!-- kody-pr-summary:end -->