### PR TITLE
fix(portal-framework-auth): preserve ?to= redirect param across all auth entry points

### DIFF
--- a/libs/portal-framework-auth/src/dataProviders/auth.spec.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.spec.ts
@@ -9,7 +9,7 @@ vi.mock("@lumeweb/portal-framework-core", () => ({
   getApiBaseUrl: () => "https://example.com",
 }));
 
-import { isExternalRedirect, sanitizeRedirectUrl } from "./auth";
+import { createAuthProvider, isExternalRedirect, sanitizeRedirectUrl } from "./auth";
 
 describe("sanitizeRedirectUrl", () => {
   beforeEach(() => {
@@ -155,5 +155,98 @@ describe("isExternalRedirect", () => {
 
   it("should return false for invalid URLs", () => {
     expect(isExternalRedirect("not-a-url")).toBe(false);
+  });
+});
+
+describe("createAuthProvider check() redirect", () => {
+  beforeEach(() => {
+    vi.stubGlobal("location", {
+      hostname: "account.example.com",
+      href: "https://account.example.com/",
+      origin: "https://account.example.com",
+      search: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function createSdk(pingResult: { data: { token?: string } } | { error: Error }) {
+    return {
+      account: () => ({
+        ping: vi.fn().mockResolvedValue(pingResult),
+      }),
+      setAuthToken: vi.fn(),
+    } as any;
+  }
+
+  it("should redirect to /login without ?to= when no to param present", async () => {
+    vi.stubGlobal("location", {
+      hostname: "account.example.com",
+      href: "https://account.example.com/",
+      origin: "https://account.example.com",
+      search: "",
+    });
+
+    const sdk = createSdk({ error: new Error("unauthorized") });
+    const provider = createAuthProvider(sdk);
+    const result = await provider.check();
+
+    expect(result.authenticated).toBe(false);
+    expect(result.redirectTo).toBe("/login");
+  });
+
+  it("should preserve ?to= cross-subdomain URL when redirecting unauthenticated user", async () => {
+    const toUrl = "https://sia.example.com/auth/connect/abc123";
+    vi.stubGlobal("location", {
+      hostname: "account.example.com",
+      href: `https://account.example.com/?to=${encodeURIComponent(toUrl)}`,
+      origin: "https://account.example.com",
+      search: `?to=${encodeURIComponent(toUrl)}`,
+    });
+
+    const sdk = createSdk({ error: new Error("unauthorized") });
+    const provider = createAuthProvider(sdk);
+    const result = await provider.check();
+
+    expect(result.authenticated).toBe(false);
+    expect(result.redirectTo).toBe(
+      `/login?to=${encodeURIComponent(toUrl)}`,
+    );
+  });
+
+  it("should sanitize external ?to= to /dashboard when redirecting unauthenticated user", async () => {
+    vi.stubGlobal("location", {
+      hostname: "account.example.com",
+      href: "https://account.example.com/?to=https://evil.com/path",
+      origin: "https://account.example.com",
+      search: "?to=https%3A%2F%2Fevil.com%2Fpath",
+    });
+
+    const sdk = createSdk({ error: new Error("unauthorized") });
+    const provider = createAuthProvider(sdk);
+    const result = await provider.check();
+
+    expect(result.authenticated).toBe(false);
+    expect(result.redirectTo).toBe(
+      `/login?to=${encodeURIComponent("/dashboard")}`,
+    );
+  });
+
+  it("should preserve relative ?to= path when redirecting unauthenticated user", async () => {
+    vi.stubGlobal("location", {
+      hostname: "account.example.com",
+      href: "https://account.example.com/?to=/dashboard",
+      origin: "https://account.example.com",
+      search: "?to=/dashboard",
+    });
+
+    const sdk = createSdk({ error: new Error("unauthorized") });
+    const provider = createAuthProvider(sdk);
+    const result = await provider.check();
+
+    expect(result.authenticated).toBe(false);
+    expect(result.redirectTo).toBe(`/login?to=${encodeURIComponent("/dashboard")}`);
   });
 });

--- a/libs/portal-framework-auth/src/dataProviders/auth.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.ts
@@ -229,10 +229,18 @@ export const createAuthProvider = (sdk: Sdk): AuthProviderWithEmitter => {
 
       if (isErrorResult(response)) {
         emitter.emit("authCheckFailed", { error: response.error });
+        const to =
+          typeof window !== "undefined"
+            ? new URLSearchParams(window.location.search).get("to")
+            : null;
+        const sanitizedTo = to ? sanitizeRedirectUrl(to) : null;
+        const redirectTo = sanitizedTo
+          ? `${LOGIN_PATH}?to=${encodeURIComponent(sanitizedTo)}`
+          : LOGIN_PATH;
         return {
           authenticated: false,
           error: response.error,
-          redirectTo: LOGIN_PATH,
+          redirectTo,
         };
       }
 

--- a/libs/portal-framework-auth/src/ui/components/index/AuthedIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/index/AuthedIndex.tsx
@@ -1,17 +1,21 @@
 import { Loading, withTheme } from "@lumeweb/portal-framework-ui";
 import { Authenticated } from "@refinedev/core";
 import React from "react";
-import { Navigate } from "react-router";
+import { useSearchParams } from "react-router";
 
-function AuthedIndex() {
+import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
+
+const Component: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const to = searchParams.get("to") ?? undefined;
+
+  useRedirectIfAuthenticated("/dashboard", to);
+
   return (
-    <Authenticated
-      key={"index"}
-      loading={<Loading aria-label="Checking login status" />}
-      v3LegacyAuthProviderCompatible>
-      <Navigate replace to="/dashboard" />
+    <Authenticated key="authed" fallback={<Loading />}>
+      <Loading />
     </Authenticated>
   );
-}
+};
 
-export default withTheme(AuthedIndex);
+export default withTheme(Component, "AuthedIndex");


### PR DESCRIPTION
## Summary
- AuthedIndex uses useRedirectIfAuthenticated instead of hardcoded /dashboard redirect, preserving ?to= for already-authenticated users
- Auth provider check() preserves ?to= from current URL when redirecting unauthenticated users to /login
- Added regression tests for check() redirect behavior (cross-subdomain, external, relative, missing)

---

<!-- kody-pr-summary:start -->
This PR ensures the `?to=` redirect parameter is preserved across all authentication entry points, so users are redirected back to their originally requested destination after logging in.

**Changes:**

- **Auth provider (`auth.ts`)**: When an unauthenticated user is redirected to the login page, the `?to=` query parameter from the current URL is now read, sanitized, and forwarded to the login redirect URL. Previously, the redirect always went to `/login` without preserving the intended destination.

- **AuthedIndex component (`AuthedIndex.tsx`)**: Refactored to read the `?to=` parameter from the URL and pass it to the `useRedirectIfAuthenticated` hook, ensuring authenticated users visiting the index page are redirected to their intended destination (or `/dashboard` by default) rather than always going to `/dashboard`. Also migrated from the legacy `v3LegacyAuthProviderCompatible` API to the current `Authenticated` component API.

- **Tests (`auth.spec.ts`)**: Added test coverage for the new redirect behavior, verifying that the `to` parameter is correctly preserved for relative paths and cross-subdomain URLs, sanitized to `/dashboard` for external URLs, and omitted entirely when not present.
<!-- kody-pr-summary:end -->