### PR TITLE
fix(pinner): export AuthManager and JwtAuthManager from SDK entry point

### DIFF
--- a/libs/pinner/src/index.ts
+++ b/libs/pinner/src/index.ts
@@ -66,6 +66,10 @@ export type {
   AbortOptions,
 } from "@/types/pin";
 
+// Auth exports
+export type { AuthManager } from "./auth";
+export { JwtAuthManager } from "./auth";
+
 // API exports
 export { IpnsClient } from "./api/ipns";
 export { WebsitesClient, WebsiteValidationReason, getValidationReason, isValidationReason } from "./api/websites";


### PR DESCRIPTION
## Summary
- Export `AuthManager` (type) and `JwtAuthManager` (class) from `libs/pinner/src/index.ts`
- These types are referenced by public API constructors (`IpnsClient`, `WebsitesClient`, `UploadManager`, `PinClient`) but were missing from the package entry point
- Fixes TypeDoc warning: `AuthManager, defined in @lumeweb/pinner/src/auth/manager.ts, is referenced by IpnsClient.auth but not included in the documentation`
- `JwtAuthManager` now gets its own SDK ref page; `AuthManager` interface appears on the types page

---

<!-- kody-pr-summary:start -->
This PR exports `AuthManager` (as a type) and `JwtAuthManager` (as a value) from the pinner SDK's entry point (`index.ts`). Previously, these auth-related interfaces and classes were not accessible to consumers of the SDK, preventing external code from implementing or utilizing the authentication management functionality provided by the pinner library.
<!-- kody-pr-summary:end -->