### PR TITLE
fix(portal-plugin-ipfs): upgrade to Helia v7 for stateless HTTP gateway

### DIFF
--- a/libs/portal-plugin-ipfs/package.json
+++ b/libs/portal-plugin-ipfs/package.json
@@ -23,12 +23,10 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "@helia/block-brokers": "^5.2.4",
     "@helia/car": "catalog:",
     "@helia/http": "catalog:",
-    "@helia/interface": "^7.0.0",
+    "@helia/interface": "catalog:",
     "@helia/remote-pinning": "^3.0.0",
-    "@helia/routers": "^5.1.1",
     "@helia/unixfs": "catalog:",
     "helia": "catalog:",
     "@ipfs-shipyard/pinning-service-client": "catalog:",
@@ -67,6 +65,7 @@
   },
   "devDependencies": {
     "@lumeweb/tsdown-config": "workspace:*",
+    "@types/react": "catalog:",
     "tsdown": "catalog:",
     "vite": "catalog:framework"
   },

--- a/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/carPreprocessor.ts
@@ -13,7 +13,8 @@ import type { ProgressOptions } from "progress-events";
 
 import { car } from "@helia/car";
 import { GetBlockProgressEvents } from "@helia/interface";
-import { createHelia } from "helia";
+import { createHeliaLight } from "helia";
+import type { AddEvents } from "@helia/unixfs";
 import { unixfs } from "@helia/unixfs";
 import { asyncIterableReader, createDecoder } from "@ipld/car/decoder";
 import { IDBBlockstore } from "blockstore-idb";
@@ -260,7 +261,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
         return (f.data as any).webkitRelativePath?.startsWith(rootDir + "/");
       }
       if (isFolderBundle(f)) {
-        return (f.meta as BundleMetadata).bundleName === rootDir;
+        return (f.meta as unknown as BundleMetadata).bundleName === rootDir;
       }
       return false;
     });
@@ -290,12 +291,12 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
 
     if (isFolderBundle(file)) {
       // Bundle directory upload
-      const meta = file.meta as BundleMetadata;
+      const meta = file.meta as unknown as BundleMetadata;
       files = meta.originalFiles || [];
     } else if (isDirectoryFile(file)) {
       // Regular directory upload with webkitRelativePath
       // First check if this file has originalFiles in its metadata (from folder bundles)
-      const meta = file.meta as BundleMetadata;
+      const meta = file.meta as unknown as BundleMetadata;
       if (meta.originalFiles && meta.originalFiles.length > 0) {
         files = meta.originalFiles;
       } else {
@@ -321,14 +322,14 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
 
     const addOptions = {
       // Use protobuf format for all nodes to preserve metadata
-      cidVersion: 1,
+      cidVersion: 1 as const,
       rawLeaves: false,
       signal: abortSignal,
-      onProgress(event) {
+      onProgress(event: AddEvents) {
         if (abortSignal.aborted) {
           throw new Error("File processing aborted");
         }
-        
+
         if (event.type === "unixfs:importer:progress:file:read") {
           tracker.updateDataProgress("fileRead", event.detail.bytesRead);
         } else if (event.type === "unixfs:importer:progress:file:write") {
@@ -341,7 +342,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     };
 
     // Add all files to UnixFS and get the root CID
-    let cid: CID;
+    let cid: CID | undefined;
 
     try {
       for await (const result of fs.addAll(src, addOptions)) {
@@ -363,6 +364,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
       throw new Error("Failed to import files to UnixFS");
     }
 
+    const rootCid = cid;
     let carBlocksWritten = 0n;
     const options: AbortOptions & ProgressOptions<GetBlockProgressEvents> = {
       signal: abortSignal,
@@ -386,8 +388,8 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
     };
 
     // Stream to CAR with progress tracking
-    const carStream = c.stream(cid, options);
-    return [asyncGeneratorToReadableStream(carStream), cid];
+    const carStream = c.export(rootCid, options);
+    return [asyncGeneratorToReadableStream(carStream), rootCid];
   }
 
   async #createHelia() {
@@ -401,8 +403,8 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
       if (!this.#datastore) this.#datastore = new IDBDatastore("helia-data");
       await Promise.all([this.#blockstore.open(), this.#datastore.open()]);
 
-      // Create Helia instance with IndexedDB stores
-      this.#helia = await createHelia({
+      // Create Helia instance with IndexedDB stores (no libp2p networking)
+      this.#helia = await createHeliaLight({
         blockstore: this.#blockstore,
         datastore: this.#datastore,
       });
@@ -432,7 +434,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
 
     try {
       // Create an async iterable from the file
-      const fileIterable = readableStreamToAsyncIterable(file.data.stream());
+      const fileIterable = readableStreamToAsyncIterable<Uint8Array>((file.data as Blob | undefined)!.stream());
 
       const reader = asyncIterableReader(fileIterable);
       // Attempt to decode the CAR file
@@ -453,9 +455,10 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
   }
 
   #isIPFSFile(file: UppyFile<M, B>) {
+    const plugins = (file as unknown as { plugins?: string[] }).plugins;
     return (
-      file.plugins &&
-      file.plugins.filter((plugin) => /ipfs/.test(plugin)).length > 0
+      plugins &&
+      plugins.filter((plugin: string) => /ipfs/.test(plugin)).length > 0
     );
   }
 
@@ -490,7 +493,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
         continue;
       }
 
-      const rootDir = (file.meta as BundleMetadata).bundleName;
+      const rootDir = (file.meta as unknown as BundleMetadata).bundleName;
 
       if (processedDirs.has(rootDir)) {
         continue;
@@ -565,7 +568,7 @@ class CarPreprocessorPlugin<M extends Meta, B extends Body> extends BasePlugin<
   }
 
   #shouldProcessFile(file: UppyFile<M, B>): boolean {
-    return this.#isIPFSFile(file);
+    return this.#isIPFSFile(file) ?? false;
   }
 
 }

--- a/libs/portal-plugin-ipfs/src/capabilities/ipfsProtocol.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/ipfsProtocol.ts
@@ -1,9 +1,9 @@
 import type { ProtocolCapability } from "@lumeweb/portal-plugin-dashboard";
 import { createNamespacedId } from "@lumeweb/portal-framework-core";
 
-import * as React from "react";
-
 import IpfsIcon from "@/ui/Icon";
+
+type IconComponent = (props: { className?: string }) => unknown;
 
 export class IpfsProtocol implements ProtocolCapability {
   readonly id = createNamespacedId("ipfs", "protocol");
@@ -16,7 +16,7 @@ export class IpfsProtocol implements ProtocolCapability {
     return "InterPlanetary File System - a peer-to-peer hypermedia protocol designed to make the web faster, safer, and more open.";
   }
 
-  getIcon(): React.ComponentType<{ className?: string }> {
+  getIcon(): any {
     return IpfsIcon;
   }
 

--- a/libs/portal-plugin-ipfs/src/capabilities/ipfsUpload.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/ipfsUpload.ts
@@ -1,5 +1,4 @@
 import type {
-  Framework,
   UploadCapability,
   UploadConfig,
   UppyPlugin,
@@ -8,6 +7,7 @@ import type {
 import {
   createNamespacedId,
   type NamespacedId,
+  type Framework,
   cleanTrailingSlashes,
   getApiBaseUrl,
 } from "@lumeweb/portal-framework-core";
@@ -18,8 +18,8 @@ export class IpfsUpload implements UploadCapability {
   readonly id = createNamespacedId("ipfs", "upload");
   status: "active" | "error" | "inactive" = "active";
   readonly type = "framework:upload" as const;
-  #tusEndpoint: string;
-  #xhrEndpoint: string;
+  #tusEndpoint!: string;
+  #xhrEndpoint!: string;
 
   async destroy() {}
 
@@ -45,15 +45,15 @@ export class IpfsUpload implements UploadCapability {
   getLargeFileUploadConfig(): UploadConfig {
     return {
       endpoint: this.#tusEndpoint,
-      getResponseData: this.#parseResponseData.bind(this)
-    };
+      getResponseData: this.#parseResponseData.bind(this),
+    } as unknown as UploadConfig;
   }
 
   getSmallFileUploadConfig(): UploadConfig {
     return {
       endpoint: this.#xhrEndpoint,
-      getResponseData: this.#parseResponseData.bind(this)
-    };
+      getResponseData: this.#parseResponseData.bind(this),
+    } as unknown as UploadConfig;
   }
 
   async initialize(framework: Framework) {

--- a/libs/portal-plugin-ipfs/src/capabilities/refineConfig.ts
+++ b/libs/portal-plugin-ipfs/src/capabilities/refineConfig.ts
@@ -18,12 +18,12 @@ const DATA_PROVIDER_NAME = "ipfs";
 
 export class Capability implements RefineConfigCapability {
   readonly id = createNamespacedId("ipfs", "refine-config");
-  status;
+  status: "active" | "error" | "inactive" = "active";
   readonly type = "framework:refine-config";
-  version: string;
-  #apiUrl: string;
+  version: string = "0.1.0";
+  #apiUrl!: string;
   #authToken: string | null = null;
-  #emitter: Emitter;
+  #emitter!: Emitter;
   #authUnbind: (() => void) | null = null;
 
   /**
@@ -59,7 +59,7 @@ export class Capability implements RefineConfigCapability {
 
     this.#authUnbind = syncAuthProviderWithDataProvider(
       acctProvider,
-      existing?.authProvider,
+      existing?.authProvider as any,
       {
         onTokenChange: (token) => {
           this.#authToken = token;
@@ -113,7 +113,7 @@ export class Capability implements RefineConfigCapability {
         : apiDomain.hostname;
       this.#apiUrl = `${apiDomain.protocol}//${SUBDOMAIN}.${hostWithPort}`;
     } catch (error) {
-      throw new Error(`Failed to construct API URL: ${error.message}`);
+      throw new Error(`Failed to construct API URL: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     // Initialize the nanoevents emitter

--- a/libs/portal-plugin-ipfs/src/features/fileManager/Feature.ts
+++ b/libs/portal-plugin-ipfs/src/features/fileManager/Feature.ts
@@ -8,6 +8,7 @@ import HeliaService from "../../helia";
 
 export interface HeliaServiceConfig {
   authToken?: string;
+  apiUrl?: string;
 }
 
 export class FileManagerFeature implements FrameworkFeature {
@@ -17,7 +18,7 @@ export class FileManagerFeature implements FrameworkFeature {
 
   #heliaService: HeliaService | null = null;
   #config: HeliaServiceConfig = {};
-  #apiUrl: string;
+  #apiUrl!: string;
 
   async initialize(framework: Framework): Promise<void> {
     // Get the IPFS RefineConfigCapability to access its API URL
@@ -28,13 +29,18 @@ export class FileManagerFeature implements FrameworkFeature {
     }
 
     // Use the capability's API URL getter
-    this.#apiUrl = refineConfigCapability.getApiUrl();
+    const ipfsConfig = refineConfigCapability as unknown as {
+      getApiUrl(): string;
+      getAuthToken(): string | null;
+      getEmitter(): { on: (event: string, callback: (token: string) => void) => void };
+    };
+    this.#apiUrl = ipfsConfig.getApiUrl();
 
     // Get the current auth token
-    const authToken = refineConfigCapability.getAuthToken();
+    const authToken = ipfsConfig.getAuthToken();
 
     // Listen for auth token changes
-    const emitter = refineConfigCapability.getEmitter();
+    const emitter = ipfsConfig.getEmitter();
     emitter.on("authTokenChanged", (token: string) => {
       if (this.#heliaService) {
         // Update helia service config with new token

--- a/libs/portal-plugin-ipfs/src/helia/index.ts
+++ b/libs/portal-plugin-ipfs/src/helia/index.ts
@@ -84,8 +84,9 @@ export class HeliaService {
     // createHeliaLight creates a Helia node without any libp2p networking.
     // withHTTP adds trustless gateway block brokers and HTTP routers only.
     // This is fully stateless — no peer discovery, no dnsaddr, no bootstrap.
+    let node: ReturnType<typeof withHTTP> | undefined;
     try {
-      this.helia = await withHTTP(
+      node = withHTTP(
         createHeliaLight({
           blockstore,
           datastore,
@@ -110,8 +111,15 @@ export class HeliaService {
             };
           },
         },
-      ).start();
+      );
+      await node.start();
+      this.helia = node;
     } catch (error) {
+      try {
+        await node?.stop?.();
+      } catch (e) {
+        console.error("Error stopping Helia:", e);
+      }
       try {
         if (blockstore) await blockstore.close();
       } catch (e) {

--- a/libs/portal-plugin-ipfs/src/helia/index.ts
+++ b/libs/portal-plugin-ipfs/src/helia/index.ts
@@ -1,6 +1,5 @@
-import { createHelia, type Helia } from "helia";
-import { trustlessGateway } from "@helia/block-brokers";
-import { httpGatewayRouting } from "@helia/routers";
+import { createHeliaLight, type Helia } from "helia";
+import { withHTTP } from "@helia/http";
 import { IDBBlockstore } from "blockstore-idb";
 import { IDBDatastore } from "datastore-idb";
 import type { UnixFS } from "@helia/unixfs";
@@ -12,6 +11,7 @@ import {
   type Pin,
   type PinResults,
   RemotePinningServiceClient,
+  Status,
 } from "@ipfs-shipyard/pinning-service-client";
 import type { HeliaServiceConfig } from "@/types";
 
@@ -81,34 +81,36 @@ export class HeliaService {
       throw new Error(`Failed to initialize stores: ${error}`);
     }
 
-    // Create trustless gateway block broker with auth headers and credentials
-    const gatewayBlockBroker = trustlessGateway({
-      transformRequestInit: (init?: RequestInit) => {
-        const headers = new Headers(init?.headers);
+    // createHeliaLight creates a Helia node without any libp2p networking.
+    // withHTTP adds trustless gateway block brokers and HTTP routers only.
+    // This is fully stateless — no peer discovery, no dnsaddr, no bootstrap.
+    this.helia = await withHTTP(
+      createHeliaLight({
+        blockstore,
+        datastore,
+      }),
+      {
+        // Use our own gateway as the sole recursive gateway — no external gateways
+        recursiveGateways: [this.config.apiUrl],
+        // No delegated routing — only our gateway
+        delegatedRouters: [],
+        // Attach auth headers and credentials to all gateway requests
+        transformRequestInit: (init?: RequestInit) => {
+          const headers = new Headers(init?.headers);
 
-        if (this.config.authToken) {
-          headers.set("Authorization", `Bearer ${this.config.authToken}`);
-        }
+          if (this.config.authToken) {
+            headers.set("Authorization", `Bearer ${this.config.authToken}`);
+          }
 
-        return {
-          ...init,
-          headers,
-          credentials: 'include',
-        };
+          return {
+            ...init,
+            headers,
+            credentials: "include",
+          };
+        },
       },
-    });
+    ).start();
 
-    // Create HTTP gateway router using the IPFS API URL
-    const gatewayRouter = httpGatewayRouting({
-      gateways: [this.config.apiUrl],
-    });
-
-    this.helia = await createHelia({
-      blockstore,
-      datastore,
-      blockBrokers: [gatewayBlockBroker],
-      routers: [gatewayRouter],
-    });
     this.unixfs = unixfs(this.helia);
 
     return this.helia;
@@ -283,7 +285,7 @@ export class HeliaService {
     try {
       const pins = await client.pinsGet({
         cid: [cid],
-        status: ["pinned"],
+        status: [Status.Pinned],
       });
       return pins.results.length > 0;
     } catch (error) {
@@ -314,16 +316,16 @@ export class HeliaService {
 
       // Close blockstore and datastore explicitly
       try {
-        if (blockstore && typeof blockstore.close === "function") {
-          await blockstore.close();
+        if (blockstore) {
+          await (blockstore as { close?: () => Promise<void> }).close?.();
         }
       } catch (error) {
         console.error("Error closing blockstore:", error);
       }
 
       try {
-        if (datastore && typeof datastore.close === "function") {
-          await datastore.close();
+        if (datastore) {
+          await (datastore as { close?: () => Promise<void> }).close?.();
         }
       } catch (error) {
         console.error("Error closing datastore:", error);

--- a/libs/portal-plugin-ipfs/src/helia/index.ts
+++ b/libs/portal-plugin-ipfs/src/helia/index.ts
@@ -84,32 +84,46 @@ export class HeliaService {
     // createHeliaLight creates a Helia node without any libp2p networking.
     // withHTTP adds trustless gateway block brokers and HTTP routers only.
     // This is fully stateless — no peer discovery, no dnsaddr, no bootstrap.
-    this.helia = await withHTTP(
-      createHeliaLight({
-        blockstore,
-        datastore,
-      }),
-      {
-        // Use our own gateway as the sole recursive gateway — no external gateways
-        recursiveGateways: [this.config.apiUrl],
-        // No delegated routing — only our gateway
-        delegatedRouters: [],
-        // Attach auth headers and credentials to all gateway requests
-        transformRequestInit: (init?: RequestInit) => {
-          const headers = new Headers(init?.headers);
+    try {
+      this.helia = await withHTTP(
+        createHeliaLight({
+          blockstore,
+          datastore,
+        }),
+        {
+          // Use our own gateway as the sole recursive gateway — no external gateways
+          recursiveGateways: [this.config.apiUrl],
+          // No delegated routing — only our gateway
+          delegatedRouters: [],
+          // Attach auth headers and credentials to all gateway requests
+          transformRequestInit: (init?: RequestInit) => {
+            const headers = new Headers(init?.headers);
 
-          if (this.config.authToken) {
-            headers.set("Authorization", `Bearer ${this.config.authToken}`);
-          }
+            if (this.config.authToken) {
+              headers.set("Authorization", `Bearer ${this.config.authToken}`);
+            }
 
-          return {
-            ...init,
-            headers,
-            credentials: "include",
-          };
+            return {
+              ...init,
+              headers,
+              credentials: "include",
+            };
+          },
         },
-      },
-    ).start();
+      ).start();
+    } catch (error) {
+      try {
+        if (blockstore) await blockstore.close();
+      } catch (e) {
+        console.error("Error closing blockstore:", e);
+      }
+      try {
+        if (datastore) await datastore.close();
+      } catch (e) {
+        console.error("Error closing datastore:", e);
+      }
+      throw new Error(`Failed to start Helia HTTP node: ${error instanceof Error ? error.message : String(error)}`);
+    }
 
     this.unixfs = unixfs(this.helia);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,14 @@ catalogs:
       specifier: ^1.19.4
       version: 1.19.4
     '@helia/car':
-      specifier: ^6.0.0
-      version: 6.0.0
+      specifier: ^6.0.3
+      version: 6.0.3
     '@helia/http':
-      specifier: ^4.0.0
-      version: 4.0.0
+      specifier: ^4.0.4
+      version: 4.0.4
+    '@helia/interface':
+      specifier: ^7.0.3
+      version: 7.0.3
     '@helia/unixfs':
       specifier: ^8.0.0
       version: 8.0.0
@@ -136,8 +139,8 @@ catalogs:
       specifier: ^20.10.6
       version: 20.10.6
     helia:
-      specifier: ^6.1.4
-      version: 6.1.4
+      specifier: ^7.0.5
+      version: 7.0.5
     ky:
       specifier: ^2.0.2
       version: 2.0.2
@@ -381,7 +384,7 @@ importers:
         version: 26.0.1
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)
       '@vitest/browser':
         specifier: ^4.1.9
         version: 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)(vitest@4.1.9)
@@ -462,7 +465,7 @@ importers:
         version: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -911,16 +914,16 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
 
   libs/pinner:
     dependencies:
       '@helia/car':
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.0.3
       '@helia/http':
         specifier: 'catalog:'
-        version: 4.0.0
+        version: 4.0.4
       '@helia/unixfs':
         specifier: 'catalog:'
         version: 8.0.0
@@ -956,7 +959,7 @@ importers:
         version: 5.0.1
       helia:
         specifier: 'catalog:'
-        version: 6.1.4(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+        version: 7.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
       idb-keyval:
         specifier: ^6.2.6
         version: 6.2.6
@@ -1078,7 +1081,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-framework-auth:
     dependencies:
@@ -1810,7 +1813,7 @@ importers:
         version: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -1987,24 +1990,18 @@ importers:
 
   libs/portal-plugin-ipfs:
     dependencies:
-      '@helia/block-brokers':
-        specifier: ^5.2.4
-        version: 5.2.4
       '@helia/car':
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 6.0.3
       '@helia/http':
         specifier: 'catalog:'
-        version: 4.0.0
+        version: 4.0.4
       '@helia/interface':
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: 'catalog:'
+        version: 7.0.3
       '@helia/remote-pinning':
         specifier: ^3.0.0
         version: 3.0.0(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
-      '@helia/routers':
-        specifier: ^5.1.1
-        version: 5.1.1
       '@helia/unixfs':
         specifier: 'catalog:'
         version: 8.0.0
@@ -2070,7 +2067,7 @@ importers:
         version: 5.0.1
       helia:
         specifier: 'catalog:'
-        version: 6.1.4(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+        version: 7.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
       lucide-react:
         specifier: 'catalog:'
         version: 0.577.0(react@19.2.7)
@@ -2102,6 +2099,9 @@ importers:
       '@lumeweb/tsdown-config':
         specifier: workspace:*
         version: link:../tsdown-config
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
@@ -2247,7 +2247,7 @@ importers:
         version: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -2320,7 +2320,7 @@ importers:
         version: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-plugin-sia:
     dependencies:
@@ -2375,7 +2375,7 @@ importers:
         version: 20.10.6
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-plugin-template:
     dependencies:
@@ -2503,7 +2503,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
 
   libs/tsdown-config:
     devDependencies:
@@ -2555,7 +2555,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
 
 packages:
 
@@ -4114,26 +4114,29 @@ packages:
   '@helia/bitswap@3.2.3':
     resolution: {integrity: sha512-uquUTgYaU5Z08SVFn+Psg1xhkeAqCdLWav0zAaNJE1bQX7UeLItW82+Nh5I40RaH9gMFFqL3IQR0mIzi+bj5Gg==}
 
+  '@helia/bitswap@4.0.5':
+    resolution: {integrity: sha512-2jGb9wpUF75SqfIZgiMVDfzgyGu6z7g2A4PVD3Yx6GT0TaT9UeRyEL0ZXvYeDtsf1ogrd5G62bfPzRe+3JrkPA==}
+
   '@helia/block-brokers@5.2.4':
     resolution: {integrity: sha512-UsxtWVy2W95FVM561BZXEnb41RL6pr+cLF+AIxVIaugEvg4edUKh+3sbZXoINtzbqS664Ss2dhisHR1ZnYI57Q==}
 
-  '@helia/car@6.0.0':
-    resolution: {integrity: sha512-1srbicIlfCU4kUywbbFI5E5kfuFw7JzDM5Ggs8yG8vix0KEDOJLt6AdJ90FPOXbqIfqn94DV8xBYfjdRynCyIg==}
+  '@helia/car@6.0.3':
+    resolution: {integrity: sha512-BiADuqicdKUAPDxvEaZ90z8LAH0xPRw9Vj3o60dJR6wU3hZIOD+PDaR15LIfepuqHJ0vJxVqUFsTEXdE0ImGAA==}
 
-  '@helia/delegated-routing-client@1.0.0':
-    resolution: {integrity: sha512-klKjQ50t6h54UDhQCwcYlkm6YJ4d9AhSThsNohGDtirTGs3NnL42ZBGyhrHDH0NRhyiNSdjV1UdFUfTmmb/ZNg==}
+  '@helia/delegated-routing-client@1.0.4':
+    resolution: {integrity: sha512-j4KDU5atZYw7lGvfszoORpMhEsDkvzlLQJAaPA0CV6ZDsVjP0OTGRhgK1vZFmixCByqOLkPH33RQGMRg4hIwUQ==}
 
   '@helia/delegated-routing-v1-http-api-client@6.0.1':
     resolution: {integrity: sha512-Y1nGpUQrdN80XSDDAfe7azJFKKD0MxM0mQqfbefNEcrYMM344rHNQJ7xgiSqsH20vMIaKv+NnQqT/MEg2aWv6g==}
 
-  '@helia/delegated-routing-v1-http-api-client@8.0.1':
-    resolution: {integrity: sha512-O9SjMwd4Xb1Umr8yyyxeCdL+0dNb/BF+ceN/CCTWE/Mfiy+B0aEafpcoSm/3Wn3e0WwXHnGfNWQqBN6cLu30qQ==}
+  '@helia/delegated-routing-v1-http-api-client@9.0.0':
+    resolution: {integrity: sha512-o5F8wr80dels/I3BE2DFBaBR657/4qdKdo728AJNIgD9mJQdmqdyj9chgVXozE55MGUYRHjMeK3Bq8Ygl8B48w==}
 
-  '@helia/fallback-router@1.0.0':
-    resolution: {integrity: sha512-1M+qgN9OeWQhU55GH298ewHs0SPhMdZIDQIP0iMukOFzuL1ux3dT/cjCWuPyEGid2cWnTosAqkHUyhVZ1S4onA==}
+  '@helia/fallback-router@1.0.3':
+    resolution: {integrity: sha512-FdnEMP3fLQ3MMEau5SxfE82eGmSqRFUKvruuW2xJbS3g+3RFRTmytYcQXU7a4iJE87eFkWyN9q4NtHiNBs+VXg==}
 
-  '@helia/http@4.0.0':
-    resolution: {integrity: sha512-cgyWmvMPU/oMTpo8bNbmp4/LHlr15RPNgXaLu03yICFqjyZA81ohFFz5YKiflbranRNcy3dsjB+zgSTvHImQ3Q==}
+  '@helia/http@4.0.4':
+    resolution: {integrity: sha512-w8L7UGNd9BpZjPulT/exASyn2VmYcMMYTQrMvxbzu9cxdW3zXQU7sfhjxpW4rzNa0QzaVUCgH34kq0QxM0zBEw==}
 
   '@helia/interface@6.2.1':
     resolution: {integrity: sha512-lL0q4mpJjUdQ3J/KjSQAoYb6KQZl5SUqQvEBIA5KMrOyuD7m31lbx8elGLttDVVzZtVp03tS4tlDIzsaVJ/Evw==}
@@ -4141,14 +4144,20 @@ packages:
   '@helia/interface@7.0.0':
     resolution: {integrity: sha512-1Y6xTCbPzY7rx+bIzfVR+YWqzdX2hS4dWwRiwMW2GnFz1DFNRS4lueDpQ1n2g7Diq62/t0HhRZLi1KYiRl55sw==}
 
+  '@helia/interface@7.0.3':
+    resolution: {integrity: sha512-PYINbpGpYwX9WDMxiXZvHGYxkSXAgmSlNGATbWzkzD1V/Q9dW06oIT4Xkr9V93grQ/FWZPdxc+ZiQppu0ejguQ==}
+
+  '@helia/libp2p@1.0.5':
+    resolution: {integrity: sha512-rq1W2Q/0G5lUSRFVHENy6uShtNeT+Zxq6Isstr0Egj11uSdH+ymK2p1G2VR9aC2QGVFu95m5zeX0rlIRx0N2LA==}
+
   '@helia/remote-pinning@3.0.0':
     resolution: {integrity: sha512-KxwsjCTMZtvZ1xdZiWqpM8Qi3X/bbdc2twKcDQSmMLg/L7uV7Zg5FZMJVNP2MGLchXRtaMYICo7c2ylTjEZAlg==}
 
   '@helia/routers@5.1.1':
     resolution: {integrity: sha512-ZQbF3fX3y9aBnwKx4FsgEETJ0tfop6CPu4uw+jecnW1FAL9fE0vjYwa90Q7KRXoCCjyu9q96cZ/8nzoipuy86A==}
 
-  '@helia/trustless-gateway-client@1.0.0':
-    resolution: {integrity: sha512-AOqJzGL0NQ7TRrvYN4GqNZm8KQVuKBROXatG2IQUwTwQKS/dncA+mxUUsJQmCdduBrjOiHQEO6Np7DR2Jb6NdQ==}
+  '@helia/trustless-gateway-client@1.0.3':
+    resolution: {integrity: sha512-ARr+YseJZ5wkMTaesepz1tUQOuDcrIOj371BmWNfyp3bnqkmH3Ba5Z5GnoGTw2aGg8xDTpF3KbO+4KGe/iWYug==}
 
   '@helia/unixfs@8.0.0':
     resolution: {integrity: sha512-G4oRsODsaehz1KONDKzo3Zssj2tfMPBGBUqwrM7l53iT8aFHljOuCJqhdWismPQXi68ySimVvD8c81jKe0LjJQ==}
@@ -4156,8 +4165,8 @@ packages:
   '@helia/utils@2.5.2':
     resolution: {integrity: sha512-6/+RInRpJsJoo13ECQsSkBtK2xUGl/KWaJpBuK9tqg+ng3s5cec2qO9RVhZt4bdkPPqJc/PX+G9zwVhKqp5UwQ==}
 
-  '@helia/utils@3.0.0':
-    resolution: {integrity: sha512-XzbaMo+oY3OSOOnojEBaxXKj+M127S9a23As3KwIrKbUEgbg1I80/wubYtG3E/PzGTXV5yRuNeC82n8gukVN2w==}
+  '@helia/utils@3.0.3':
+    resolution: {integrity: sha512-5bfeE9PgLOStWbSdqJsBE2fOV0J8wUT/1PN0jGofMcKS3RyuekRturqLtFVtAwJIx5Rsqyp9Ne400/wrXJeREA==}
 
   '@henrygd/queue@1.2.0':
     resolution: {integrity: sha512-jW/BLSTpcvExDhqJGxtIPgGr2O0IFF8XUNDwEbfCfhrXT8a4xztQ9Lv6U/vbYzYC0xVWn+3zv6YnLUh3bEFUKA==}
@@ -4768,23 +4777,38 @@ packages:
   '@libp2p/autonat@3.0.19':
     resolution: {integrity: sha512-1KKZZT0y5Mt3VPzKLPeCBHXsLI0Q9i7Pieg1UuL472oNvC1kXLiQJbHaJOgLvfXXb91m5U+fK4fFSOK1RpEHXA==}
 
+  '@libp2p/autonat@3.0.22':
+    resolution: {integrity: sha512-l0rje2VA7xVEPWz+/M0KtAsOgBWzBHMDlBo1SdXefIBoRrk5Hmzm0phwN/Xo81EvtI+pB3R9gCgDxl4mIW2c0g==}
+
   '@libp2p/bootstrap@12.0.21':
     resolution: {integrity: sha512-k2lyLYcLbK00E8myG5t1NQG/iX2wyNo4vkSQRH/B/i2Q5MSlH1CGIVBATGNm+x/Cck/+qjd3dS1HEE+QftGaWg==}
+
+  '@libp2p/bootstrap@12.0.25':
+    resolution: {integrity: sha512-Q2CiaI9Zq2FUCmC7jt3OwgREEff29VB5+A4aw3I7z9qNwBUF7M53Gg77RL3cTvh5qhd9KngK7yUY1HwvxD6Ddw==}
 
   '@libp2p/circuit-relay-v2@4.2.4':
     resolution: {integrity: sha512-e955bA2XiDzhs+y23pgIOayOEqaPuLGfPxnXAlJ+4ECLxtEOxPaUKBq5XowkwZwqn0wwBbgGZ8LBcJikr4Q68g==}
 
+  '@libp2p/circuit-relay-v2@4.2.7':
+    resolution: {integrity: sha512-aV5u1p+4O0J/qW1Rc1toHvU/Omqx1pnAICWRHITOTrQcDopUnCryyW8FYW37PSS/+P0mPfnc6AncAnFr5emd4A==}
+
   '@libp2p/config@1.1.29':
     resolution: {integrity: sha512-dG03vrURYrg2hSDipCDhQqf4aNaJPpHx+RQfgQIcyo46WayV5vUbajI9eVGoQjmlFUEo+hV4kz9sFXmGdMg5fQ==}
 
-  '@libp2p/crypto@5.1.17':
-    resolution: {integrity: sha512-gzn9b3tX9D5xCiXb36PF0rH16kGkLW5ESbT+nmXKUp1HCDD30RXQT/oHSylz5I3GN39BC1C3hBOBNaIQYuO+qw==}
+  '@libp2p/config@1.1.33':
+    resolution: {integrity: sha512-Kg+Gkbfe/w2MaRipra9T14XlpiFdg71xIFUSu9J50YZ7Fc/nCLLgsQWqErjI864h6yl1YpBtRBfiC/F4DHP0eA==}
 
   '@libp2p/crypto@5.1.18':
     resolution: {integrity: sha512-sCm+dFFZmH4LJIHTCzPy7+EBRhzkndFUcIU8bui6iaxK6SDSRVa11+/O6DzW8hn/U9LgDXe6jXnzWM8bM7OoCA==}
 
+  '@libp2p/crypto@5.1.20':
+    resolution: {integrity: sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==}
+
   '@libp2p/dcutr@3.0.19':
     resolution: {integrity: sha512-plhWCWn4IzLUnrpc/i+Lulz0YQAR41i9P3/o6B6dnqzXENgJXM8kplbfQfmTmZepNSuGNgxdZ2Ra8PZbXx4Rtg==}
+
+  '@libp2p/dcutr@3.0.22':
+    resolution: {integrity: sha512-n9u/CwzyUjXVezZSplpQY37T1xZq7cVz1UV1hDRo6dk5PeOK+voj0FRktYefaTvjwvQFI2ZFDnv16Qr8xUtOfw==}
 
   '@libp2p/http-fetch@4.0.2':
     resolution: {integrity: sha512-fpUfevPjinWgEit+NO7LcYPH2of0pv+qHfznB0zchwJr1ngpb5EBzk4IqU8xCkO3LkdObKAxwz9fvrQvAFxUXA==}
@@ -4804,8 +4828,14 @@ packages:
   '@libp2p/identify@4.1.5':
     resolution: {integrity: sha512-vIjDjhzAKkZUc5bGMM1ORdgtymsQAfjBNKLlzyZZtb9jTaUzEhwM0ymFIQDrH6fIHtqD8cOQ6B6ekR+SYiTluQ==}
 
+  '@libp2p/identify@4.1.8':
+    resolution: {integrity: sha512-qcquky5SjOqe1I83DHJMRwWFUmk6mqwqX8z0JMOVFcXe96czBZ3pbXMksOoUWsGvDSoTHygX0yYn07sVDF+uoQ==}
+
   '@libp2p/interface-internal@3.1.4':
     resolution: {integrity: sha512-8pHJ3SeGyLTUw9F5r5aNQtHI+UtrHMNkk7ou3xFs6HOevDtzzzwexXw4CBCeewLHMI8s/rbxvX57laXr1EAoYQ==}
+
+  '@libp2p/interface-internal@3.1.7':
+    resolution: {integrity: sha512-5qzZOx1JU+CdT8UKLWKtM3LOQ3C9aSlRzVLJkLZXVN0ULhmctlAeZckPEEZ5z4pDtLpgFHjr+H9bd7NSTHqtVQ==}
 
   '@libp2p/interface@2.11.0':
     resolution: {integrity: sha512-0MUFKoXWHTQW3oWIgSHApmYMUKWO/Y02+7Hpyp+n3z+geD4Xo2Rku2gYWmxcq+Pyjkz6Q9YjDWz3Yb2SoV2E8Q==}
@@ -4823,8 +4853,14 @@ packages:
   '@libp2p/kad-dht@16.2.6':
     resolution: {integrity: sha512-Lzwz75YCpDu3yTLMCzcQx7yWTJfjn0jzvjcwWC+WIMLZ8gAg+BX2srSMlbVRhguS+2C/1T7ph8Raoooog3541A==}
 
+  '@libp2p/kad-dht@16.3.3':
+    resolution: {integrity: sha512-G5BOmuExm/ACP2jx557yZmXhylztyDNLpYsKGCj91Sq7dTvP+EIe4+n0LkKKt//AqHscaQQT2B96RHp5SNOmUw==}
+
   '@libp2p/keychain@6.1.1':
     resolution: {integrity: sha512-szZBnnO+VX4Fjz6KZKE6Z0mFEWaQautb5sV+cK23r6nZ17gd3dv/U8hI2I2DjtPDKB3HimpQcVLnDF8Tc3EkfQ==}
+
+  '@libp2p/keychain@6.1.3':
+    resolution: {integrity: sha512-inkEQehXycDZY3xD13GnqXRxl8HRmGVvpwdHi/FVxQltKgGzkX5pagnFrviWIGelCXMheY8UQMfdFW/7Fy0PXw==}
 
   '@libp2p/logger@5.2.0':
     resolution: {integrity: sha512-OEFS529CnIKfbWEHmuCNESw9q0D0hL8cQ8klQfjIVPur15RcgAEgc1buQ7Y6l0B6tCYg120bp55+e9tGvn8c0g==}
@@ -4841,17 +4877,29 @@ packages:
   '@libp2p/mdns@12.0.21':
     resolution: {integrity: sha512-FbHfUNogRAwTGMNM2QDryuW0mSx1J00JXQynZh4LpTXDLoj5Q34irysXxHryOqGru24Y86n438NzKqZrCscAnw==}
 
+  '@libp2p/mdns@12.0.25':
+    resolution: {integrity: sha512-o6WAHe43tW1JNIQokg5m1QZMyRt9gh2lwTe9v8FAsw0CgxBk+awxf4XyCNxNs4jsRQqOMa5MAefCxPiN4OSecg==}
+
   '@libp2p/mplex@12.0.21':
     resolution: {integrity: sha512-0w8FQCT3DwB886knb4pDJ4fNclr+hBBJ8GJXqKQYp33EJWtoO7NKLW8Khxp7WmypEqOoO34hDMj6JgISSfBbuw==}
+
+  '@libp2p/mplex@12.0.25':
+    resolution: {integrity: sha512-X2mredhpryAz1234mgyS+8rYaAmj/XZ67VPyVRktLPbBl3ibX7TofJW9ackEpFa9h0HgR87/rsfRjeqNamudHA==}
 
   '@libp2p/multistream-select@7.0.17':
     resolution: {integrity: sha512-CXQ9mTpAubudCAiwnRKvzt50YVHLTSoadKUZkpU5Flvonewd+yeyDVUi0gMfp69G2pqrDUz//Kx642SctSSPOg==}
 
-  '@libp2p/peer-collections@7.0.17':
-    resolution: {integrity: sha512-3KIwE+rHGMgrfElDMWnIT7VrzFgLB/IeMWzn8VE8FOT1Bjw77tR93NThJkpuWuP+VkadYEcrXgWyCNm8Jlm8wg==}
+  '@libp2p/multistream-select@7.0.22':
+    resolution: {integrity: sha512-KJ1/i6NVAdPjsGFByB7eECW1j/c54nZIfCyDH3/gl4cLX+l1Pnkm2AgLRuk/3D/tNNVjsSJC2VOwJg6Z8NW3ww==}
 
   '@libp2p/peer-collections@7.0.19':
     resolution: {integrity: sha512-vUV6kovHqYQQP2oLq7Ph12AfDRDgsSgE+WfF1slRm1xY4AFmDP6EnCEQwPzmxHVbkfP4XiekgLZ48NDRh4/f2Q==}
+
+  '@libp2p/peer-collections@7.0.22':
+    resolution: {integrity: sha512-46Mq8ly8uqcpnADo0wWqTEuP8tRDyRtxz/CbTwVSZfz6TbRM/nIRlhoxZu8EIrYBqBZAu3F+3EB7hrzJDyUerQ==}
+
+  '@libp2p/peer-id@6.0.11':
+    resolution: {integrity: sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==}
 
   '@libp2p/peer-id@6.0.8':
     resolution: {integrity: sha512-D9fkXL5g+RfSvDVnj/DxVeuGPq5SQrWPWf4VPf+pPkIZVcTOuuR6OUN9XtYfOUxeN3CbsoAlRk0EDXqRA8Zyxg==}
@@ -4862,29 +4910,44 @@ packages:
   '@libp2p/peer-record@9.0.10':
     resolution: {integrity: sha512-pbDHpOPzE2vLlyiIAitpKG+aDNcnVmtLCYb1wGeRRAnarZC/vREZGM6JmR8Y79INu7jQ1IwTN1iKMj9jaXdAGg==}
 
+  '@libp2p/peer-record@9.0.12':
+    resolution: {integrity: sha512-tYGHo9gSO1ZqQripsEtpzxMrWDnmCMgFe8c1TKcml8dZUBCAsM9k5js25RKb0HA1aqZ2VX54XPFazpbjVs3tow==}
+
   '@libp2p/peer-store@12.0.17':
     resolution: {integrity: sha512-BMrTO9G3MO0Q4N+kSeqN1fAAkWLBiCUBaLqEyZo8ECK64gRbzoIj/3CRFOSbET+dVpcl0BRXdI3S9+4L2pi1gA==}
+
+  '@libp2p/peer-store@12.0.22':
+    resolution: {integrity: sha512-LoBq4uZp5TvPVcU1DtEsuBEC8Fcq1sprgY+KBoIoecL2bsUpCaQsbPIqbByLR6hCfDgWPv5ChFvIoZwn3YCyDw==}
 
   '@libp2p/ping@3.1.4':
     resolution: {integrity: sha512-jKv4sdV5AkcR3jqUqEnH5AMUKbBEaPh57g9Vn5Fz+nFV8zwNQYN0VFpIyYLGRi3myvkLQ3R/0segiltQKxiSkA==}
 
+  '@libp2p/ping@3.1.7':
+    resolution: {integrity: sha512-CJHX7BELM0iB16BayHYA/Tzi+BSrveAMKF5EkNMU0+XNIMgA5A/1G7Yh/VC11N5RUJmk07eYFZQBEQavfoCgNA==}
+
   '@libp2p/record@4.0.12':
     resolution: {integrity: sha512-CODkztILDzow3I76XbqshRpsP6g7EczNH0fZQdvbNXEqkwJtMOvRrpqxC9n/q65A6V7z6r9oUNSl7etvxS8WnQ==}
+
+  '@libp2p/record@4.0.14':
+    resolution: {integrity: sha512-YObHdE1dkAiVDPR+YHIFcCD5YMppP0lj2shnMj0L5PgLka8lnZgaY5AjiQo+DMvLFhRvNIMHyxlE9WQUbrM1wA==}
 
   '@libp2p/tcp@11.0.19':
     resolution: {integrity: sha512-K5rGoFS+PfdSon3gkyCwx9WTqwUFmJlCmnUi1624L2275/f/LN5TQ5XELRgXw6H23ZWNdfNLmOg/qw1I4U4s9w==}
 
+  '@libp2p/tcp@11.0.22':
+    resolution: {integrity: sha512-q1jeWt0XMk6uZQrNOE9YBPciQPgGdNEroD3Wf/TOf2DvzRHpiG6nyMxS3HFdrlCOnuyxlvpMl4jfCh+YGjdxQw==}
+
   '@libp2p/tls@3.1.1':
     resolution: {integrity: sha512-lDz7tmGtkvzMZw7IAUBSFgjL8zxAIGxHrBotjicWxcNeVALUp28doCJqb93ad7EyQRuHFZCD3bXgUl/P6Dj5yQ==}
+
+  '@libp2p/tls@3.1.4':
+    resolution: {integrity: sha512-JJMaV0408+TWeRXlddK8vr8V7R/IRMITnRagAfWPHTqhiw8ULZLS+6AZj0KfpQxTS4G9zSJIOj1fbMtE4xmGmA==}
 
   '@libp2p/upnp-nat@4.0.19':
     resolution: {integrity: sha512-INUMoD3UGBoSYkL7G8pv7ihmaCMWpOIfvV74itiW6Kfilzq/TDveTikN5KYv235d0FHZ8Zs/FmC0TBEhWB6nYA==}
 
-  '@libp2p/utils@7.0.17':
-    resolution: {integrity: sha512-jN8c/OAO6AZHf+P7FuU7DOP++oGfy+dIBxhznXiyuHSYAkv0WE49gTMZzvV+N1DII89vWe9+xaNbjyiI1Ksicg==}
-
-  '@libp2p/utils@7.2.0':
-    resolution: {integrity: sha512-XvzCyjK7Tc5sYG/wOlo0l2BVk7KgQu2Q1+SC+WRFAQz+sPTiAzwe5buxAYQaBUb/upIrnD0alyWbcdUCkz5LFA==}
+  '@libp2p/upnp-nat@4.0.22':
+    resolution: {integrity: sha512-8yks0iIrkz/qXCblPlCT8eZz0M9YeSy0TfkUgxSm4HJ9hbHKAE0+tCve8n0O7hdOWurHPzMNzh9pPuttOEbgpw==}
 
   '@libp2p/utils@7.2.3':
     resolution: {integrity: sha512-7RN1UtSYga3LbpOuW5XsMseQIGawrz5jfWFsgQGI9B130VA6UXKHhzgQbDGHfXLjoNv2RWALp8u6laUvcL65lg==}
@@ -4892,8 +4955,14 @@ packages:
   '@libp2p/webrtc@6.0.22':
     resolution: {integrity: sha512-3xtMLynwzp8Ig2y0vcNw8KRts12XZT4jZWv07OQpXuTKuQ0WiFG+DS70+q0bKWgF9zX5bu3DmcGY3FqRlIkQsQ==}
 
+  '@libp2p/webrtc@6.0.25':
+    resolution: {integrity: sha512-c7QwXOjqBR+xgCIE8bv/A1NGQQMX3Sfrek+CD5n+XJur2TOoEmNjYyRX98Yt2h5YzbD083/bZK7ITZiu9xSdmQ==}
+
   '@libp2p/websockets@10.1.12':
     resolution: {integrity: sha512-QDLAZNYbbfvQRQSyrfvL7Kg4zJb3Shu5vdf2xYtWVLXeE7QSDL1GO8XMexq8D1bZZ6DpUgdMnuRgDqe0zxH6cw==}
+
+  '@libp2p/websockets@10.1.15':
+    resolution: {integrity: sha512-+F8OuUVWz/JP68qcJRLtBbLRFonZr0BKRVqpSaLV1c+/lJxOmiTJqhdnTX7klLZO+JRxSmqZowJ42wNrXcGxtw==}
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -5040,8 +5109,8 @@ packages:
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
-  '@multiformats/dns@1.0.13':
-    resolution: {integrity: sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==}
+  '@multiformats/dns@1.0.15':
+    resolution: {integrity: sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==}
 
   '@multiformats/multiaddr-matcher@3.0.2':
     resolution: {integrity: sha512-iphGQJliZxe2yKu57bdRDgeS+3znc5uXtMybDO1Wau3rIjas4zjrjlyxmFz3wqyUL9f3VDQwas/ZqA7N4QeSfw==}
@@ -9362,6 +9431,10 @@ packages:
     resolution: {integrity: sha512-OwailRORD5pIyxaLKKVdGHQ2OXWmYW7YsjDXnl64cIwWdQiyXRffVFsL34JR5c+BEeeSOHADM3cy/QNERH1SUw==}
     hasBin: true
 
+  cborg@5.1.7:
+    resolution: {integrity: sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==}
+    hasBin: true
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -11135,6 +11208,9 @@ packages:
   helia@6.1.4:
     resolution: {integrity: sha512-MSfgusZMjUMsVIYJ0pd430Z58YEWWJbtSYVH7IWwBiMwn9t5s/ymLElhQl4qMv9DitQEiWIUTW1sX1phP6FfOw==}
 
+  helia@7.0.5:
+    resolution: {integrity: sha512-BgzGQyfX3IA0bggis3KMvMjQxra7n7rDpQQICp0xl+4R6NGsSGApuNa6YlagwXv+G4nrB/NTlDJTaNc5zo2Nqg==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -11684,6 +11760,9 @@ packages:
   it-byte-stream@2.0.3:
     resolution: {integrity: sha512-h7FFcn4DWiWsJw1dCJhuPdiY8cGi1z8g4aLAfFspTaJbwQxvEMlEBFG/f8lIVGwM8YK26ClM4/9lxLVhF33b8g==}
 
+  it-byte-stream@3.0.0:
+    resolution: {integrity: sha512-dpTm5CaRFuz7Wp8VRo8TLkhVNx4KCNT7fAtVorAz/CxrwBJwyz6a6Au9inPxqDN6kN7VVN3WUweJCziG39T48w==}
+
   it-drain@3.0.12:
     resolution: {integrity: sha512-RaFA9X1PF2Pf1Jlqhgf5PlXLgf6CaZt7tSzhia+EkEVcAJRKa0Uhr8UnjVv0GmOA3Air9jDJfIX2KIvz5hZ1Ag==}
 
@@ -11704,6 +11783,9 @@ packages:
 
   it-length-prefixed-stream@2.0.3:
     resolution: {integrity: sha512-Ns3jNFy2mcFnV59llCYitJnFHapg8wIcOsWkEaAwOkG9v4HBCk24nze/zGDQjiJdDTyFXTT5GOY3M/uaksot3w==}
+
+  it-length-prefixed-stream@3.0.1:
+    resolution: {integrity: sha512-XffBM6F8exghmr9jLQa2TdnwYm/Y5a1zC/v9NFFIiGrDb4lgJfo3YBlXHwjtCqbOJBQ4idO5agY8uUM9VUEb8Q==}
 
   it-length-prefixed@10.0.1:
     resolution: {integrity: sha512-BhyluvGps26u9a7eQIpOI1YN7mFgi8lFwmiPi07whewbBARKAG9LE09Odc8s1Wtbt2MB6rNUrl7j9vvfXTJwdQ==}
@@ -11742,6 +11824,9 @@ packages:
 
   it-protobuf-stream@2.0.3:
     resolution: {integrity: sha512-Dus9qyylOSnC7l75/3qs6j3Fe9MCM2K5luXi9o175DYijFRne5FPucdOGIYdwaDBDQ4Oy34dNCuFobOpcusvEQ==}
+
+  it-protobuf-stream@3.0.1:
+    resolution: {integrity: sha512-lKjTCPwL+aKUDovZUt4CyUAsYlOv9z09zyNnnGVWaQmbO6f0n6vV12F4hg0YwWyk9Er6UVWdu1EM7d6P62JnHw==}
 
   it-pushable@3.2.3:
     resolution: {integrity: sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==}
@@ -12033,6 +12118,9 @@ packages:
   libp2p@3.2.2:
     resolution: {integrity: sha512-UfuWXEmd5cSI/tMrmZwbXOctSCBOFXV0ARwbkjIOUNdECSnNmLHUfpFe/wP6lxW2hc9UugECx3qrZ0c3hRXcVw==}
 
+  libp2p@3.3.4:
+    resolution: {integrity: sha512-K/B7XNepJcDB8g+M36Uh6wQDmhPyN5pyEsVwJPBtrXjouC0xBFmU9z5gRh2phRD0oRj9xvIZQwklo2v3zH4AiQ==}
+
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
@@ -12248,9 +12336,6 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
-
-  main-event@1.0.1:
-    resolution: {integrity: sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==}
 
   main-event@1.0.4:
     resolution: {integrity: sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==}
@@ -17889,16 +17974,16 @@ snapshots:
       '@helia/interface': 6.2.1
       '@helia/utils': 2.5.2
       '@libp2p/interface': 3.2.4
-      '@libp2p/logger': 6.2.7
-      '@libp2p/peer-collections': 7.0.17
-      '@libp2p/utils': 7.2.0
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/logger': 6.2.9
+      '@libp2p/peer-collections': 7.0.19
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       any-signal: 4.2.0
       interface-blockstore: 6.0.2
       it-drain: 3.0.12
       it-length-prefixed: 10.0.1
       it-map: 3.1.6
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       it-take: 3.0.11
       it-to-buffer: 4.0.12
       multiformats: 13.4.2
@@ -17910,15 +17995,48 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@helia/bitswap@4.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      '@helia/interface': 7.0.3
+      '@helia/libp2p': 1.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+      '@helia/utils': 3.0.3
+      '@libp2p/interface': 3.2.4
+      '@libp2p/logger': 6.2.9
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      any-signal: 4.2.0
+      interface-blockstore: 7.0.1
+      it-drain: 3.0.12
+      it-length-prefixed: 11.0.1
+      it-map: 3.1.6
+      it-pushable: 3.2.4
+      it-take: 3.0.11
+      it-to-buffer: 5.0.0
+      multiformats: 14.0.2
+      p-defer: 4.0.1
+      progress-events: 1.1.0
+      protons-runtime: 7.0.0
+      race-event: 1.6.1
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - react-native
+      - supports-color
+      - utf-8-validate
+
   '@helia/block-brokers@5.2.4':
     dependencies:
       '@helia/bitswap': 3.2.3
       '@helia/interface': 6.2.1
       '@helia/utils': 2.5.2
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/peer-id': 6.0.8
-      '@libp2p/utils': 7.0.17
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       '@multiformats/multiaddr-to-uri': 12.0.0
       '@multiformats/uri-to-multiaddr': 10.0.0
@@ -17928,10 +18046,10 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
-  '@helia/car@6.0.0':
+  '@helia/car@6.0.3':
     dependencies:
-      '@helia/interface': 7.0.0
-      '@helia/utils': 3.0.0
+      '@helia/interface': 7.0.3
+      '@helia/utils': 3.0.3
       '@ipld/car': 5.4.6
       '@ipld/dag-pb': 4.1.7
       '@libp2p/interface': 3.2.4
@@ -17943,14 +18061,14 @@ snapshots:
       it-drain: 3.0.12
       it-map: 3.1.6
       it-to-buffer: 5.0.0
-      multiformats: 14.0.0
+      multiformats: 14.0.2
       progress-events: 1.1.0
       race-signal: 2.0.0
 
-  '@helia/delegated-routing-client@1.0.0':
+  '@helia/delegated-routing-client@1.0.4':
     dependencies:
-      '@helia/delegated-routing-v1-http-api-client': 8.0.1
-      '@helia/interface': 7.0.0
+      '@helia/delegated-routing-v1-http-api-client': 9.0.0
+      '@helia/interface': 7.0.3
       '@libp2p/interface': 3.2.4
       it-first: 3.0.11
       it-map: 3.1.6
@@ -17973,10 +18091,10 @@ snapshots:
       p-queue: 9.3.0
       uint8arrays: 5.1.0
 
-  '@helia/delegated-routing-v1-http-api-client@8.0.1':
+  '@helia/delegated-routing-v1-http-api-client@9.0.0':
     dependencies:
       '@libp2p/interface': 3.2.4
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       '@libp2p/utils': 7.2.3
       '@multiformats/multiaddr': 13.0.3
       any-signal: 4.2.0
@@ -17987,24 +18105,24 @@ snapshots:
       multiformats: 14.0.2
       uint8arrays: 6.1.1
 
-  '@helia/fallback-router@1.0.0':
+  '@helia/fallback-router@1.0.3':
     dependencies:
-      '@helia/interface': 7.0.0
+      '@helia/interface': 7.0.3
       '@multiformats/uri-to-multiaddr': 10.0.0
       multiformats: 14.0.2
       uint8arrays: 6.1.1
 
-  '@helia/http@4.0.0':
+  '@helia/http@4.0.4':
     dependencies:
-      '@helia/delegated-routing-client': 1.0.0
-      '@helia/fallback-router': 1.0.0
-      '@helia/interface': 7.0.0
-      '@helia/trustless-gateway-client': 1.0.0
+      '@helia/delegated-routing-client': 1.0.4
+      '@helia/fallback-router': 1.0.3
+      '@helia/interface': 7.0.3
+      '@helia/trustless-gateway-client': 1.0.3
 
   '@helia/interface@6.2.1':
     dependencies:
       '@libp2p/interface': 3.2.4
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
       interface-blockstore: 6.0.2
       interface-datastore: 9.0.3
@@ -18017,15 +18135,70 @@ snapshots:
       '@ipshipyard/crypto': 1.1.0
       '@ipshipyard/keychain': 1.0.2
       '@libp2p/interface': 3.2.4
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
       abort-error: 1.0.2
       birnam: 1.0.0
       interface-blockstore: 7.0.1
       interface-datastore: 10.0.1
       main-event: 1.0.4
-      multiformats: 14.0.0
+      multiformats: 14.0.2
       progress-events: 1.1.0
+
+  '@helia/interface@7.0.3':
+    dependencies:
+      '@ipshipyard/crypto': 1.1.0
+      '@ipshipyard/keychain': 1.0.2
+      '@libp2p/interface': 3.2.4
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
+      abort-error: 1.0.2
+      birnam: 1.0.0
+      interface-blockstore: 7.0.1
+      interface-datastore: 10.0.1
+      main-event: 1.0.4
+      multiformats: 14.0.2
+      progress-events: 1.1.0
+
+  '@helia/libp2p@1.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      '@chainsafe/libp2p-noise': 17.0.0
+      '@chainsafe/libp2p-yamux': 8.0.1
+      '@helia/delegated-routing-client': 1.0.4
+      '@helia/delegated-routing-v1-http-api-client': 9.0.0
+      '@helia/interface': 7.0.3
+      '@ipshipyard/libp2p-auto-tls': 2.0.1
+      '@libp2p/autonat': 3.0.22
+      '@libp2p/bootstrap': 12.0.25
+      '@libp2p/circuit-relay-v2': 4.2.7
+      '@libp2p/config': 1.1.33
+      '@libp2p/dcutr': 3.0.22
+      '@libp2p/http': 2.0.2
+      '@libp2p/identify': 4.1.8
+      '@libp2p/interface': 3.2.4
+      '@libp2p/kad-dht': 16.3.3
+      '@libp2p/keychain': 6.1.3
+      '@libp2p/mdns': 12.0.25
+      '@libp2p/mplex': 12.0.25
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/ping': 3.1.7
+      '@libp2p/tcp': 11.0.22
+      '@libp2p/tls': 3.1.4
+      '@libp2p/upnp-nat': 4.0.22
+      '@libp2p/webrtc': 6.0.25(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+      '@libp2p/websockets': 10.1.15
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
+      it-foreach: 2.1.7
+      it-map: 3.1.6
+      libp2p: 3.3.4
+      multiformats: 14.0.2
+      uint8arrays: 6.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - react-native
+      - supports-color
+      - utf-8-validate
 
   '@helia/remote-pinning@3.0.0(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))':
     dependencies:
@@ -18048,7 +18221,7 @@ snapshots:
     dependencies:
       '@helia/delegated-routing-v1-http-api-client': 6.0.1
       '@helia/interface': 6.2.1
-      '@libp2p/interface': 3.2.2
+      '@libp2p/interface': 3.2.4
       '@libp2p/peer-id': 6.0.8
       '@multiformats/uri-to-multiaddr': 10.0.0
       ipns: 10.1.6
@@ -18057,10 +18230,10 @@ snapshots:
       multiformats: 13.4.2
       uint8arrays: 5.1.0
 
-  '@helia/trustless-gateway-client@1.0.0':
+  '@helia/trustless-gateway-client@1.0.3':
     dependencies:
-      '@helia/interface': 7.0.0
-      '@helia/utils': 3.0.0
+      '@helia/interface': 7.0.3
+      '@helia/utils': 3.0.3
       '@libp2p/utils': 7.2.3
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
@@ -18108,7 +18281,7 @@ snapshots:
       '@libp2p/interface': 3.2.4
       '@libp2p/keychain': 6.1.1
       '@libp2p/utils': 7.2.3
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
       any-signal: 4.2.0
       blockstore-core: 6.1.3
@@ -18129,9 +18302,9 @@ snapshots:
       race-signal: 2.0.0
       uint8arrays: 5.1.0
 
-  '@helia/utils@3.0.0':
+  '@helia/utils@3.0.3':
     dependencies:
-      '@helia/interface': 7.0.0
+      '@helia/interface': 7.0.3
       '@libp2p/interface': 3.2.4
       '@libp2p/utils': 7.2.3
       '@multiformats/multiaddr': 13.0.3
@@ -18465,12 +18638,12 @@ snapshots:
 
   '@ipld/dag-cbor@9.2.6':
     dependencies:
-      cborg: 5.1.0
+      cborg: 5.1.7
       multiformats: 13.4.2
 
   '@ipld/dag-json@10.2.7':
     dependencies:
-      cborg: 5.1.0
+      cborg: 5.1.7
       multiformats: 13.4.2
 
   '@ipld/dag-json@11.0.0':
@@ -18870,11 +19043,34 @@ snapshots:
       protons-runtime: 6.0.1
       uint8arraylist: 2.4.8
 
+  '@libp2p/autonat@3.0.22':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      any-signal: 4.2.0
+      main-event: 1.0.4
+      multiformats: 14.0.2
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+
   '@libp2p/bootstrap@12.0.21':
     dependencies:
       '@libp2p/interface': 3.2.4
       '@libp2p/interface-internal': 3.1.4
       '@libp2p/peer-id': 6.0.9
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      main-event: 1.0.4
+
+  '@libp2p/bootstrap@12.0.25':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-id': 6.0.11
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       main-event: 1.0.4
@@ -18900,6 +19096,27 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/circuit-relay-v2@4.2.7':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-record': 9.0.12
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      any-signal: 4.2.0
+      main-event: 1.0.4
+      multiformats: 14.0.2
+      nanoid: 5.1.16
+      progress-events: 1.1.0
+      protons-runtime: 7.0.0
+      retimeable-signal: 1.0.1
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/config@1.1.29':
     dependencies:
       '@libp2p/crypto': 5.1.18
@@ -18908,15 +19125,13 @@ snapshots:
       '@libp2p/logger': 6.2.9
       interface-datastore: 9.0.3
 
-  '@libp2p/crypto@5.1.17':
+  '@libp2p/config@1.1.33':
     dependencies:
+      '@libp2p/crypto': 5.1.20
       '@libp2p/interface': 3.2.4
-      '@noble/curves': 2.2.0
-      '@noble/hashes': 2.2.0
-      multiformats: 13.4.2
-      protons-runtime: 6.0.1
-      uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
+      '@libp2p/keychain': 6.1.3
+      '@libp2p/logger': 6.2.9
+      interface-datastore: 10.0.1
 
   '@libp2p/crypto@5.1.18':
     dependencies:
@@ -18927,6 +19142,16 @@ snapshots:
       protons-runtime: 6.0.1
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
+
+  '@libp2p/crypto@5.1.20':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      multiformats: 14.0.2
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@libp2p/dcutr@3.0.19':
     dependencies:
@@ -18939,6 +19164,17 @@ snapshots:
       protons-runtime: 6.0.1
       uint8arraylist: 2.4.8
 
+  '@libp2p/dcutr@3.0.22':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      delay: 7.0.0
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+
   '@libp2p/http-fetch@4.0.2':
     dependencies:
       '@achingbrain/http-parser-js': 0.5.9
@@ -18950,7 +19186,7 @@ snapshots:
     dependencies:
       '@libp2p/crypto': 5.1.18
       '@libp2p/interface': 3.2.4
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       uint8-varint: 2.0.4
       uint8arrays: 5.1.0
 
@@ -18958,7 +19194,7 @@ snapshots:
     dependencies:
       '@achingbrain/http-parser-js': 0.5.9
       '@libp2p/interface': 3.2.4
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       '@libp2p/utils': 7.2.3
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-to-uri': 12.0.0
@@ -19012,6 +19248,23 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/identify@4.1.8':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-record': 9.0.12
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      it-drain: 3.0.12
+      it-parallel: 3.0.15
+      main-event: 1.0.4
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/interface-internal@3.1.4':
     dependencies:
       '@libp2p/interface': 3.2.4
@@ -19019,9 +19272,16 @@ snapshots:
       '@multiformats/multiaddr': 13.0.3
       progress-events: 1.1.0
 
+  '@libp2p/interface-internal@3.1.7':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-collections': 7.0.22
+      '@multiformats/multiaddr': 13.0.3
+      progress-events: 1.1.0
+
   '@libp2p/interface@2.11.0':
     dependencies:
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 12.5.1
       it-pushable: 3.2.4
       it-stream-types: 2.0.2
@@ -19032,18 +19292,18 @@ snapshots:
 
   '@libp2p/interface@3.2.2':
     dependencies:
-      '@multiformats/dns': 1.0.13
-      '@multiformats/multiaddr': 13.0.1
-      main-event: 1.0.1
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
+      main-event: 1.0.4
       multiformats: 13.4.2
       progress-events: 1.1.0
       uint8arraylist: 2.4.8
 
   '@libp2p/interface@3.2.4':
     dependencies:
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
-      main-event: 1.0.1
+      main-event: 1.0.4
       multiformats: 14.0.2
       progress-events: 1.1.0
       uint8arraylist: 3.0.2
@@ -19084,6 +19344,40 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/kad-dht@16.3.3':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/ping': 3.1.7
+      '@libp2p/record': 4.0.14
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      any-signal: 4.2.0
+      interface-datastore: 10.0.1
+      it-all: 3.0.11
+      it-drain: 3.0.12
+      it-length: 3.0.9
+      it-map: 3.1.6
+      it-merge: 3.0.14
+      it-parallel: 3.0.15
+      it-pipe: 3.0.1
+      it-pushable: 3.2.4
+      it-take: 3.0.11
+      main-event: 1.0.4
+      multiformats: 14.0.2
+      p-defer: 4.0.1
+      p-event: 7.1.0
+      progress-events: 1.1.0
+      protons-runtime: 7.0.0
+      race-signal: 2.0.0
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/keychain@6.1.1':
     dependencies:
       '@libp2p/crypto': 5.1.18
@@ -19094,6 +19388,17 @@ snapshots:
       multiformats: 13.4.2
       sanitize-filename: 1.6.4
       uint8arrays: 5.1.0
+
+  '@libp2p/keychain@6.1.3':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@noble/hashes': 2.2.0
+      asn1js: 3.0.6
+      interface-datastore: 10.0.1
+      multiformats: 14.0.2
+      sanitize-filename: 1.6.4
+      uint8arrays: 6.1.1
 
   '@libp2p/logger@5.2.0':
     dependencies:
@@ -19106,7 +19411,7 @@ snapshots:
   '@libp2p/logger@6.2.6':
     dependencies:
       '@libp2p/interface': 3.2.4
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       interface-datastore: 9.0.3
       multiformats: 13.4.2
       weald: 1.1.1
@@ -19114,7 +19419,7 @@ snapshots:
   '@libp2p/logger@6.2.7':
     dependencies:
       '@libp2p/interface': 3.2.4
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       interface-datastore: 9.0.3
       multiformats: 13.4.2
       weald: 1.1.1
@@ -19139,6 +19444,18 @@ snapshots:
       main-event: 1.0.4
       multicast-dns: 7.2.5
 
+  '@libp2p/mdns@12.0.25':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@types/multicast-dns': 7.2.4
+      dns-packet: 5.6.1
+      main-event: 1.0.4
+      multicast-dns: 7.2.5
+
   '@libp2p/mplex@12.0.21':
     dependencies:
       '@libp2p/interface': 3.2.4
@@ -19148,6 +19465,15 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/mplex@12.0.25':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      it-pushable: 3.2.4
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/multistream-select@7.0.17':
     dependencies:
       '@libp2p/interface': 3.2.4
@@ -19156,23 +19482,38 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
-  '@libp2p/peer-collections@7.0.17':
+  '@libp2p/multistream-select@7.0.22':
     dependencies:
       '@libp2p/interface': 3.2.4
-      '@libp2p/peer-id': 6.0.8
-      '@libp2p/utils': 7.2.0
-      multiformats: 13.4.2
+      '@libp2p/utils': 7.2.3
+      it-length-prefixed: 11.0.1
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@libp2p/peer-collections@7.0.19':
     dependencies:
       '@libp2p/interface': 3.2.4
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       '@libp2p/utils': 7.2.3
       multiformats: 13.4.2
 
+  '@libp2p/peer-collections@7.0.22':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      multiformats: 14.0.2
+
+  '@libp2p/peer-id@6.0.11':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      multiformats: 14.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/peer-id@6.0.8':
     dependencies:
-      '@libp2p/crypto': 5.1.17
+      '@libp2p/crypto': 5.1.18
       '@libp2p/interface': 3.2.4
       multiformats: 13.4.2
       uint8arrays: 5.1.0
@@ -19188,7 +19529,7 @@ snapshots:
     dependencies:
       '@libp2p/crypto': 5.1.18
       '@libp2p/interface': 3.2.4
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       '@multiformats/multiaddr': 13.0.3
       multiformats: 13.4.2
       protons-runtime: 6.0.1
@@ -19196,12 +19537,24 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/peer-record@9.0.12':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@multiformats/multiaddr': 13.0.3
+      multiformats: 14.0.2
+      protons-runtime: 7.0.0
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/peer-store@12.0.17':
     dependencies:
       '@libp2p/crypto': 5.1.18
       '@libp2p/interface': 3.2.4
       '@libp2p/peer-collections': 7.0.19
-      '@libp2p/peer-id': 6.0.9
+      '@libp2p/peer-id': 6.0.11
       '@libp2p/peer-record': 9.0.10
       '@multiformats/multiaddr': 13.0.3
       interface-datastore: 9.0.3
@@ -19213,6 +19566,23 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/peer-store@12.0.22':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-record': 9.0.12
+      '@multiformats/multiaddr': 13.0.3
+      interface-datastore: 10.0.1
+      it-all: 3.0.11
+      main-event: 1.0.4
+      mortice: 3.3.1
+      multiformats: 14.0.2
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/ping@3.1.4':
     dependencies:
       '@libp2p/crypto': 5.1.18
@@ -19223,11 +19593,26 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/ping@3.1.7':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      p-event: 7.1.0
+      race-signal: 2.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/record@4.0.12':
     dependencies:
       protons-runtime: 6.0.1
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
+
+  '@libp2p/record@4.0.14':
+    dependencies:
+      protons-runtime: 7.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
 
   '@libp2p/tcp@11.0.19':
     dependencies:
@@ -19239,6 +19624,17 @@ snapshots:
       p-event: 7.1.0
       progress-events: 1.1.0
       uint8arraylist: 2.4.8
+
+  '@libp2p/tcp@11.0.22':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      main-event: 1.0.4
+      p-event: 7.1.0
+      progress-events: 1.1.0
+      uint8arraylist: 3.0.2
 
   '@libp2p/tls@3.1.1':
     dependencies:
@@ -19257,6 +19653,23 @@ snapshots:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
 
+  '@libp2p/tls@3.1.4':
+    dependencies:
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-x509': 2.7.0
+      '@peculiar/webcrypto': 1.5.0
+      '@peculiar/x509': 2.0.0
+      asn1js: 3.0.6
+      p-event: 7.1.0
+      protons-runtime: 7.0.0
+      reflect-metadata: 0.2.2
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+
   '@libp2p/upnp-nat@4.0.19':
     dependencies:
       '@achingbrain/nat-port-mapper': 4.0.4
@@ -19270,60 +19683,18 @@ snapshots:
       p-defer: 4.0.1
       race-signal: 2.0.0
 
-  '@libp2p/utils@7.0.17':
+  '@libp2p/upnp-nat@4.0.22':
     dependencies:
+      '@achingbrain/nat-port-mapper': 4.0.4
       '@chainsafe/is-ip': 2.1.0
-      '@chainsafe/netmask': 2.0.0
-      '@libp2p/crypto': 5.1.17
       '@libp2p/interface': 3.2.4
-      '@libp2p/logger': 6.2.7
-      '@multiformats/multiaddr': 13.0.1
-      '@sindresorhus/fnv1a': 3.1.0
-      any-signal: 4.2.0
-      cborg: 5.1.0
-      delay: 7.0.0
-      is-loopback-addr: 2.0.2
-      it-length-prefixed: 10.0.1
-      it-pipe: 3.0.1
-      it-pushable: 3.2.3
-      it-stream-types: 2.0.2
-      main-event: 1.0.1
-      netmask: 2.0.2
-      p-defer: 4.0.1
-      p-event: 7.1.0
-      progress-events: 1.1.0
-      race-signal: 2.0.0
-      uint8-varint: 2.0.4
-      uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
-
-  '@libp2p/utils@7.2.0':
-    dependencies:
-      '@chainsafe/is-ip': 2.1.0
-      '@chainsafe/netmask': 2.0.0
-      '@libp2p/crypto': 5.1.18
-      '@libp2p/interface': 3.2.4
-      '@libp2p/logger': 6.2.7
-      '@multiformats/multiaddr': 13.0.1
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
-      '@sindresorhus/fnv1a': 3.1.0
-      any-signal: 4.2.0
-      cborg: 5.1.0
-      delay: 7.0.0
-      is-loopback-addr: 2.0.2
-      it-length-prefixed: 10.0.1
-      it-pipe: 3.0.1
-      it-pushable: 3.2.3
-      it-stream-types: 2.0.2
-      main-event: 1.0.1
-      netmask: 2.0.2
+      main-event: 1.0.4
       p-defer: 4.0.1
-      p-event: 7.1.0
-      progress-events: 1.1.0
       race-signal: 2.0.0
-      uint8-varint: 2.0.4
-      uint8arraylist: 2.4.8
-      uint8arrays: 5.1.0
 
   '@libp2p/utils@7.2.3':
     dependencies:
@@ -19335,14 +19706,14 @@ snapshots:
       '@multiformats/multiaddr-matcher': 3.0.2
       '@sindresorhus/fnv1a': 3.1.0
       any-signal: 4.2.0
-      cborg: 5.1.0
+      cborg: 5.1.7
       delay: 7.0.0
       is-loopback-addr: 2.0.2
       it-length-prefixed: 11.0.1
       it-pipe: 3.0.1
-      it-pushable: 3.2.3
+      it-pushable: 3.2.4
       it-stream-types: 2.0.2
-      main-event: 1.0.1
+      main-event: 1.0.4
       netmask: 2.0.2
       p-defer: 4.0.1
       p-event: 7.1.0
@@ -19391,6 +19762,45 @@ snapshots:
       - react-native
       - supports-color
 
+  '@libp2p/webrtc@6.0.25(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      '@chainsafe/is-ip': 2.1.0
+      '@chainsafe/libp2p-noise': 17.0.0
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/keychain': 6.1.3
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      '@peculiar/webcrypto': 1.5.0
+      '@peculiar/x509': 2.0.0
+      get-port: 7.1.0
+      interface-datastore: 10.0.1
+      it-length-prefixed: 11.0.1
+      it-protobuf-stream: 3.0.1
+      it-pushable: 3.2.4
+      it-stream-types: 2.0.2
+      main-event: 1.0.4
+      multiformats: 14.0.2
+      node-datachannel: 0.32.3
+      p-defer: 4.0.1
+      p-event: 7.1.0
+      p-timeout: 7.0.1
+      p-wait-for: 6.0.0
+      progress-events: 1.1.0
+      protons-runtime: 7.0.0
+      race-signal: 2.0.0
+      react-native-webrtc: 124.0.6(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+      reflect-metadata: 0.2.2
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
+    transitivePeerDependencies:
+      - react-native
+      - supports-color
+
   '@libp2p/websockets@10.1.12':
     dependencies:
       '@libp2p/interface': 3.2.4
@@ -19403,6 +19813,23 @@ snapshots:
       progress-events: 1.1.0
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libp2p/websockets@10.1.15':
+    dependencies:
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      '@multiformats/multiaddr-to-uri': 12.0.0
+      main-event: 1.0.4
+      p-event: 7.1.0
+      progress-events: 1.1.0
+      uint8arraylist: 3.0.2
+      uint8arrays: 6.1.1
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -19703,28 +20130,28 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@multiformats/dns@1.0.13':
+  '@multiformats/dns@1.0.15':
     dependencies:
       '@dnsquery/dns-packet': 6.1.1
       '@libp2p/interface': 3.2.4
       hashlru: 2.3.0
       p-queue: 9.3.0
       progress-events: 1.1.0
-      uint8arrays: 5.1.0
+      uint8arrays: 6.1.1
 
   '@multiformats/multiaddr-matcher@3.0.2':
     dependencies:
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
 
   '@multiformats/multiaddr-to-uri@12.0.0':
     dependencies:
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
 
   '@multiformats/multiaddr@12.5.1':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
       '@chainsafe/netmask': 2.0.0
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       abort-error: 1.0.2
       multiformats: 13.4.2
       uint8-varint: 2.0.4
@@ -19750,7 +20177,7 @@ snapshots:
 
   '@multiformats/uri-to-multiaddr@10.0.0':
     dependencies:
-      '@multiformats/multiaddr': 13.0.1
+      '@multiformats/multiaddr': 13.0.3
       is-ip: 5.0.1
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -21522,16 +21949,6 @@ snapshots:
 
   '@rolldown/debug@1.1.2': {}
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.16)':
-    dependencies:
-      '@babel/core': 7.29.0
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
-    optionalDependencies:
-      '@babel/runtime': 7.29.2
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    optional: true
-
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)':
     dependencies:
       '@babel/core': 7.29.0
@@ -21539,7 +21956,7 @@ snapshots:
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@rolldown/plugin-node-polyfills@1.0.3': {}
 
@@ -23595,18 +24012,10 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@8.0.16)
-      babel-plugin-react-compiler: 1.0.0
-
   '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16)':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)
       babel-plugin-react-compiler: 1.0.0
@@ -23633,7 +24042,7 @@ snapshots:
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -23649,7 +24058,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -23669,7 +24078,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
     optionalDependencies:
       '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)(vitest@4.1.9)
 
@@ -23704,7 +24113,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@26.0.1)(typescript@6.0.3)
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -24671,6 +25080,8 @@ snapshots:
   caniuse-lite@1.0.30001799: {}
 
   cborg@5.1.0: {}
+
+  cborg@5.1.7: {}
 
   ccount@2.0.1: {}
 
@@ -26941,13 +27352,52 @@ snapshots:
       '@libp2p/upnp-nat': 4.0.19
       '@libp2p/webrtc': 6.0.22(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
       '@libp2p/websockets': 10.1.12
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       blockstore-core: 6.1.3
       datastore-core: 11.0.4
       interface-datastore: 9.0.3
       ipns: 10.1.6
       libp2p: 3.2.2
       multiformats: 13.4.2
+    transitivePeerDependencies:
+      - bufferutil
+      - react-native
+      - supports-color
+      - utf-8-validate
+
+  helia@7.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7)):
+    dependencies:
+      '@helia/bitswap': 4.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+      '@helia/http': 4.0.4
+      '@helia/interface': 7.0.3
+      '@helia/libp2p': 1.0.5(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.2.17)(react@19.2.7))
+      '@helia/utils': 3.0.3
+      '@ipld/dag-cbor': 10.0.1
+      '@ipld/dag-json': 11.0.0
+      '@ipld/dag-pb': 4.1.7
+      '@ipshipyard/crypto': 1.1.0
+      '@ipshipyard/keychain': 1.0.2
+      '@libp2p/interface': 3.2.4
+      '@libp2p/utils': 7.2.3
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
+      abort-error: 1.0.2
+      any-signal: 4.2.0
+      birnam: 1.0.0
+      blockstore-core: 7.0.1
+      cborg: 5.1.7
+      datastore-core: 12.0.1
+      interface-blockstore: 7.0.1
+      interface-datastore: 10.0.1
+      it-drain: 3.0.12
+      it-filter: 3.1.6
+      it-foreach: 2.1.7
+      it-merge: 3.0.14
+      main-event: 1.0.4
+      mortice: 3.3.1
+      multiformats: 14.0.2
+      progress-events: 1.1.0
+      uint8arrays: 6.1.1
     transitivePeerDependencies:
       - bufferutil
       - react-native
@@ -27504,6 +27954,14 @@ snapshots:
       race-signal: 1.1.3
       uint8arraylist: 2.4.8
 
+  it-byte-stream@3.0.0:
+    dependencies:
+      abort-error: 1.0.2
+      it-queueless-pushable: 2.0.2
+      it-stream-types: 2.0.2
+      race-signal: 2.0.0
+      uint8arraylist: 3.0.2
+
   it-drain@3.0.12: {}
 
   it-filter@3.1.6:
@@ -27529,6 +27987,14 @@ snapshots:
       it-stream-types: 2.0.2
       uint8-varint: 2.0.4
       uint8arraylist: 2.4.8
+
+  it-length-prefixed-stream@3.0.1:
+    dependencies:
+      abort-error: 1.0.2
+      it-byte-stream: 3.0.0
+      it-stream-types: 2.0.2
+      uint8-varint: 3.0.0
+      uint8arraylist: 3.0.2
 
   it-length-prefixed@10.0.1:
     dependencies:
@@ -27586,6 +28052,13 @@ snapshots:
       it-length-prefixed-stream: 2.0.3
       it-stream-types: 2.0.2
       uint8arraylist: 2.4.8
+
+  it-protobuf-stream@3.0.1:
+    dependencies:
+      abort-error: 1.0.2
+      it-length-prefixed-stream: 3.0.1
+      it-stream-types: 2.0.2
+      uint8arraylist: 3.0.2
 
   it-pushable@3.2.3:
     dependencies:
@@ -27938,7 +28411,7 @@ snapshots:
       '@libp2p/peer-id': 6.0.9
       '@libp2p/peer-store': 12.0.17
       '@libp2p/utils': 7.2.3
-      '@multiformats/dns': 1.0.13
+      '@multiformats/dns': 1.0.15
       '@multiformats/multiaddr': 13.0.3
       '@multiformats/multiaddr-matcher': 3.0.2
       any-signal: 4.2.0
@@ -27954,6 +28427,36 @@ snapshots:
       progress-events: 1.1.0
       race-signal: 2.0.0
       uint8arrays: 5.1.0
+
+  libp2p@3.3.4:
+    dependencies:
+      '@chainsafe/is-ip': 2.1.0
+      '@chainsafe/netmask': 2.0.0
+      '@libp2p/crypto': 5.1.20
+      '@libp2p/interface': 3.2.4
+      '@libp2p/interface-internal': 3.1.7
+      '@libp2p/logger': 6.2.9
+      '@libp2p/multistream-select': 7.0.22
+      '@libp2p/peer-collections': 7.0.22
+      '@libp2p/peer-id': 6.0.11
+      '@libp2p/peer-store': 12.0.22
+      '@libp2p/utils': 7.2.3
+      '@multiformats/dns': 1.0.15
+      '@multiformats/multiaddr': 13.0.3
+      '@multiformats/multiaddr-matcher': 3.0.2
+      any-signal: 4.2.0
+      datastore-core: 12.0.1
+      interface-datastore: 10.0.1
+      it-merge: 3.0.14
+      it-parallel: 3.0.15
+      main-event: 1.0.4
+      multiformats: 14.0.2
+      p-defer: 4.0.1
+      p-event: 7.1.0
+      p-retry: 8.0.0
+      progress-events: 1.1.0
+      race-signal: 2.0.0
+      uint8arrays: 6.1.1
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -28155,8 +28658,6 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
-
-  main-event@1.0.1: {}
 
   main-event@1.0.4: {}
 
@@ -31845,7 +32346,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.37
     optionalDependencies:
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)
       publint: 0.3.21
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -32482,7 +32983,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
+      vitest: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -32514,37 +33015,6 @@ snapshots:
       '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16)(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.5(vitest@4.1.9)
-      happy-dom: 20.10.6
-      jsdom: 29.1.1(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.0.16)
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.0.1)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 26.0.1
-      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16)(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       happy-dom: 20.10.6
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,10 +6,11 @@ catalog:
   '@astrojs/mdx': ^7.0.0
   '@astrojs/react': ^5.0.7
   '@conform-to/react': ^1.19.4
-  '@helia/car': ^6.0.0
-  '@helia/http': ^4.0.0
+  '@helia/car': ^6.0.3
+  '@helia/http': ^4.0.4
+  '@helia/interface': ^7.0.3
   '@helia/unixfs': ^8.0.0
-  'helia': ^6.1.4
+  'helia': ^7.0.5
   '@hookform/resolvers': 5.2.2
   '@ipfs-shipyard/pinning-service-client': ^3.0.0
   '@ipld/car': ^5.4.6
@@ -182,6 +183,17 @@ onlyBuiltDependencies:
 minimumReleaseAge: 720
 minimumReleaseAgeExclude:
   - vocs
+  - helia
+  - '@helia/http'
+  - '@helia/interface'
+  - '@helia/unixfs'
+  - '@helia/car'
+  - '@helia/bitswap'
+  - '@helia/libp2p'
+  - '@helia/utils'
+  - '@helia/delegated-routing-client'
+  - '@helia/fallback-router'
+  - '@helia/trustless-gateway-client'
 
 strictDepBuilds: false
 


### PR DESCRIPTION
## Summary
- Upgrade helia to v7.0.5, @helia/http to v4.0.4, @helia/interface to v7.0.3
- Migrate from createHelia to createHeliaLight + withHTTP (stateless, no libp2p)
- Remove @helia/block-brokers and @helia/routers (replaced by withHTTP)
- Use AddEvents type from @helia/unixfs for importer progress callbacks
- Fix TypeScript errors in refineConfig, ipfsUpload, ipfsProtocol, Feature
- Extend minimumReleaseAgeExclude for @helia/* ecosystem packages

---

<!-- kody-pr-summary:start -->
This PR upgrades the IPFS portal plugin from Helia v6 to Helia v7, adopting a stateless HTTP gateway architecture.

Key changes:

- **Helia v7 upgrade**: Bumps `helia` from v6.1.4 to v7.0.5 and related `@helia/*` packages to their latest versions. Removes direct dependencies on `@helia/block-brokers` and `@helia/routers`.

- **Stateless HTTP gateway**: Replaces the previous `createHelia` + `trustlessGateway` + `httpGatewayRouting` setup with `createHeliaLight` (no libp2p networking) combined with `withHTTP` from `@helia/http`. This configures the node to use only the portal's own gateway as the sole recursive gateway with no delegated routing or external gateways, making it fully stateless — no peer discovery, dnsaddr, or bootstrap.

- **CAR preprocessor updates**: Switches from `createHelia` to `createHeliaLight` in the car preprocessor, updates the CAR streaming API from `c.stream()` to `c.export()`, and fixes various TypeScript type compatibility issues introduced by the upgrade.

- **Type compatibility fixes**: Adjusts type casts, return types, and imports across multiple files (`ipfsProtocol.ts`, `ipfsUpload.ts`, `refineConfig.ts`, `FileManagerFeature.ts`) to resolve type errors from the Helia v7 API changes.

- **Pinning service**: Updates pin status check to use the `Status.Pinned` enum instead of a string literal.
<!-- kody-pr-summary:end -->