### PR TITLE
fix(portal-framework-core): set host base to "/" for absolute asset paths

### DIFF
--- a/apps/portal-app-shell/index.html
+++ b/apps/portal-app-shell/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="stylesheet" type="text/css" href="./src/loader.scss" />
+  <link rel="stylesheet" type="text/css" href="/src/loader.scss" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>%VITE_PORTAL_APP_TITLE%</title>
 </head>
@@ -62,7 +62,7 @@
   </div>
 </div>
 <div id="root"></div>
-<script type="module" src="./src/index.tsx"></script>
-<script type="module" src="./src/loader.ts"></script>
+<script type="module" src="/src/index.tsx"></script>
+<script type="module" src="/src/loader.ts"></script>
 </body>
 </html>

--- a/libs/portal-framework-core/src/vite/vite-config.ts
+++ b/libs/portal-framework-core/src/vite/vite-config.ts
@@ -152,7 +152,7 @@ function createHostConfig(opts: ConfigOptions) {
   ].filter(Boolean);
 
   const config = defineConfig({
-    base: "",
+    base: "/",
     resolve: {
       tsconfigPaths: true,
     },


### PR DESCRIPTION
## Summary
- Change host Vite config `base` from `""` to `"/"` so built HTML uses absolute paths (`/static/js/...`) instead of relative (`./static/js/...`)
- Update `index.html` script/link src paths from `./src/` to `/src/`
- MF manifest `publicPath` stays `"auto"` (unaffected by `base` change)
- Fixes SPA reload on subpaths (e.g. `/dashboard/files`)

---

<!-- kody-pr-summary:start -->
This PR fixes asset path resolution in the portal app shell by setting the Vite host base configuration to `"/"` and updating asset references in `index.html` from relative paths (`./`) to absolute paths (`/`). This ensures that stylesheets, scripts, and other assets are correctly resolved from the root path rather than relative to the current URL, preventing broken asset loading in certain routing scenarios.
<!-- kody-pr-summary:end -->