### PR TITLE
feat: add split-mode Dockerfile and update vocs to 2.3.0

### DIFF
--- a/apps/docs.pinner.xyz/Dockerfile
+++ b/apps/docs.pinner.xyz/Dockerfile
@@ -1,18 +1,15 @@
-# Pinner Docs Backend
+# Pinner Docs API (Split Mode)
 # Multi-stage build: tsdown-bundled standalone server (no node_modules at runtime)
-# Static frontend is built separately and deployed to IPFS
+# Static frontend is built separately and deployed to IPFS/CDN.
+# This image only serves the API routes (OG, MCP, feedback).
 #
-# Result: ~40MB runtime image with zero node_modules
-# tsdown bundles all npm deps (hono, vocs, etc.) via Rolldown.
-# Only Node.js built-ins remain external (platform: 'node').
+# Set VOCS_RENDER_STRATEGY=split to activate split-mode behavior.
+# Result: ~30MB runtime image with zero node_modules (no static assets bundled).
 #
 # Layout at runtime:
 #   /app/server/serve-node.mjs  (entry + chunks, ~25MB)
 #   /app/vocs.config.js         (compiled config, 12KB)
 #   /app/assets/                (Vocs config definition, 6MB)
-#
-# vocs.config.js is placed one dir above server/ because the
-# config resolver does: path.resolve(import.meta.dirname, "../vocs.config.js")
 
 # ── Stage 1a: Build pinner-cli ────────────────────────────────────────────
 FROM golang:1.26 AS pinner-cli
@@ -21,7 +18,6 @@ RUN go install go.lumeweb.com/pinner-cli/cmd/pinner@latest
 # ── Stage 1b: Build docs ──────────────────────────────────────────────────
 FROM node:22-slim AS builder
 
-# Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /build
@@ -45,10 +41,6 @@ COPY libs/pinner/tsconfig.typedoc.json libs/pinner/tsconfig.typedoc.json
 COPY tsconfig.base.json tsconfig.base.json
 
 # Build: inline the build chain to avoid pnpm's runDepsStatusCheck
-# (pnpm v11 re-runs install before every pnpm script invocation, which
-# fails on workspace-level unused patches)
-# pinner binary is already copied from the golang stage, so setup-pinner-cli.sh
-# is a no-op (it exits early when pinner is on PATH)
 WORKDIR /build/apps/docs.pinner.xyz
 RUN mkdir -p reference-sources \
     && pinner generate-docs json > reference-sources/cli-ref.json \
@@ -63,7 +55,6 @@ RUN npx tsdown
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────
 FROM node:22-slim AS runtime
 
-# Non-root user
 RUN groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin app
 
 # Server bundle + chunks
@@ -75,11 +66,7 @@ COPY --from=builder /build/apps/docs.pinner.xyz/dist/server/vocs.config.js /app/
 # Vocs config definition module (imported by vocs.config.js)
 COPY --from=builder /build/apps/docs.pinner.xyz/dist/server/assets/ /app/assets/
 
-# Static frontend assets
-# fetchMarkdown: distDir = dirname(import.meta.url)/.. = /app, reads /app/public/
-# serveStatic: config.distDir ("dist") + "public" relative to CWD = /app/server/dist/public/
-COPY --from=builder /build/apps/docs.pinner.xyz/dist/public/ /app/public/
-RUN mkdir -p /app/server/dist && ln -s /app/public /app/server/dist/public
+# No static frontend assets in split mode — those are deployed to IPFS/CDN separately
 
 RUN chown -R app:app /app
 
@@ -87,9 +74,10 @@ USER app
 WORKDIR /app/server
 
 ENV HOST=0.0.0.0
-ENV PORT=5173
-ENV VOCS_RENDER_STRATEGY=dynamic
+ENV PORT=3001
+ENV VOCS_RENDER_STRATEGY=split
+ENV NODE_ENV=production
 
-EXPOSE 5173
+EXPOSE 3001
 
 CMD ["node", "serve-node.mjs"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ catalogs:
       specifier: ^2.2.0
       version: 2.2.0
     vocs:
-      specifier: ^2.2.1
-      version: 2.2.1
+      specifier: ^2.3.0
+      version: 2.3.0
     zod:
       specifier: ^4.4.3
       version: 4.4.3
@@ -311,7 +311,7 @@ patchedDependencies:
   object-inspect: 58d41550bac212c6dff14bd065070f98aa763f5cfcdd9bf73f9f83f728e19cd8
   papaparse: 8db42de1f1871890a205b993db193bd7914e8201801637ba4b6247c7604f7c56
   pluralize: 88650615c62a180c406201cd54b23afb592a6a678db498f8b1a730f85ca868d2
-  vocs: 8dccd878c1f5f7562a044e19b3416674f41cc8550dfc6aec0b23a04d67520b5c
+  vocs@2.3.0: 09e6f098155fbef86c55906ac127bf13789e56a843aba02c08d6002f53159b2a
   warn-once: 5720ed82c72c077a0bf56dcede206d50538aa93a6bc2c943e8610ea924298b87
 
 importers:
@@ -486,7 +486,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       vocs:
         specifier: 'catalog:'
-        version: 2.2.1(patch_hash=8dccd878c1f5f7562a044e19b3416674f41cc8550dfc6aec0b23a04d67520b5c)(5d6dc1955313fc0a6b9d753608dadbd3)
+        version: 2.3.0(patch_hash=09e6f098155fbef86c55906ac127bf13789e56a843aba02c08d6002f53159b2a)(5d6dc1955313fc0a6b9d753608dadbd3)
       waku:
         specifier: 1.0.0-beta.0
         version: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -507,7 +507,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       vocs:
         specifier: 'catalog:'
-        version: 2.2.1(patch_hash=8dccd878c1f5f7562a044e19b3416674f41cc8550dfc6aec0b23a04d67520b5c)(5d6dc1955313fc0a6b9d753608dadbd3)
+        version: 2.3.0(patch_hash=09e6f098155fbef86c55906ac127bf13789e56a843aba02c08d6002f53159b2a)(5d6dc1955313fc0a6b9d753608dadbd3)
       waku:
         specifier: 1.0.0-beta.0
         version: 1.0.0-beta.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -7801,17 +7801,8 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.2.0'
 
-  '@tailwindcss/node@4.3.1':
-    resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
-
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
-
-  '@tailwindcss/oxide-android-arm64@4.3.1':
-    resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [android]
 
   '@tailwindcss/oxide-android-arm64@4.3.2':
     resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
@@ -7819,22 +7810,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.1':
-    resolution: {integrity: sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@tailwindcss/oxide-darwin-arm64@4.3.2':
     resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-darwin-x64@4.3.1':
-    resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
     os: [darwin]
 
   '@tailwindcss/oxide-darwin-x64@4.3.2':
@@ -7843,36 +7822,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.1':
-    resolution: {integrity: sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@tailwindcss/oxide-freebsd-x64@4.3.2':
     resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
-    resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
-    engines: {node: '>= 20'}
-    cpu: [arm]
-    os: [linux]
-
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
     resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
-    resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
     resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
@@ -7881,26 +7841,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
-    resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
-    resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
@@ -7909,31 +7855,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
-    resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
-
-  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
-    resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-    bundledDependencies:
-      - '@napi-rs/wasm-runtime'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@tybys/wasm-util'
-      - '@emnapi/wasi-threads'
-      - tslib
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
@@ -7947,22 +7874,10 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
-    resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [win32]
-
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
     resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
-    os: [win32]
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
-    resolution: {integrity: sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
     os: [win32]
 
   '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
@@ -7970,10 +7885,6 @@ packages:
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
-
-  '@tailwindcss/oxide@4.3.1':
-    resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
-    engines: {node: '>= 20'}
 
   '@tailwindcss/oxide@4.3.2':
     resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
@@ -7983,11 +7894,6 @@ packages:
     resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
-
-  '@tailwindcss/vite@4.3.1':
-    resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
-    peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tailwindcss/vite@4.3.2':
     resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
@@ -10425,6 +10331,9 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -15908,8 +15817,8 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
-  vocs@2.2.1:
-    resolution: {integrity: sha512-naPotNSOk6l9UHqE75Yn5cMN/BmAmwDl5QnE4TVZ46XdhGd+oSEDw7SmiMdHV/sI5qmH1PlAtPLVAwtVUKNSXQ==}
+  vocs@2.3.0:
+    resolution: {integrity: sha512-pWfoG3J2iUrllEKZi83TkR+53tXl9HAvZ47lPuwH/8r866Hp7B/zBbcaDF2hDK2BCpIsTcZb+EN+yh0ViHph7w==}
     hasBin: true
     peerDependencies:
       '@vocs/twoslash-rust': ^0.1.0
@@ -17966,9 +17875,9 @@ snapshots:
   '@gwhitney/detect-indent@7.0.1':
     optional: true
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.1)':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.2)':
     dependencies:
-      tailwindcss: 4.3.1
+      tailwindcss: 4.3.2
 
   '@headlessui/vue@1.7.23(vue@3.5.38(typescript@6.0.3))':
     dependencies:
@@ -21773,17 +21682,17 @@ snapshots:
 
   '@rspack/lite-tapable@1.0.1': {}
 
-  '@scalar/api-client@3.12.0(axios@1.16.0)(idb-keyval@6.2.6)(jwt-decode@4.0.0)(qrcode@1.5.4)(tailwindcss@4.3.1)(typescript@6.0.3)':
+  '@scalar/api-client@3.12.0(axios@1.16.0)(idb-keyval@6.2.6)(jwt-decode@4.0.0)(qrcode@1.5.4)(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.1)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.2)
       '@headlessui/vue': 1.7.23(vue@3.5.38(typescript@6.0.3))
-      '@scalar/blocks': 0.1.0(tailwindcss@4.3.1)(typescript@6.0.3)
-      '@scalar/components': 0.27.4(tailwindcss@4.3.1)(typescript@6.0.3)
+      '@scalar/blocks': 0.1.0(tailwindcss@4.3.2)(typescript@6.0.3)
+      '@scalar/components': 0.27.4(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/oas-utils': 0.19.1(typescript@6.0.3)
       '@scalar/openapi-types': 0.9.1
-      '@scalar/sidebar': 0.9.25(tailwindcss@4.3.1)(typescript@6.0.3)
+      '@scalar/sidebar': 0.9.25(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/snippetz': 0.9.19
       '@scalar/themes': 0.16.2
       '@scalar/typebox': 0.1.3
@@ -21821,9 +21730,9 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@scalar/blocks@0.1.0(tailwindcss@4.3.1)(typescript@6.0.3)':
+  '@scalar/blocks@0.1.0(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.4(tailwindcss@4.3.1)(typescript@6.0.3)
+      '@scalar/components': 0.27.4(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/snippetz': 0.9.19
@@ -21859,11 +21768,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@scalar/components@0.27.4(tailwindcss@4.3.1)(typescript@6.0.3)':
+  '@scalar/components@0.27.4(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/utils': 0.2.10
       '@floating-ui/vue': 1.1.9(vue@3.5.38(typescript@6.0.3))
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.1)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.2)
       '@headlessui/vue': 1.7.23(vue@3.5.38(typescript@6.0.3))
       '@scalar/code-highlight': 0.4.0
       '@scalar/helpers': 0.9.0
@@ -21949,9 +21858,9 @@ snapshots:
       '@scalar/helpers': 0.9.0
       '@scalar/validation': 0.6.0
 
-  '@scalar/sidebar@0.9.25(tailwindcss@4.3.1)(typescript@6.0.3)':
+  '@scalar/sidebar@0.9.25(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.4(tailwindcss@4.3.1)(typescript@6.0.3)
+      '@scalar/components': 0.27.4(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/themes': 0.16.2
@@ -22538,16 +22447,6 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
 
-  '@tailwindcss/node@4.3.1':
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.6
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      magic-string: 0.30.21
-      source-map-js: 1.2.1
-      tailwindcss: 4.3.1
-
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -22558,92 +22457,41 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.3.2
 
-  '@tailwindcss/oxide-android-arm64@4.3.1':
-    optional: true
-
   '@tailwindcss/oxide-android-arm64@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-darwin-arm64@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.3.2':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.3.1':
-    optional: true
-
   '@tailwindcss/oxide-darwin-x64@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-freebsd-x64@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.3.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
-    optional: true
-
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
-    optional: true
-
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.1':
-    optional: true
-
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
-    optional: true
-
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
     optional: true
-
-  '@tailwindcss/oxide@4.3.1':
-    optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.3.1
-      '@tailwindcss/oxide-darwin-arm64': 4.3.1
-      '@tailwindcss/oxide-darwin-x64': 4.3.1
-      '@tailwindcss/oxide-freebsd-x64': 4.3.1
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.1
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.1
-      '@tailwindcss/oxide-linux-arm64-musl': 4.3.1
-      '@tailwindcss/oxide-linux-x64-gnu': 4.3.1
-      '@tailwindcss/oxide-linux-x64-musl': 4.3.1
-      '@tailwindcss/oxide-wasm32-wasi': 4.3.1
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
-      '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
   '@tailwindcss/oxide@4.3.2':
     optionalDependencies:
@@ -22664,13 +22512,6 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
-
-  '@tailwindcss/vite@4.3.1(vite@8.0.16)':
-    dependencies:
-      '@tailwindcss/node': 4.3.1
-      '@tailwindcss/oxide': 4.3.1
-      tailwindcss: 4.3.1
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.2(vite@8.0.16)':
     dependencies:
@@ -23043,7 +22884,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -23760,6 +23601,14 @@ snapshots:
       vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.16)
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)
       babel-plugin-react-compiler: 1.0.0
 
   '@vitejs/plugin-rsc@0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(vite@8.0.16)':
@@ -25918,6 +25767,8 @@ snapshots:
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -30701,7 +30552,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
@@ -31743,9 +31594,9 @@ snapshots:
     dependencies:
       tailwindcss: 4.2.4
 
-  tailwindcss-logical@4.2.0(tailwindcss@4.3.1):
+  tailwindcss-logical@4.2.0(tailwindcss@4.3.2):
     dependencies:
-      tailwindcss: 4.3.1
+      tailwindcss: 4.3.2
 
   tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -32701,7 +32552,7 @@ snapshots:
 
   vlq@1.0.1: {}
 
-  vocs@2.2.1(patch_hash=8dccd878c1f5f7562a044e19b3416674f41cc8550dfc6aec0b23a04d67520b5c)(5d6dc1955313fc0a6b9d753608dadbd3):
+  vocs@2.3.0(patch_hash=09e6f098155fbef86c55906ac127bf13789e56a843aba02c08d6002f53159b2a)(5d6dc1955313fc0a6b9d753608dadbd3):
     dependencies:
       '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -32716,7 +32567,7 @@ snapshots:
       '@mdx-js/rollup': 3.1.1(rollup@4.60.2)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@remix-run/node-fetch-server': 0.13.3
-      '@scalar/api-client': 3.12.0(axios@1.16.0)(idb-keyval@6.2.6)(jwt-decode@4.0.0)(qrcode@1.5.4)(tailwindcss@4.3.1)(typescript@6.0.3)
+      '@scalar/api-client': 3.12.0(axios@1.16.0)(idb-keyval@6.2.6)(jwt-decode@4.0.0)(qrcode@1.5.4)(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/openapi-parser': 0.28.7
       '@scalar/snippetz': 0.9.19
       '@scalar/workspace-store': 0.54.5(typescript@6.0.3)
@@ -32726,14 +32577,15 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
-      '@tailwindcss/vite': 4.3.1(vite@8.0.16)
+      '@tailwindcss/vite': 4.3.2(vite@8.0.16)
       '@takumi-rs/image-response': 0.62.8
       '@takumi-rs/wasm': 0.62.8
-      '@vitejs/plugin-react': 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)
+      '@vitejs/plugin-react': 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)
       '@vitejs/plugin-rsc': 0.5.27(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.13)))(react@19.2.7)(vite@8.0.16)
       cac: 6.7.14
       cva: class-variance-authority@0.7.1
       debug: 4.4.3
+      es-module-lexer: 2.3.0
       esast-util-from-js: 2.0.1
       estree-util-value-to-estree: 3.5.0
       estree-util-visit: 2.0.0
@@ -32768,8 +32620,8 @@ snapshots:
       remark-stringify: 11.0.0
       shiki: 3.23.0
       sucrase: 3.35.1
-      tailwindcss: 4.3.1
-      tailwindcss-logical: 4.2.0(tailwindcss@4.3.1)
+      tailwindcss: 4.3.2
+      tailwindcss-logical: 4.2.0(tailwindcss@4.3.2)
       tsx: 4.22.4
       twoslash: 0.3.8(typescript@6.0.3)
       unified: 11.0.5
@@ -33029,7 +32881,7 @@ snapshots:
       browserslist: 4.28.4
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.0
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,7 +97,7 @@ catalog:
   vite: 8.0.16
 
   vitest: ^4.1.9
-  vocs: ^2.2.1
+  vocs: ^2.3.0
   entities: ^8.0.0
   p-queue: ^9.3.0
   zod: ^4.4.3
@@ -165,7 +165,7 @@ patchedDependencies:
   papaparse: patches/papaparse.patch
   '@uppy/core': patches/@uppy__core.patch
   better-sse@0.16.1: patches/better-sse@0.16.1.patch
-  vocs: patches/vocs.patch
+  vocs@2.3.0: patches/vocs.patch
 
 onlyBuiltDependencies:
   - '@ipshipyard/node-datachannel'


### PR DESCRIPTION
## What

- Add standalone Dockerfile for Vocs split-mode (API-only serving)
- Serves MCP, OG image, and feedback routes without frontend assets
- Runtime image is ~30MB with zero node_modules
- Frontend built separately and deployed to IPFS/CDN

## Changes

- Rename `Dockerfile.split` to `Dockerfile`
- Update vocs catalog to `^2.3.0` (rebased on upstream)
- Replace old vocs patch with updated `patches/vocs.patch` for 2.3.0
- Update pnpm-lock.yaml

## Depends on

- LumeWeb/vocs `split-api-mode` branch

---

<!-- kody-pr-summary:start -->
This PR adds a split-mode Dockerfile for the Pinner docs site and upgrades Vocs from 2.2.1 to 2.3.0.

**Key changes:**

1. **Split-mode Dockerfile**: The Dockerfile for `docs.pinner.xyz` is updated to use `VOCS_RENDER_STRATEGY=split`, which separates the API server (OG, MCP, feedback routes) from the static frontend. Static frontend assets are no longer bundled into the Docker image — they are deployed separately to IPFS/CDN. The runtime port changed from 5173 to 3001, and `NODE_ENV=production` is now set explicitly.

2. **Vocs upgrade to 2.3.0**: The Vocs dependency is bumped from `^2.2.1` to `^2.3.0` across the workspace catalog, lockfile, and patch hash configuration. This also pulls in updated transitive dependencies including `@tailwindcss` packages (4.3.1 → 4.3.2), `@vitejs/plugin-react` (6.0.2 → 6.0.3), and `es-module-lexer` (2.1.0 → 2.3.0).

3. **Patch configuration update**: The `patchedDependencies` entry for vocs is updated to use the version-scoped format (`vocs@2.3.0`) to match the new version.
<!-- kody-pr-summary:end -->