### PR TITLE
fix(portal-framework-ui-core): use brand.siteUrl for ToS/Privacy Policy links in cookie banner

### DIFF
--- a/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
+++ b/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
@@ -16,9 +16,10 @@ import {
 import { Switch } from "@/components/ui/switch";
 
 function getPortalUrl(path: string): string {
-  const domain = import.meta.env.VITE_PORTAL_DOMAIN;
-  if (!domain) return path;
-  return `https://${domain}${path}`;
+  const brand = import.meta.env.VITE_PORTAL_BRAND;
+  const siteUrl = typeof brand === "string" ? JSON.parse(brand).siteUrl : brand?.siteUrl;
+  if (!siteUrl) return path;
+  return `${siteUrl}${path}`;
 }
 
 interface CookieCategoryConfig {

--- a/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
+++ b/libs/portal-framework-ui-core/src/components/ui/cookie-banner.tsx
@@ -17,7 +17,16 @@ import { Switch } from "@/components/ui/switch";
 
 function getPortalUrl(path: string): string {
   const brand = import.meta.env.VITE_PORTAL_BRAND;
-  const siteUrl = typeof brand === "string" ? JSON.parse(brand).siteUrl : brand?.siteUrl;
+  let siteUrl: string | undefined;
+  if (typeof brand === "string") {
+    try {
+      siteUrl = JSON.parse(brand).siteUrl;
+    } catch {
+      /* fall through to relative path */
+    }
+  } else {
+    siteUrl = brand?.siteUrl;
+  }
   if (!siteUrl) return path;
   return `${siteUrl}${path}`;
 }


### PR DESCRIPTION
## Summary
- Cookie banner's `getPortalUrl()` now reads `siteUrl` from `VITE_PORTAL_BRAND` instead of constructing URLs from `VITE_PORTAL_DOMAIN`
- Aligns with the register form, which already uses `brand.siteUrl` for ToS/Privacy Policy links
- Falls back to relative paths when `siteUrl` is not configured

---

<!-- kody-pr-summary:start -->
This pull request updates the cookie banner component to use the `siteUrl` from the portal brand configuration instead of the `VITE_PORTAL_DOMAIN` environment variable when constructing URLs for ToS and Privacy Policy links. This ensures the links are built using the correct site URL defined in the brand settings, which may include a full URL (with protocol) rather than just a domain.
<!-- kody-pr-summary:end -->