### PR TITLE
ci: pass VITE_PORTAL_BRAND env var to release-go build

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Release
         id: release
+        env:
+          VITE_PORTAL_BRAND: ${{ vars.VITE_PORTAL_BRAND }}
         run: |
           ARGS=()
           


### PR DESCRIPTION
## Summary
- Passes VITE_PORTAL_BRAND as a GitHub Actions environment variable (not a secret) to the Release step in release-go.yml
- The env var is consumed by the Vite build process (localhost-plugin.ts) to inject brand config into index.html at build time
- Reads from vars.VITE_PORTAL_BRAND (repository variable), must be configured in GitHub repo settings

---

<!-- kody-pr-summary:start -->
This PR updates the `release-go` GitHub Actions workflow to pass the `VITE_PORTAL_BRAND` environment variable into the Release step, sourced from the repository's configured variables. This ensures the brand configuration is available during the release build process.
<!-- kody-pr-summary:end -->