### PR TITLE
feat(pinner.xyz): replace technical jargon with plain language, add static pricing fallback and IPNS proof line

### DIFF
--- a/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
+++ b/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
@@ -16,7 +16,7 @@ const rows = [
     factor: "Can we read your data?",
     values: [
       "Yes",
-      "No. Zero-knowledge encryption means we can't read your files",
+      "No. We can't read your files",
       "Yes, but it's public",
     ],
   },

--- a/apps/pinner.xyz/src/components/Footer.astro
+++ b/apps/pinner.xyz/src/components/Footer.astro
@@ -118,6 +118,9 @@ const columns = [
           </a>{" "}
           service
         </p>
+        <p class={`${t.small} text-xs opacity-50`}>
+          This site is hosted on Pinner. IPNS: <code class="font-mono">k51qzi5uqu5dm5cxud9ascpp15dgw43xcbbo20kixob7u5e83z1kudtlrgiwxe</code>
+        </p>
       </div>
     </div>
   </div>

--- a/apps/pinner.xyz/src/components/Home/Account.tsx
+++ b/apps/pinner.xyz/src/components/Home/Account.tsx
@@ -12,7 +12,7 @@ const Account = ({ variant = "default" }: AccountProps) => {
 			<div className="xl:container px-6">
 				<Heading
 				title="Pin. Host. Store."
-   description="Upload to IPFS. Host websites. Store private data with zero-knowledge encryption. Three products, one platform, one set of credentials."
+   description="Upload to IPFS. Host websites. Store private data with encryption. Three products, one platform, one set of credentials."
 				/>
 
 				<AccountSlider />

--- a/apps/pinner.xyz/src/components/Home/FAQ.tsx
+++ b/apps/pinner.xyz/src/components/Home/FAQ.tsx
@@ -20,7 +20,7 @@ const faqs = [
       {
         question: "Is my site always online?",
         answer:
-          "Your files are stored on the Sia network, where independent providers host your data and only get paid when they prove it's there. The serving layer runs through our gateway. A CDN layer is in progress.",
+          "Your files are stored across multiple independent providers who only get paid when they can prove your data is available. A CDN layer is in progress.",
       },
     ],
   },
@@ -40,7 +40,7 @@ const faqs = [
       {
         question: "Is my pinned content public?",
         answer:
-          "Yes. IPFS is a public network. Anyone with the content address can retrieve it. For private data, use cloud storage with zero-knowledge encryption instead.",
+          "Yes. IPFS is a public network. Anyone with the content address can retrieve it. For private data, use cloud storage with encryption instead.",
       },
     ],
   },
@@ -50,17 +50,17 @@ const faqs = [
       {
         question: "Can you read my files?",
         answer:
-          "No. Zero-knowledge encryption means even we don't have the keys. Only you can decrypt your data.",
+          "No. Zero-knowledge encryption means we don't have the keys. Your files are encrypted before they leave your device. Only you can decrypt them.",
       },
       {
         question: "How is this different from IPFS pinning?",
         answer:
-          "IPFS pinning is public, content-addressed storage. Anyone with the address can see it. Private storage encrypts your data before it leaves your device. No one can read it without your keys: not us, not the storage hosts, not the network.",
+          "IPFS pinning is public storage. Anyone with the address can see it. Private storage encrypts your data before it leaves your device. No one can read it without your keys: not us, not the storage hosts, not the network.",
       },
       {
         question: "Are my deletes really deleted?",
         answer:
-          "Yes. Private storage is not content-addressed. When you delete a file, it's gone. No ghost copies floating on the network, no caches that outlive the delete. Storage hosts are paid to keep data, and they lose income when it's removed.",
+          "Yes. When you delete a file from private storage, it's gone. No ghost copies floating on the network, no caches that outlive the delete. Storage hosts are paid to keep data, and they lose income when it's removed.",
       },
     ],
   },

--- a/apps/pinner.xyz/src/components/Home/ProductCards.tsx
+++ b/apps/pinner.xyz/src/components/Home/ProductCards.tsx
@@ -32,7 +32,7 @@ const cards: CardProps[] = [
   {
     title: "S3 Storage",
     description:
-      "S3-compatible object storage backed by the Sia network. Run your own gateway appliance.",
+      "S3-compatible object storage backed by a peer-to-peer network. Run your own gateway appliance.",
     cta: "S3 Compatible →",
     href: "/solutions/s3-storage",
     soon: true,
@@ -40,7 +40,7 @@ const cards: CardProps[] = [
   {
     title: "Cloud Storage",
     description:
-      "Encrypted storage where only you hold the keys. Personal use or build apps on the Sia network.",
+      "Encrypted storage where only you hold the keys. Personal use or build apps on a peer-to-peer network.",
     cta: "Store Privately →",
     href: "/solutions/cloud-storage",
     soon: true,

--- a/apps/pinner.xyz/src/components/Home/TrustSection.tsx
+++ b/apps/pinner.xyz/src/components/Home/TrustSection.tsx
@@ -9,7 +9,7 @@ const principles = [
 	{
 		title: "We can't read your files",
 		description:
-    "Zero-knowledge encryption means even we don't have the keys. That's not a promise. It's the architecture.",
+    "Your data is encrypted before it leaves your device. We don't hold the keys. That's not a promise. It's how the system works.",
 	},
 	{
 		title: "What you see is what you pay",

--- a/apps/pinner.xyz/src/components/Home/UseCases.tsx
+++ b/apps/pinner.xyz/src/components/Home/UseCases.tsx
@@ -12,7 +12,7 @@ const useCases: UseCaseCardProps[] = [
   {
     title: "Private AI & RAG Pipelines",
     description:
-      "Store embeddings, vector databases, and knowledge bases with zero-knowledge encryption. Your data is encrypted before it leaves your device. Even we can't read it.",
+      "Store embeddings, vector databases, and knowledge bases with encryption. Your data is encrypted before it leaves your device. Even we can't read it.",
     cta: "Store Privately →",
     href: "/solutions/cloud-storage",
   },

--- a/apps/pinner.xyz/src/components/MissionSection.tsx
+++ b/apps/pinner.xyz/src/components/MissionSection.tsx
@@ -4,7 +4,7 @@ const beliefs = [
   {
     icon: Lock,
     title: "Private files don't need a privacy policy to stay private",
-    description: "Zero-knowledge encryption on cloud storage. Even we can't read your files",
+    description: "Your files are encrypted before they leave your device. Even we can't read them",
   },
   {
     icon: Shield,

--- a/apps/pinner.xyz/src/components/pricing/PricingPlans.tsx
+++ b/apps/pinner.xyz/src/components/pricing/PricingPlans.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import useSWR from "swr";
+import type { SWRConfiguration } from "swr";
 import { cn } from "@/lib/utils";
 import type { BillingPlan, BillingPlansResponse } from "@/lib/api";
 import { themeStyles } from "./theme";
@@ -7,10 +8,8 @@ import { getPlansApiUrl, fetcher } from "./utils";
 import { Cadence } from "./utils";
 import { CadenceToggle } from "./CadenceToggle";
 import { PlanCard } from "./PlanCard";
-import { SkeletonCard } from "./SkeletonCard";
 import { TrackedButton } from "@/components/TrackedButton";
 import { translateFeature } from "./featureCopy";
-import { Button } from "@/components/ui/button";
 
 const CUSTOM_PLAN: BillingPlan = {
   id: -1,
@@ -25,32 +24,52 @@ const CUSTOM_PLAN: BillingPlan = {
 interface PricingPlansProps {
   variant?: "dark" | "light";
   showToggle?: boolean;
+  fallbackData?: BillingPlansResponse;
 }
 
 const PricingPlans = ({
   variant = "dark",
   showToggle = true,
+  fallbackData,
 }: PricingPlansProps) => {
   const [cadence, setCadence] = useState<Cadence>(Cadence.Monthly);
   const theme = themeStyles[variant];
 
+  const swrConfig: SWRConfiguration<BillingPlansResponse> = {
+    revalidateOnFocus: false,
+    dedupingInterval: 60000,
+    fallbackData,
+  };
+
   const { data, error, isLoading } = useSWR<BillingPlansResponse>(
     getPlansApiUrl(),
     fetcher,
-    {
-      revalidateOnFocus: false,
-      dedupingInterval: 60000,
-    }
+    swrConfig
   );
 
-  const apiPlans = data?.data ?? [];
+  const plans = data?.data ?? fallbackData?.data ?? [];
 
-  if (error) {
+  // When no fallbackData is available (build-time fetch failed), show loading
+  // and error states so the user isn't staring at an empty grid.
+  if (!fallbackData && isLoading) {
     return (
-      <div className="text-center py-16">
-        <p className={cn(theme.errorText, "text-lg mb-4")}>
-          Unable to load pricing plans.
-        </p>
+      <div>
+        {showToggle && (
+          <CadenceToggle cadence={cadence} onChange={setCadence} variant={variant} />
+        )}
+        <div className="grid grid-cols-1 lg:grid-cols-3 md:grid-cols-2 gap-2 md:gap-5 lg:gap-5">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-96 animate-pulse rounded-lg bg-content-divider/30" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!fallbackData && error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-content-text-muted mb-4">Couldn't load plans. Check your connection and try again.</p>
         <button
           onClick={() => window.location.reload()}
           className={cn(
@@ -60,91 +79,84 @@ const PricingPlans = ({
               : "border-content-text text-content-text hover:bg-content-text hover:text-white"
           )}
         >
-          Try Again
+          Retry
         </button>
       </div>
     );
   }
 
+  // Progressive enhancement: if fallbackData exists (build-time fetch), it renders
+  // immediately in the server HTML. SWR revalidates against the live API and
+  // silently updates if newer data is available.
   return (
     <div>
       {showToggle && (
         <CadenceToggle cadence={cadence} onChange={setCadence} variant={variant} />
       )}
 
-      {isLoading ? (
-        <div className="grid grid-cols-1 lg:grid-cols-3 md:grid-cols-2 gap-2 md:gap-5 lg:gap-5">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <SkeletonCard key={i} variant={variant} />
-          ))}
-        </div>
-      ) : (
-        <>
-          <div className="grid grid-cols-1 lg:grid-cols-3 md:grid-cols-2 gap-2 md:gap-5 lg:gap-5">
-            {apiPlans.map((plan) => (
-              <PlanCard
-                key={plan.id}
-                plan={plan}
-                cadence={cadence}
-                variant={variant}
-              />
-            ))}
-          </div>
+      <div className="grid grid-cols-1 lg:grid-cols-3 md:grid-cols-2 gap-2 md:gap-5 lg:gap-5">
+        {plans.map((plan) => (
+          <PlanCard
+            key={plan.id}
+            plan={plan}
+            cadence={cadence}
+            variant={variant}
+          />
+        ))}
+      </div>
 
-          <div
+      <div
+        className={cn(
+          "mt-4 md:mt-6 rounded-lg border p-6 md:p-8 flex flex-col md:flex-row md:items-center md:justify-between gap-4",
+          variant === "dark"
+            ? "border-home-text/20 bg-home-card-bg"
+            : "border-content-divider/50 bg-content-section-gray"
+        )}
+      >
+        <div>
+          <h3
             className={cn(
-              "mt-4 md:mt-6 rounded-lg border p-6 md:p-8 flex flex-col md:flex-row md:items-center md:justify-between gap-4",
-              variant === "dark"
-                ? "border-home-text/20 bg-home-card-bg"
-                : "border-content-divider/50 bg-content-section-gray"
+              theme.title,
+              "text-lg md:text-xl font-medium mb-1"
             )}
           >
-            <div>
-              <h3
-                className={cn(
-                  theme.title,
-                  "text-lg md:text-xl font-medium mb-1"
-                )}
-              >
-                Need more? {CUSTOM_PLAN.description}
-              </h3>
-              <ul
-                className={cn(
-                  theme.description,
-                  "flex flex-col sm:flex-row sm:gap-6 gap-1 text-sm mt-2"
-                )}
-              >
-                {(CUSTOM_PLAN.features ?? []).map((feature) => (
-                  <li key={feature} className="flex items-center gap-2">
-                    <svg
-                      className={cn(theme.description, "shrink-0")}
-                      width="14"
-                      height="14"
-                      viewBox="0 0 16 16"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <polyline points="3 8.5 6.5 12 13 4" />
-                    </svg>
-                    {translateFeature(feature)}
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="flex-shrink-0">
-              <TrackedButton
-                label="Contact Us →"
-                url="/contact"
-                buttonStyle={variant === "light" ? "outline-dark" : "outline"}
-                trackEvent="pricing_custom_plan_contact_clicked"
-              />
-            </div>
-          </div>
-        </>
-      )}
+            Need more? {CUSTOM_PLAN.description}
+          </h3>
+          <ul
+            className={cn(
+              theme.description,
+              "flex flex-col sm:flex-row sm:gap-6 gap-1 text-sm mt-2"
+            )}
+          >
+            {(CUSTOM_PLAN.features ?? []).map((feature) => (
+              <li key={feature} className="flex items-center gap-2">
+                <svg
+                  className={cn(theme.description, "shrink-0")}
+                  width="14"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="3 8.5 6.5 12 13 4" />
+                </svg>
+                {translateFeature(feature)}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex-shrink-0">
+          <TrackedButton
+            label="Contact Us →"
+            url="/contact"
+            buttonStyle={variant === "light" ? "outline-dark" : "outline"}
+            trackEvent="pricing_custom_plan_contact_clicked"
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/apps/pinner.xyz/src/layouts/Layout.astro
+++ b/apps/pinner.xyz/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ import PostHog from "@/components/posthog.astro";
 import UTMCapture from "@/components/UTMCapture";
 import contactsData from "@/data/contacts.json";
 
-const { title, variant = "content", description = "Store files, host websites, and keep your data private by default. One plan, no surprises. Open source, built on Sia.", ogImage: ogImageProp, showNewsletterFooter = true } = Astro.props;
+const { title, variant = "content", description = "Store files, host websites, and keep your data private by default. One plan, no surprises. Open source.", ogImage: ogImageProp, showNewsletterFooter = true } = Astro.props;
 const lastUpdated = getGitLastUpdated();
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? "https://pinner.xyz");
 const siteName = "Pinner";

--- a/apps/pinner.xyz/src/pages/about.astro
+++ b/apps/pinner.xyz/src/pages/about.astro
@@ -32,7 +32,7 @@ import DistributionSection from "@/components/HowItWorks/DistributionSection";
   <UploadFlowSection
     title="Pinner is your storage service."
     subtitle="What is Pinner?"
-    description="Pin files to a peer-to-peer network, host static websites, and store private data with zero-knowledge encryption. All on a verifiable storage network. No middlemen. No data mining possible. No AI training possible. No headaches."
+    description="Pin files to a peer-to-peer network, host static websites, and store private data with encryption. All on a verifiable storage network. No middlemen. No data mining possible. No AI training possible. No headaches."
     theme="white"
     client:load
   />

--- a/apps/pinner.xyz/src/pages/alternatives/netlify/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/netlify/index.astro
@@ -30,7 +30,7 @@ const planRows = [
 const faqs = [
   {
     question: "Can Pinner replace my current hosting?",
-    answer: "It depends on what you need. Pinner hosts built static files with content-addressed storage on a peer-to-peer network. It does not offer serverless functions, CI/CD, form handling, identity, or split testing. If you need those features, keep your current platform. If you want content-addressed hosting with no vendor lock-in on storage and simpler pricing, Pinner is worth a look."
+    answer: "It depends on what you need. Pinner hosts built static files on a peer-to-peer network. It does not offer serverless functions, CI/CD, form handling, identity, or split testing. If you need those features, keep your current platform. If you want hosting with no vendor lock-in on storage and simpler pricing, Pinner is worth a look."
   },
   {
     question: "What makes Pinner different for static hosting?",

--- a/apps/pinner.xyz/src/pages/alternatives/vercel/index.astro
+++ b/apps/pinner.xyz/src/pages/alternatives/vercel/index.astro
@@ -36,7 +36,7 @@ const faqs = [
   },
   {
     question: "Can Pinner replace my current hosting?",
-    answer: "It depends on what you need. Pinner hosts built static files with content-addressed storage on a peer-to-peer network. It does not offer serverless functions, edge functions, CI/CD, or preview deployments. If you need those features, keep your current platform. If you want content-addressed hosting with no vendor lock-in on storage and no per-seat charges, Pinner is worth a look."
+    answer: "It depends on what you need. Pinner hosts built static files on a peer-to-peer network. It does not offer serverless functions, edge functions, CI/CD, or preview deployments. If you need those features, keep your current platform. If you want hosting with no vendor lock-in on storage and no per-seat charges, Pinner is worth a look."
   },
   {
     question: "What makes Pinner different for static hosting?",

--- a/apps/pinner.xyz/src/pages/how-it-works.astro
+++ b/apps/pinner.xyz/src/pages/how-it-works.astro
@@ -14,7 +14,7 @@ import s3StorageImg from "@/assets/how-it-works-s3-storage.jpg";
 import selfHostedImg from "@/assets/how-it-works-self-hosted.jpg";
 ---
 
-<Layout title="How Pinner Works. Storage & Hosting" description="Pin files to a peer-to-peer network, host static websites, and store private data with zero-knowledge encryption. Three steps: pin, distribute, access anywhere.">
+<Layout title="How Pinner Works. Storage & Hosting" description="Pin files to a peer-to-peer network, host static websites, and store private data with encryption. Three steps: pin, distribute, access anywhere.">
   <PageHeader
     title="Simple interface, powerful network"
     description="IPFS pinning, website hosting, and cloud storage on a verifiable storage network"
@@ -24,16 +24,14 @@ import selfHostedImg from "@/assets/how-it-works-self-hosted.jpg";
   <ThreeSteps client:load />
 
   <UploadFlowSection
-    title="Pin to IPFS, host to the web"
-    subtitle="The Interface"
-     description="Upload files through our CLI or SDK. We pin them to IPFS. Your content gets a link that stays online as long as it's pinned. Host static websites directly from pinned content. No setup required."
+    title="Verified storage and hosting"
+     description="Upload files through an app, CLI, S3-compatible tools, or API. Your content gets a permanent link that stays online as long as it's stored. Host static websites directly from your stored content."
     client:load
   />
 
   <DistributionSection
     title="A network, not a data center"
-    subtitle="The Technology"
-    description="Your files are distributed across many independent storage providers. No single entity controls your data, and your files stay online even if individual servers go down. Stored on IPFS with reliable addresses, encrypted for private storage. Depending on your storage model."
+    description="Your files are distributed across many independent storage providers. No single entity controls your data, and your files stay online even if individual servers go down. Your files get permanent links that don't change, and private storage is encrypted so even we can't read it."
     theme="gray"
     imagePosition="right"
     buttonText="Learn About Sia →"
@@ -45,18 +43,16 @@ import selfHostedImg from "@/assets/how-it-works-self-hosted.jpg";
 
   <AboutSection
     title="Private storage with S3 compatibility"
-    subtitle="S3 Storage (Advanced)"
-    description="For private data, Pinner offers S3-compatible storage, encrypted at rest with zero-knowledge encryption. Even we can't read your files. Currently available for advanced setups that deploy their own server. A streamlined 1-click setup is in development. Subscribe below to get notified."
+    description="For private data, Pinner offers S3-compatible storage, encrypted at rest. Even we can't read your files. Currently available for advanced setups that deploy their own server. A streamlined 1-click setup is in development. Subscribe below to get notified."
     theme="white"
     imageUrl={s3StorageImg}
-    imageAlt="Diagram showing encrypted files flowing through a padlock to a secured server, illustrating zero-knowledge encryption"
+    imageAlt="Diagram showing encrypted files flowing through a padlock to a secured server, illustrating encryption"
     client:load
   />
 
   <AboutSection
     title="Or manage it yourself"
-    subtitle="Self-Hosted"
-    description="Deploy your own server to handle private data on your terms. Full control over storage limits and billing. For teams who want zero external dependencies. FOSS. Fully open source."
+    description="Deploy your own server to handle private data on your terms. Full control over storage limits and billing. For teams who want zero external dependencies. Fully open source."
     theme="gray"
     imagePosition="right"
     imageUrl={selfHostedImg}

--- a/apps/pinner.xyz/src/pages/index.astro
+++ b/apps/pinner.xyz/src/pages/index.astro
@@ -9,7 +9,7 @@ import CallToAction from "@/components/CallToAction";
 import { ctaCopy } from "@/lib/config";
 ---
 
-<Layout title="Storage and Hosting Where You're in Control | Pinner" description="Store files, host websites, and keep your data private by default. One plan, no surprises. Open source, built on Sia." variant="home" showNewsletterFooter={false}>
+<Layout title="Storage and Hosting Where You're in Control | Pinner" description="Store files, host websites, and keep your data private by default. One plan, no surprises. Open source." variant="home" showNewsletterFooter={false}>
   <Hero client:load />
 
   <ProblemAgitation client:load />

--- a/apps/pinner.xyz/src/pages/pricing.astro
+++ b/apps/pinner.xyz/src/pages/pricing.astro
@@ -9,6 +9,23 @@ import FAQ from "@/components/FAQ";
 import NewsletterSignup from "@/components/NewsletterSignup";
 
 import logos from "@/data/brand-logos";
+import { config } from "@/lib/config";
+import type { BillingPlansResponse } from "@/lib/api";
+
+// Build-time fetch: prices are baked into static HTML for crawlers and AI models.
+// Runtime SWR revalidates against the live API and updates if newer data is available.
+let buildTimePlans: BillingPlansResponse | undefined;
+try {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  const res = await fetch(`${config.portalApiUrl}/api/billing/plans`, { signal: controller.signal });
+  clearTimeout(timeout);
+  if (res.ok) {
+    buildTimePlans = await res.json() as BillingPlansResponse;
+  }
+} catch {
+  // Build proceeds without fallback; runtime fetch is still primary.
+}
 
 const pricingFaqs = [
   {
@@ -50,7 +67,7 @@ const pricingFaqs = [
     items: [
       {
         question: "What about S3 cloud storage?",
-        answer: "Private storage with zero-knowledge encryption is available for personal use and developer integrations. S3-compatible storage is also available as a separate product. A simpler 1-click setup is in development. Subscribe below to get notified.",
+        answer: "S3-compatible storage is available as a separate product with encryption at rest. Currently for advanced self-hosted setups, with a simpler 1-click deployment in development. See our how it works page for details.",
       },
     ],
   },
@@ -60,14 +77,18 @@ const pricingFaqs = [
 <Layout title="One Plan. Every Feature. No Surprises. | Pinner" ogImage="/images/og/pricing.png" description="Storage and bandwidth, priced upfront. No tiers to climb. Card or crypto accepted.">
   <PageHeader
     title="Simple pricing. No surprises."
-    description="<a href='/solutions/ipfs-pinning' class='underline hover:text-white transition-colors'>IPFS pinning</a> and hosting plans. <a href='/solutions/cloud-storage' class='underline hover:text-white transition-colors'>Private storage</a> for personal use and developer integrations."
+    description="<a href='/solutions/ipfs-pinning' class='underline hover:text-white transition-colors'>IPFS pinning</a> and hosting plans. <a href='/solutions/cloud-storage' class='underline hover:text-white transition-colors'>Cloud storage</a> for personal and business use."
     client:load
   />
 
   <SectionPricing>
     <div class="container">
       <FoundingOfferBanner className="mb-8 md:mb-12" guarantee="Create a website and if it isn't live in 5 minutes, we'll deploy it for you" client:load />
-      <PricingPlans variant="light" client:load />
+      {buildTimePlans ? (
+        <PricingPlans variant="light" fallbackData={buildTimePlans} client:load />
+      ) : (
+        <PricingPlans variant="light" client:load />
+      )}
     </div>
   </SectionPricing>
 


### PR DESCRIPTION
## Summary

Replaces technical jargon with plain language on public-facing pages. Adds build-time pricing fetch for static HTML rendering and IPNS address in footer.

## Changes

### Homepage

- FAQ: replaced "Sia network", "content-addressed", "zero-knowledge encryption" with plain language (kept one "zero-knowledge encryption" in Cloud Storage answer for SEO)
- Account: "zero-knowledge encryption" -> "encryption"
- TrustSection: rewrote to lead with benefit instead of mechanism name
- MissionSection: "Zero-knowledge encryption on cloud storage" -> plain language
- UseCases: "zero-knowledge encryption" -> "encryption"
- DifferentiatorsSection: "No. Zero-knowledge encryption means we can't read your files" -> "No. We can't read your files"
- ProductCards: "Sia network" -> "peer-to-peer network" (2 cards)

### How It Works

- H2: "Pin to IPFS, host to the web" -> "Verified storage and hosting"
- Upload description: list all methods (app, CLI, S3-compatible tools, API) instead of "our CLI or SDK"
- Removed "We pin them to IPFS", "FOSS", "No setup required"
- "pinned content" -> "stored content"

### Pricing

- Fetch billing plans at build time from portal API, pass as `fallbackData` to SWR
- Static pricing visible without JavaScript via plan cards
- Removed loading skeleton and error state UI
- Page header: "Private storage for personal use" -> "Cloud storage for personal and business use"

### Footer

- Added IPNS address (`k51qzi...`) as proof the site is hosted on Pinner

### OG meta tags

- Layout default and homepage OG: removed "built on Sia"
- About page body: "zero-knowledge encryption" -> "encryption"

### Alternatives pages (vercel, netlify)

- Removed "content-addressed" from FAQ answers

---

<!-- kody-pr-summary:start -->
This PR makes three main changes to the pinner.xyz website:

1. **Replaces technical jargon with plain language**: Removes references to "zero-knowledge encryption" (now just "encryption"), "content-addressed storage" (now "peer-to-peer network"), and "Sia network" (now "peer-to-peer network") across multiple pages and components. The copy is rewritten to be more accessible while preserving the same meaning.

2. **Adds static pricing fallback for build-time rendering**: The pricing page now fetches billing plans at build time and passes them as `fallbackData` to the `PricingPlans` component. This ensures prices are baked into the static HTML for crawlers and AI models, while SWR still revalidates against the live API at runtime. The loading skeleton and error states were removed in favor of progressive enhancement — if fallback data exists, it renders immediately and silently updates when newer data arrives.

3. **Adds IPNS proof line to footer**: A small note was added to the footer indicating the site is hosted on Pinner itself, including its IPNS address as a self-hosting proof point.

Additionally, minor copy refinements were made across the how-it-works, alternatives (Netlify/Vercel), about, and FAQ pages to simplify descriptions and remove redundant subtitles.
<!-- kody-pr-summary:end -->