### PR TITLE
fix(pinner.xyz): homepage rewrite, OG cards, and cloud storage rename

### DIFF
--- a/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
+++ b/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
@@ -7,7 +7,7 @@ interface DifferentiatorsSectionProps {
 
 const columns = [
   { label: "Traditional Cloud" },
-  { label: "Private Storage", highlight: true },
+  { label: "Cloud Storage", highlight: true },
   { label: "Public (IPFS)", highlight: true },
 ];
 

--- a/apps/pinner.xyz/src/components/Home/FAQ.tsx
+++ b/apps/pinner.xyz/src/components/Home/FAQ.tsx
@@ -40,12 +40,12 @@ const faqs = [
       {
         question: "Is my pinned content public?",
         answer:
-          "Yes. IPFS is a public network. Anyone with the content address can retrieve it. For private data, use private storage with zero-knowledge encryption instead.",
+          "Yes. IPFS is a public network. Anyone with the content address can retrieve it. For private data, use cloud storage with zero-knowledge encryption instead.",
       },
     ],
   },
   {
-    group: "Private Storage",
+    group: "Cloud Storage",
     items: [
       {
         question: "Can you read my files?",

--- a/apps/pinner.xyz/src/components/Home/Hero.tsx
+++ b/apps/pinner.xyz/src/components/Home/Hero.tsx
@@ -47,8 +47,13 @@ const Hero = () => {
 
   return (
     <HeroSection
-      headline={<>Your data.<br />Your rules.</>}
-      subheadline={<><span className="block mb-2"><a href="/solutions/ipfs-pinning" className="underline hover:text-white transition-colors">Pin files</a>. <a href="/solutions/website-hosting" className="underline hover:text-white transition-colors">Host sites</a>. <a href="/solutions/private-storage" className="underline hover:text-white transition-colors">Store private data</a>.</span><span className="block mb-2">All on one quota. Zero-knowledge encrypted.</span><span className="block">Pay by card or crypto, no KYC on crypto.</span></>}
+      headline="Storage & hosting where you're in control."
+      subheadline={
+        <>
+          <span className="block mb-2">Your data. Your rules.</span>
+          <span className="block">Store files, host websites, and keep your data private by default. One plan, no surprises.</span>
+        </>
+      }
       primaryButtons={[
         { label: "Start Pinning →", url: config.registerUrl("pinning"), buttonStyle: "btn-light" },
         { label: "Host a Website →", url: config.registerUrl("hosting"), buttonStyle: "btn-light" },
@@ -60,7 +65,6 @@ const Hero = () => {
         target: "_blank"
       }}
       visualContent={visualContent}
-      microcopy="Pay with crypto or card · No ID required for crypto"
       trustLine="Built on Sia · FOSS · Zero-knowledge encryption · No bandwidth tricks, no feature gating"
     />
   );

--- a/apps/pinner.xyz/src/components/Home/PricingTable.tsx
+++ b/apps/pinner.xyz/src/components/Home/PricingTable.tsx
@@ -5,7 +5,7 @@ import PricingPlans from "@/components/pricing";
 const trustBadges = [
   "Priced upfront",
   "Open source",
-  "Encrypted private storage",
+  "Encrypted cloud storage",
   "Crypto & card payments",
 ];
 

--- a/apps/pinner.xyz/src/components/Home/ProductCards.tsx
+++ b/apps/pinner.xyz/src/components/Home/ProductCards.tsx
@@ -38,11 +38,11 @@ const cards: CardProps[] = [
     soon: true,
   },
   {
-    title: "Private Storage",
+    title: "Cloud Storage",
     description:
       "Encrypted storage where only you hold the keys. Personal use or build apps on the Sia network.",
     cta: "Store Privately →",
-    href: "/solutions/private-storage",
+    href: "/solutions/cloud-storage",
     soon: true,
   },
 ];
@@ -52,10 +52,10 @@ const ProductCards = () => {
     <Section variant="dark" padding="md">
       <div className="xl:container px-6">
         <h2 className="text-home-text text-2xl lg:text-3xl font-semibold text-center mb-2">
-          Four ways to store
+          One plan. Every feature.
         </h2>
         <p className="text-home-text-muted text-sm text-center mb-10">
-          Simple tiered pricing. Priced upfront, no seats.
+          Storage, hosting, and pinning on one balance. Priced upfront, no feature gates.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {cards.map((card) => (

--- a/apps/pinner.xyz/src/components/Home/UseCases.tsx
+++ b/apps/pinner.xyz/src/components/Home/UseCases.tsx
@@ -14,14 +14,14 @@ const useCases: UseCaseCardProps[] = [
     description:
       "Store embeddings, vector databases, and knowledge bases with zero-knowledge encryption. Your data is encrypted before it leaves your device. Even we can't read it.",
     cta: "Store Privately →",
-    href: "/solutions/private-storage",
+    href: "/solutions/cloud-storage",
   },
   {
     title: "Client & Project Files for Agencies",
     description:
       "Keep sensitive client documents under your own keys. No vendor can be compelled to hand them over.",
     cta: "Store Privately →",
-    href: "/solutions/private-storage",
+    href: "/solutions/cloud-storage",
   },
   {
     title: "Static Sites & Developer Workflows",

--- a/apps/pinner.xyz/src/components/MissionSection.tsx
+++ b/apps/pinner.xyz/src/components/MissionSection.tsx
@@ -4,7 +4,7 @@ const beliefs = [
   {
     icon: Lock,
     title: "Private files don't need a privacy policy to stay private",
-    description: "Zero-knowledge encryption on private storage. Even we can't read your files",
+    description: "Zero-knowledge encryption on cloud storage. Even we can't read your files",
   },
   {
     icon: Shield,

--- a/apps/pinner.xyz/src/components/Navbar.tsx
+++ b/apps/pinner.xyz/src/components/Navbar.tsx
@@ -29,7 +29,7 @@ const solutions = [
   { label: "Website Hosting", href: "/solutions/website-hosting" },
   { label: "IPFS Pinning", href: "/solutions/ipfs-pinning" },
   { label: "S3 Storage", href: "/solutions/s3-storage" },
-  { label: "Private Storage", href: "/solutions/private-storage" },
+  { label: "Cloud Storage", href: "/solutions/cloud-storage" },
 ];
 
 interface NavProps {

--- a/apps/pinner.xyz/src/components/UseCaseSection.tsx
+++ b/apps/pinner.xyz/src/components/UseCaseSection.tsx
@@ -1,0 +1,84 @@
+import Section from "@/components/layout/Section";
+import { cn } from "@/lib/utils";
+
+export interface UseCaseCard {
+  title: string;
+  description: string;
+  cta: string;
+  href: string;
+}
+
+interface UseCaseSectionProps {
+  cases: UseCaseCard[];
+  heading?: string;
+  subheading?: string;
+  variant?: "dark" | "gray" | "white" | "default";
+}
+
+/**
+ * Reusable use-case card grid for solution pages.
+ * Each solution page passes only the use cases relevant to that product.
+ */
+const UseCaseSection = ({
+  cases,
+  heading = "What you can build",
+  subheading,
+  variant = "white",
+}: UseCaseSectionProps) => {
+  return (
+    <Section variant={variant} padding="md">
+      <div className="xl:container px-6">
+        <h2
+          className={cn(
+            "text-2xl lg:text-3xl font-semibold text-center mb-2",
+            variant === "dark" ? "text-home-text" : "text-content-text"
+          )}
+        >
+          {heading}
+        </h2>
+        {subheading && (
+          <p
+            className={cn(
+              "text-sm text-center mb-10",
+              variant === "dark" ? "text-home-text-muted" : "text-content-text-muted"
+            )}
+          >
+            {subheading}
+          </p>
+        )}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {cases.map((card) => (
+            <a
+              key={`${card.title}-${card.href}`}
+              href={card.href}
+              className={cn(
+                "group flex flex-col rounded-lg border p-6 lg:p-8",
+                variant === "dark"
+                  ? "border-home-text/10 text-home-text hover:border-home-text/30"
+                  : "border-content-divider/30 text-content-text hover:border-content-divider/60",
+                "transition-colors duration-200"
+              )}
+            >
+              <h3 className="text-lg font-semibold mb-3">
+                {card.title}
+              </h3>
+              <p
+                className={cn(
+                  "text-sm leading-relaxed mb-4",
+                  variant === "dark" ? "text-home-text-muted" : "text-content-text-muted"
+                )}
+              >
+                {card.description}
+              </p>
+              <span className="text-sm font-medium group-hover:underline mt-auto">
+                {card.cta}
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+};
+
+export default UseCaseSection;

--- a/apps/pinner.xyz/src/layouts/Layout.astro
+++ b/apps/pinner.xyz/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ import PostHog from "@/components/posthog.astro";
 import UTMCapture from "@/components/UTMCapture";
 import contactsData from "@/data/contacts.json";
 
-const { title, variant = "content", description = "Website hosting, IPFS pinning, and private storage on a peer-to-peer network. Zero-knowledge encryption. Even we can't read your files. Pay with crypto or card.", ogImage: ogImageProp, showNewsletterFooter = true } = Astro.props;
+const { title, variant = "content", description = "Store files, host websites, and keep your data private by default. One plan, no surprises. Open source, built on Sia.", ogImage: ogImageProp, showNewsletterFooter = true } = Astro.props;
 const lastUpdated = getGitLastUpdated();
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? "https://pinner.xyz");
 const siteName = "Pinner";

--- a/apps/pinner.xyz/src/lib/config.ts
+++ b/apps/pinner.xyz/src/lib/config.ts
@@ -56,8 +56,8 @@ export const ctaCopy = {
     subheading: "S3-compatible API, revenue sharing, and the Sia SDK.",
   },
   home: {
-    heading: "Your data, on open standards, with permanence.",
-    subheading: "Pin files, host sites, or store private data. Content-addressed, portable, no platform lock-in.",
+    heading: "Your data is yours.",
+    subheading: "We can't look at it. We can't sell it. Open source; verify the architecture yourself.",
   },
   about: {
     heading: "Your data is yours.",

--- a/apps/pinner.xyz/src/lib/og-pages.ts
+++ b/apps/pinner.xyz/src/lib/og-pages.ts
@@ -7,20 +7,24 @@ export interface OGPage extends OGConfig {
 export const OG_PAGES: OGPage[] = [
   {
     slug: "default",
-    headline: "Your data. Your rules.",
-    subtitle: "IPFS pinning - S3-compatible storage - Static hosting",
-    footer: "Card and crypto accepted - Priced upfront",
+    headline: "Storage and hosting where you're in control.",
+    subtitle:
+      "Store files, host websites, and keep your data private by default. One plan, no surprises.",
+    subtitleSize: 24,
+    footer: "Open source - Built on Sia",
   },
   {
     slug: "about",
-    headline: "Infrastructure that respects your data",
-    subtitle: "Open source - Built on Sia network - Priced upfront",
+    headline: "Your data. Your rules.",
+    subtitle:
+      "Independent, open-source storage that respects you.",
+    footer: "Founder-owned. No investors. No exit strategy.",
   },
   {
     slug: "pricing",
-    headline: "Simple, transparent pricing",
+    headline: "One plan. Every feature. No surprises.",
     subtitle:
-      "Storage and bandwidth, priced upfront - Encrypted private storage - Card and crypto accepted",
-    subtitleSize: 20,
+      "Storage and bandwidth, priced upfront. No tiers to climb.",
+    footer: "Card or crypto accepted",
   },
 ];

--- a/apps/pinner.xyz/src/pages/about.astro
+++ b/apps/pinner.xyz/src/pages/about.astro
@@ -14,7 +14,7 @@ import UploadFlowSection from "@/components/HowItWorks/UploadFlowSection";
 import DistributionSection from "@/components/HowItWorks/DistributionSection";
 ---
 
-<Layout title="Verifiable Storage That Respects Your Data" variant="home" ogImage="/images/og/about.png" description="A small business building storage infrastructure that respects your data. Zero-knowledge encryption, open source, built on the Sia network.">
+<Layout title="Independent, Open-Source Storage That Respects You | Pinner" variant="home" ogImage="/images/og/about.png" description="Independent, open-source storage that respects you. Founder-owned. No investors. No exit strategy.">
   <PageHeader
     title="Why we're building Pinner"
     description="A small business building storage infrastructure that respects your data."
@@ -32,7 +32,7 @@ import DistributionSection from "@/components/HowItWorks/DistributionSection";
   <UploadFlowSection
     title="Pinner is your storage service."
     subtitle="What is Pinner?"
-    description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. All on a verifiable storage network. No middlemen. No data mining possible. No AI training possible. No headaches."
+    description="Pin files to a peer-to-peer network, host static websites, and store private data with zero-knowledge encryption. All on a verifiable storage network. No middlemen. No data mining possible. No AI training possible. No headaches."
     theme="white"
     client:load
   />
@@ -43,7 +43,7 @@ import DistributionSection from "@/components/HowItWorks/DistributionSection";
     id="how-it-works"
     title="Pin. Host. Store."
     subtitle="How It Works"
-    description="1. <a href='/solutions/ipfs-pinning' class='underline hover:text-content-text transition-colors'>Pin</a>. Upload files to IPFS, get a permanent link.<br/><br/>2. <a href='/solutions/website-hosting' class='underline hover:text-content-text transition-colors'>Host</a>. Serve static websites directly from pinned content.<br/><br/>3. Store. Private data encrypted at rest via an S3-compatible API. Only you can read your files.<br/><br/><a href='/how-it-works' class='underline hover:text-content-text transition-colors font-medium'>Learn how payments and storage proofs work →</a>"
+    description="1. <a href='/solutions/ipfs-pinning' class='underline hover:text-content-text transition-colors'>Pin</a>. Upload files to a peer-to-peer network and get a permanent link.<br/><br/>2. <a href='/solutions/website-hosting' class='underline hover:text-content-text transition-colors'>Host</a>. Serve static websites directly from your stored content.<br/><br/>3. Store. Private data encrypted at rest. Only you can read your files.<br/><br/><a href='/how-it-works' class='underline hover:text-content-text transition-colors font-medium'>Learn how payments and storage proofs work →</a>"
     theme="white"
     imagePosition="right"
     client:load

--- a/apps/pinner.xyz/src/pages/alternatives/pinata/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/pinata/index.astro
@@ -56,7 +56,7 @@ const faqs = [
 ];
 ---
 
-<Layout title="Pinata Alternative: IPFS Pinning with Website Hosting & No-KYC Payments | Pinner" description="IPFS pinning with no-KYC crypto payments, website hosting, and private storage on a verifiable storage network. We help you migrate.">
+<Layout title="Pinata Alternative: IPFS Pinning with Website Hosting & No-KYC Payments | Pinner" description="IPFS pinning with no-KYC crypto payments, website hosting, and cloud storage on a verifiable storage network. We help you migrate.">
   <PageHeader
     title="IPFS pinning with website hosting and verifiable storage"
     description="Pay with crypto (no KYC) or use a card. Host websites from pinned content and store on a verifiable network. Need help migrating? We'll work with you."

--- a/apps/pinner.xyz/src/pages/how-it-works.astro
+++ b/apps/pinner.xyz/src/pages/how-it-works.astro
@@ -14,10 +14,10 @@ import s3StorageImg from "@/assets/how-it-works-s3-storage.jpg";
 import selfHostedImg from "@/assets/how-it-works-self-hosted.jpg";
 ---
 
-<Layout title="How Pinner Works. IPFS Pinning & Storage" description="Pin files to IPFS, host static websites, and store private data with zero-knowledge encryption. Three steps: pin, distribute, access anywhere.">
+<Layout title="How Pinner Works. Storage & Hosting" description="Pin files to a peer-to-peer network, host static websites, and store private data with zero-knowledge encryption. Three steps: pin, distribute, access anywhere.">
   <PageHeader
     title="Simple interface, powerful network"
-    description="IPFS pinning, website hosting, and private storage on a verifiable storage network"
+    description="IPFS pinning, website hosting, and cloud storage on a verifiable storage network"
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/index.astro
+++ b/apps/pinner.xyz/src/pages/index.astro
@@ -2,23 +2,14 @@
 import Layout from "@/layouts/Layout.astro";
 import Hero from "@/components/Home/Hero";
 import ProductCards from "@/components/Home/ProductCards";
-import UseCases from "@/components/Home/UseCases";
-import BrandLogos from "@/components/BrandLogos";
 import ProblemAgitation from "@/components/Home/ProblemAgitation";
 import TrustSection from "@/components/Home/TrustSection";
-import Account from "@/components/Home/Account";
 import DifferentiatorsSection from "@/components/DifferentiatorsSection";
-import FAQ from "@/components/Home/FAQ";
-import FoundingOfferBanner from "@/components/FoundingOfferBanner";
-import PaymentMethodsBar from "@/components/PaymentMethodsBar";
-import PricingTable from "@/components/Home/PricingTable";
 import CallToAction from "@/components/CallToAction";
-import NewsletterSignup from "@/components/NewsletterSignup";
-import logos from "@/data/brand-logos";
 import { ctaCopy } from "@/lib/config";
 ---
 
-<Layout title="Website Hosting, IPFS Pinning & Private Storage. Pinner" variant="home" showNewsletterFooter={false}>
+<Layout title="Storage and Hosting Where You're in Control | Pinner" description="Store files, host websites, and keep your data private by default. One plan, no surprises. Open source, built on Sia." variant="home" showNewsletterFooter={false}>
   <Hero client:load />
 
   <ProblemAgitation client:load />
@@ -27,40 +18,7 @@ import { ctaCopy } from "@/lib/config";
 
   <ProductCards client:load />
 
-  <UseCases client:load />
-
-  <BrandLogos
-    logos={logos}
-    logoType="dark"
-    title="Built On"
-    variant="dark"
-    client:load
-  />
-
-  <Account client:load variant="dark" />
-
   <DifferentiatorsSection client:load variant="dark" />
-
-  <FAQ client:load />
-
-  <FoundingOfferBanner variant="home" guarantee="Create a website and if it isn't live in 5 minutes, we'll deploy it for you" client:load />
-
-  <PaymentMethodsBar client:load variant="dark" />
-
-  <PricingTable client:load />
-
-  <section class="py-12 md:py-16 border-t border-border-dark">
-    <div class="xl:container px-6 flex flex-col items-center">
-      <NewsletterSignup
-        source="pricing_home"
-        label="Building on IPFS? Get notified about new features and pricing changes."
-        buttonLabel="Notify me"
-        successMessage="You're on the list. We'll email you when something changes."
-        theme="dark"
-        client:load
-      />
-    </div>
-  </section>
 
   <CallToAction
     variant="dark"

--- a/apps/pinner.xyz/src/pages/pricing.astro
+++ b/apps/pinner.xyz/src/pages/pricing.astro
@@ -49,7 +49,7 @@ const pricingFaqs = [
     group: "Advanced",
     items: [
       {
-        question: "What about S3 private storage?",
+        question: "What about S3 cloud storage?",
         answer: "Private storage with zero-knowledge encryption is available for personal use and developer integrations. S3-compatible storage is also available as a separate product. A simpler 1-click setup is in development. Subscribe below to get notified.",
       },
     ],
@@ -57,10 +57,10 @@ const pricingFaqs = [
 ];
 ---
 
-<Layout title="Simple Pricing for IPFS Pinning & Private Storage" ogImage="/images/og/pricing.png"   description="Simple, transparent pricing for IPFS pinning and private storage. Pay for storage and bandwidth, priced upfront. Annual plans save 2 months.">
+<Layout title="One Plan. Every Feature. No Surprises. | Pinner" ogImage="/images/og/pricing.png" description="Storage and bandwidth, priced upfront. No tiers to climb. Card or crypto accepted.">
   <PageHeader
     title="Simple pricing. No surprises."
-    description="<a href='/solutions/ipfs-pinning' class='underline hover:text-white transition-colors'>IPFS pinning</a> and hosting plans. <a href='/solutions/private-storage' class='underline hover:text-white transition-colors'>Private storage</a> for personal use and developer integrations."
+    description="<a href='/solutions/ipfs-pinning' class='underline hover:text-white transition-colors'>IPFS pinning</a> and hosting plans. <a href='/solutions/cloud-storage' class='underline hover:text-white transition-colors'>Private storage</a> for personal use and developer integrations."
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/solutions/cloud-storage.astro
+++ b/apps/pinner.xyz/src/pages/solutions/cloud-storage.astro
@@ -20,12 +20,12 @@ import { ctaCopy } from '@/lib/config';
     <div class="xl:container px-6 text-center">
       <h2 class="text-[24px] sm:text-[28px] md:text-[31px] font-medium text-content-text mb-10 md:mb-14">Choose Your Path</h2>
       <div class="flex flex-col sm:flex-row justify-center gap-6">
-        <a href="/solutions/private-storage/personal" class="inline-block bg-white border border-gray-200 rounded-lg px-8 py-10 text-content-text hover:shadow-lg transition-shadow max-w-[400px] text-left flex-1">
+        <a href="/solutions/cloud-storage/personal" class="inline-block bg-white border border-gray-200 rounded-lg px-8 py-10 text-content-text hover:shadow-lg transition-shadow max-w-[400px] text-left flex-1">
           <span class="inline-block text-xs font-medium text-content-accent bg-content-accent/10 px-2 py-1 rounded mb-3">Coming Soon</span>
           <span class="block text-xl font-medium mb-3">For Personal Use</span>
-          <span class="block text-base text-content-text-muted">Store private data on the Sia network. Encrypted, self-hosted, zero-knowledge.</span>
+          <span class="block text-base text-content-text-muted">Store private data on the Sia network. Encrypted, zero-knowledge. No one can read your files but you.</span>
         </a>
-        <a href="/solutions/private-storage/developers" class="inline-block bg-white border border-gray-200 rounded-lg px-8 py-10 text-content-text hover:shadow-lg transition-shadow max-w-[400px] text-left flex-1">
+        <a href="/solutions/cloud-storage/developers" class="inline-block bg-white border border-gray-200 rounded-lg px-8 py-10 text-content-text hover:shadow-lg transition-shadow max-w-[400px] text-left flex-1">
           <span class="inline-block text-xs font-medium text-content-accent bg-content-accent/10 px-2 py-1 rounded mb-3">Coming Soon</span>
           <span class="block text-xl font-medium mb-3">For Developers</span>
           <span class="block text-base text-content-text-muted">Build apps on encrypted, peer-to-peer storage. Integrate the storage layer, earn when your users store data.</span>
@@ -38,9 +38,9 @@ import { ctaCopy } from '@/lib/config';
     <div class="xl:container px-6 flex flex-col items-center">
       <NewsletterSignup
         source="private_storage_page"
-        label="Want to know when private storage is available? Get notified."
+        label="Want to know when cloud storage is available? Get notified."
         buttonLabel="Notify me"
-        successMessage="You're on the list. We'll email you when private storage is ready."
+        successMessage="You're on the list. We'll email you when cloud storage is ready."
         theme="light"
         rounded
         client:load

--- a/apps/pinner.xyz/src/pages/solutions/cloud-storage/developers.astro
+++ b/apps/pinner.xyz/src/pages/solutions/cloud-storage/developers.astro
@@ -82,7 +82,7 @@ const faqs = [
     <div class="xl:container px-6 flex flex-col items-center">
       <NewsletterSignup
         source="private_storage_developers"
-        label="Want to build on private storage? Get notified when the developer platform is ready."
+        label="Want to build on cloud storage? Get notified when the developer platform is ready."
         buttonLabel="Notify me"
         successMessage="You're on the list. We'll email you when the developer platform is available."
         theme="light"

--- a/apps/pinner.xyz/src/pages/solutions/cloud-storage/personal.astro
+++ b/apps/pinner.xyz/src/pages/solutions/cloud-storage/personal.astro
@@ -109,7 +109,7 @@ const faqs = [
     { href: "/solutions/website-hosting", label: "Website Hosting", description: "Host static websites on IPFS with a permanent, verifiable address" },
   ]} />
 
-  <section class="bg-white border-t border-content-divider/50 py-12 md:py-16">
+  <section id="cloud-storage-page" class="bg-white border-t border-content-divider/50 py-12 md:py-16">
     <div class="xl:container px-6 flex flex-col items-center">
       <NewsletterSignup
         source="private_storage_personal"

--- a/apps/pinner.xyz/src/pages/solutions/cloud-storage/personal.astro
+++ b/apps/pinner.xyz/src/pages/solutions/cloud-storage/personal.astro
@@ -12,6 +12,7 @@ import { ctaCopy } from '@/lib/config';
 
 import UploadFlowSection from "@/components/HowItWorks/UploadFlowSection";
 import DistributionSection from "@/components/HowItWorks/DistributionSection";
+import UseCaseSection from "@/components/UseCaseSection";
 
 const faqs = [
   {
@@ -37,9 +38,9 @@ const faqs = [
 ];
 ---
 
-<Layout title="Private Storage for Your Data: Coming Soon | Pinner" description="Store your files privately with zero-knowledge encryption on the Sia network. Coming soon.">
+<Layout title="Cloud Storage for Your Data: Coming Soon | Pinner" description="Store your files privately with zero-knowledge encryption on the Sia network. Coming soon.">
   <PageHeader
-    title="Private Storage for Your Data"
+    title="Cloud Storage for Your Data"
     description="Store your files privately with zero-knowledge encryption on the Sia network. Your keys, your data. No one can read your files without your key. Not us, not the storage hosts."
     client:load
   />
@@ -69,6 +70,33 @@ const faqs = [
     client:load
   />
 
+  <UseCaseSection
+    heading="What people store privately"
+    subheading="Files that should stay yours alone."
+    variant="gray"
+    cases={[
+      {
+        title: "Client & Project Files",
+        description: "Keep sensitive client documents under your own keys. No vendor can be compelled to hand them over because we can't read them.",
+        cta: "Get Notified",
+        href: "#cloud-storage-page",
+      },
+      {
+        title: "Backups & Off-Site Storage",
+        description: "Store encrypted backups on an independent network. When you delete, the file is gone. No residual copies, no recovery by anyone.",
+        cta: "Get Notified",
+        href: "#cloud-storage-page",
+      },
+      {
+        title: "Private Documents",
+        description: "Store personal files, financial records, and anything private. Encrypted before it leaves your device. Only you hold the key.",
+        cta: "Get Notified",
+        href: "#cloud-storage-page",
+      },
+    ]}
+    client:load
+  />
+
   <section class="py-[60px] md:py-[120px] bg-white">
     <div class="xl:container px-6">
       <h2 class="text-[24px] sm:text-[28px] md:text-[31px] font-medium text-content-text text-center mb-10 md:mb-14">Frequently Asked Questions</h2>
@@ -85,9 +113,9 @@ const faqs = [
     <div class="xl:container px-6 flex flex-col items-center">
       <NewsletterSignup
         source="private_storage_personal"
-        label="Want to know when private storage is available? Get notified."
+        label="Want to know when cloud storage is available? Get notified."
         buttonLabel="Notify me"
-        successMessage="You're on the list. We'll email you when private storage is ready."
+        successMessage="You're on the list. We'll email you when cloud storage is ready."
         theme="light"
         rounded
         client:load

--- a/apps/pinner.xyz/src/pages/solutions/ipfs-pinning.astro
+++ b/apps/pinner.xyz/src/pages/solutions/ipfs-pinning.astro
@@ -13,6 +13,7 @@ import { config, ctaCopy } from '@/lib/config';
 import UseCasesImage from "@/assets/solutions-ipfs-use-cases.jpg";
 import UploadFlowSection from "@/components/HowItWorks/UploadFlowSection";
 import DistributionSection from "@/components/HowItWorks/DistributionSection";
+import UseCaseSection from "@/components/UseCaseSection";
 
 const faqs = [
   {
@@ -29,7 +30,7 @@ const faqs = [
   },
   {
     question: "What happens if I unpin something?",
-    answer: "If you unpin content, it may eventually be garbage-collected by the network. Other nodes may still have copies if they've pinned it independently. For private storage where deletes are definitive, see our S3-compatible storage option."
+    answer: "If you unpin content, it may eventually be garbage-collected by the network. Other nodes may still have copies if they've pinned it independently. For cloud storage where deletes are definitive, see our S3-compatible storage option."
   },
   {
     question: "Can I pay with crypto?",
@@ -76,13 +77,30 @@ const faqs = [
     client:load
   />
 
-  <AboutSection
-    subtitle="Use Cases"
-    title="From NFT metadata to dApp assets"
-    description="IPFS pinning powers a range of use cases: NFT metadata and asset storage, dApp frontend hosting, scientific data publishing with verifiable hashes, archival content that needs to stay link-stable, and any data that benefits from content addressing. If you need a link that points to the same data forever, IPFS pinning is the answer."
-    theme="white"
-    imageUrl={UseCasesImage}
-    imageAlt="Use cases for IPFS pinning: NFT metadata, dApp assets, scientific data, and archival content"
+  <UseCaseSection
+    heading="What you can do with IPFS pinning"
+    subheading="Permanent, verifiable links for content that needs to stay accessible."
+    variant="white"
+    cases={[
+      {
+        title: "NFT Metadata & Assets",
+        description: "Pin NFT metadata, artwork, and on-chain assets with permanent links. Content stays accessible as long as it's pinned, no dependency on a single marketplace or server.",
+        cta: "Start Pinning",
+        href: config.registerUrl("pinning"),
+      },
+      {
+        title: "Verifiable Public Data",
+        description: "Publish scientific datasets, public records, and archival data with permanent links. Anyone can verify the data hasn't been altered since no single organization controls access.",
+        cta: "Start Pinning",
+        href: config.registerUrl("pinning"),
+      },
+      {
+        title: "dApp Frontends",
+        description: "Host your decentralized application frontend on IPFS. Deploy from the CLI, a zip file, or GitHub Actions. Your users get a permanent link to your interface.",
+        cta: "Host a dApp",
+        href: "/solutions/website-hosting",
+      },
+    ]}
     client:load
   />
 

--- a/apps/pinner.xyz/src/pages/solutions/s3-storage.astro
+++ b/apps/pinner.xyz/src/pages/solutions/s3-storage.astro
@@ -13,6 +13,7 @@ import { config, ctaCopy } from '@/lib/config';
 import EncryptionImage from "@/assets/solutions-website-static-sites.jpg";
 import UploadFlowSection from "@/components/HowItWorks/UploadFlowSection";
 import DistributionSection from "@/components/HowItWorks/DistributionSection";
+import UseCaseSection from "@/components/UseCaseSection";
 
 const faqs = [
   {
@@ -74,6 +75,33 @@ const faqs = [
     client:load
   />
 
+  <UseCaseSection
+    heading="What you can store"
+    subheading="Use the S3 tools you already have, on a network you control."
+    variant="gray"
+    cases={[
+      {
+        title: "Backups & Disaster Recovery",
+        description: "Automated backups to S3-compatible storage on a peer-to-peer network. Use rclone, restic, or any S3 backup tool you already run. Encrypted by default, no surprise bills.",
+        cta: "Start Storing",
+        href: config.registerUrl("storing"),
+      },
+      {
+        title: "Private AI & RAG Pipelines",
+        description: "Store embeddings, vector databases, and knowledge bases through your own gateway. Your data is encrypted locally before it leaves your server. You control the keys.",
+        cta: "Start Storing",
+        href: config.registerUrl("storing"),
+      },
+      {
+        title: "Agency Client Files",
+        description: "Keep sensitive client documents on storage you control. Deploy your own gateway, use your existing S3 tools, and maintain custody of your encryption keys.",
+        cta: "Start Storing",
+        href: config.registerUrl("storing"),
+      },
+    ]}
+    client:load
+  />
+
   <section class="py-[60px] md:py-[120px] bg-white">
     <div class="xl:container px-6">
       <h2 class="text-[24px] sm:text-[28px] md:text-[31px] font-medium text-content-text text-center mb-10 md:mb-14">Frequently Asked Questions</h2>
@@ -96,7 +124,7 @@ const faqs = [
   </section>
 
   <RelatedPages links={[
-    { href: "/solutions/private-storage", label: "Private Storage", description: "Encrypted file storage with zero-knowledge architecture" },
+    { href: "/solutions/cloud-storage", label: "Cloud Storage", description: "Encrypted file storage with zero-knowledge architecture" },
     { href: "/solutions/ipfs-pinning", label: "IPFS Pinning", description: "Pin files to a peer-to-peer network with permanent links" },
     { href: "/how-it-works", label: "How It Works", description: "Understand where your money goes and how storage proofs work" },
   ]} />

--- a/apps/pinner.xyz/src/pages/solutions/website-hosting.astro
+++ b/apps/pinner.xyz/src/pages/solutions/website-hosting.astro
@@ -14,6 +14,7 @@ import { frameworkList, worksWithFrameworks } from '@/lib/frameworks';
 import StaticSitesImage from "@/assets/solutions-website-static-sites.jpg";
 import UploadFlowSection from "@/components/HowItWorks/UploadFlowSection";
 import DistributionSection from "@/components/HowItWorks/DistributionSection";
+import UseCaseSection from "@/components/UseCaseSection";
 
 const faqs = [
   {
@@ -78,6 +79,33 @@ const faqs = [
     theme="white"
     imageUrl={StaticSitesImage}
     imageAlt="Static site frameworks including Astro, Next.js, Hugo, and others that deploy to Pinner"
+    client:load
+  />
+
+  <UseCaseSection
+    heading="What you can host"
+    subheading="If it builds to static files, it works here."
+    variant="gray"
+    cases={[
+      {
+        title: "Static Sites & Portfolios",
+        description: "Host portfolios, landing pages, and marketing sites with a permanent address. Deploy from the CLI, a zip file, or GitHub Actions. No vendor lock-in, no surprise bills.",
+        cta: "Host a Site",
+        href: config.registerUrl("hosting"),
+      },
+      {
+        title: "Developer Workflows",
+        description: "Deploy from GitHub Actions, CI/CD pipelines, or the CLI. Your build output gets a permanent link that never breaks. Point a custom domain at it for a familiar URL.",
+        cta: "Host a Site",
+        href: config.registerUrl("hosting"),
+      },
+      {
+        title: "dApp Frontends",
+        description: "Host decentralized application frontends on IPFS. Your users get a permanent, content-addressed link to your interface that doesn't depend on a single server.",
+        cta: "Learn About Pinning",
+        href: "/solutions/ipfs-pinning",
+      },
+    ]}
     client:load
   />
 


### PR DESCRIPTION
## Changes

- **Homepage rewrite**: Clear hero copy ("Storage & hosting where you're in control."), simplified page flow (Hero, Problem, Trust, Products, CTA)
- **OG social cards**: Updated copy via Satori pipeline for default, about, and pricing cards
- **Cloud storage rename**: `/solutions/private-storage` -> `/solutions/cloud-storage` across URL paths, nav, footer, product cards, and cross-references
- **How-it-works copy**: Removed service-specific assumptions from step descriptions
- **Solution pages**: Added UseCaseSection component to IPFS pinning, website hosting, S3 storage, and cloud storage pages
- **Meta updates**: Titles and descriptions refreshed across about, pricing, and how-it-works pages

---

<!-- kody-pr-summary:start -->
This PR rewrites the pinner.xyz homepage, updates Open Graph card content, and renames "Private Storage" to "Cloud Storage" across the entire site.

## Key Changes

**Homepage Rewrite**
- Simplified the hero section with a new headline ("Storage & hosting where you're in control") and cleaner subheadline
- Removed multiple homepage sections including UseCases, BrandLogos, Account, FAQ, FoundingOfferBanner, PaymentMethodsBar, PricingTable, and NewsletterSignup for a more focused landing experience
- Updated the ProductCards section heading to "One plan. Every feature." with revised copy
- Updated the homepage CTA copy to emphasize data ownership and open-source values

**"Private Storage" → "Cloud Storage" Rename**
- Renamed the product label and all associated URLs from `/solutions/private-storage` to `/solutions/cloud-storage` across the navbar, product cards, use cases, differentiators table, mission section, pricing FAQs, and related page links
- Updated all user-facing copy, newsletter signup messages, and meta descriptions to reflect the new "Cloud Storage" naming

**Open Graph Cards**
- Rewrote OG card content for the default, about, and pricing pages with new headlines, subtitles, and footers that align with the updated messaging

**New Reusable UseCaseSection Component**
- Added a `UseCaseSection` component that renders a grid of use-case cards with support for light/dark variants
- Integrated this component into the IPFS pinning, website hosting, S3 storage, and cloud storage (personal) solution pages, replacing or supplementing existing use-case content with structured, product-specific examples

**Meta & SEO Updates**
- Updated page titles and descriptions across the homepage, about, how-it-works, pricing, and alternative pages to match the new messaging direction
<!-- kody-pr-summary:end -->