### PR TITLE
fix(pinner.xyz): change TrustSection and DifferentiatorsSection to second person voice

### DIFF
--- a/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
+++ b/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
@@ -13,10 +13,10 @@ const columns = [
 
 const rows = [
   {
-    factor: "Can we read your data?",
+    factor: "Can your data be read?",
     values: [
       "Yes",
-      "No. Encrypted on your device. We don't hold the keys.",
+      "No. Encrypted on your device. No one holds the keys",
       "Yes, but it's public",
     ],
   },

--- a/apps/pinner.xyz/src/components/Home/TrustSection.tsx
+++ b/apps/pinner.xyz/src/components/Home/TrustSection.tsx
@@ -9,7 +9,7 @@ const principles = [
 	{
 		title: "Private by design",
 		description:
-    "Your data is encrypted before it leaves your device. We don't hold the keys. No one can train AI models on your data. That's not a policy we could change. It's how the system is built.",
+		"Your data is encrypted before it leaves your device. No one holds the keys. No one can train AI models on your data. That's not a policy. It's how the system is built.",
 	},
 	{
 		title: "What you see is what you pay",


### PR DESCRIPTION
## Summary

Changes TrustSection and DifferentiatorsSection copy from first person (we/our) to second person (you/your) voice.

## Changes

**TrustSection (`TrustSection.tsx`)**
- Change first principle title from "We can't read your files" to "Private by design"
- Change description from "Zero-knowledge encryption means even we don't have the keys. That's not a promise. It's the architecture." to "Your data is encrypted before it leaves your device. No one holds the keys. No one can train AI models on your data. That's not a policy. It's how the system is built."

**DifferentiatorsSection (`DifferentiatorsSection.tsx`)**
- Change comparison table factor from "Can we read your data?" to "Can your data be read?"
- Change response from "No. Zero-knowledge encryption means we can't read your files" to "No. Encrypted on your device. No one holds the keys"