### PR TITLE
fix(portal-plugin-sia): use "private cloud data" in user-facing copy

### DIFF
--- a/libs/portal-plugin-sia/src/routes.tsx
+++ b/libs/portal-plugin-sia/src/routes.tsx
@@ -12,11 +12,11 @@ const routes = [
     component: "apps",
     id: createNamespacedId("core", "private-data"),
     navigation: {
-      label: "Private Data",
-      description: "Secure private storage on Sia",
+      label: "Private Cloud Data",
+      description: "Secure private cloud storage on Sia",
       icon: HardDrive,
       order: 20,
-      section: "Private Data",
+      section: "Private Cloud Data",
     },
   },
 ] satisfies RouteDefinition[];

--- a/libs/portal-plugin-sia/src/ui/dialogs/disconnectAppDialog.tsx
+++ b/libs/portal-plugin-sia/src/ui/dialogs/disconnectAppDialog.tsx
@@ -6,7 +6,7 @@ export function disconnectAppDialogConfig(
 ): DialogConfig {
   return {
     confirmText: "Disconnect",
-    description: `Are you sure you want to disconnect "${appName}"? This will revoke its access to your private storage. The app will no longer be able to pin or retrieve data on your behalf. This action cannot be undone.`,
+    description: `Are you sure you want to disconnect "${appName}"? This will revoke its access to your private cloud data. The app will no longer be able to pin or retrieve data on your behalf. This action cannot be undone.`,
     onConfirm,
     title: "Disconnect App",
     type: DialogTypes.CONFIRM,

--- a/libs/portal-plugin-sia/src/ui/routes/apps.tsx
+++ b/libs/portal-plugin-sia/src/ui/routes/apps.tsx
@@ -207,7 +207,7 @@ export default function Apps() {
         <div className="space-y-6">
           <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
             <PageHeader
-              description="Manage apps connected to your private storage and view your storage usage."
+              description="Manage apps connected to your private cloud data and view your storage usage."
               title="My Apps"
             />
             <Button
@@ -235,7 +235,7 @@ export default function Apps() {
               ],
             }}
             columns={columns}
-            emptyStateMessage="No apps are connected to your private storage yet. Apps will appear here when they request access to your storage."
+            emptyStateMessage="No apps are connected to your private cloud data yet. Apps will appear here when they request access to your data."
             pagination={true}
             resource="sia/apps"
             responsive={true}


### PR DESCRIPTION
## Summary
- Renamed nav label and section from "Private Data" to "Private Cloud Data"
- Updated page description, empty state message, and disconnect dialog to use "private cloud data" instead of "private storage"

---

<!-- kody-pr-summary:start -->
This pull request updates user-facing copy throughout the Sia portal plugin to consistently use "Private Cloud Data" instead of "Private Data" and "private storage." The changes affect navigation labels, section names, descriptions, dialog messages, and empty state text across the apps management interface, ensuring consistent terminology for users interacting with their Sia-based private cloud storage.
<!-- kody-pr-summary:end -->