### PR TITLE
fix(portal-framework-auth): use loading prop instead of fallback in AuthedIndex

### DIFF
--- a/libs/portal-framework-auth/src/ui/components/index/AuthedIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/index/AuthedIndex.tsx
@@ -12,9 +12,10 @@ const Component: React.FC = () => {
   useRedirectIfAuthenticated("/dashboard", to);
 
   return (
-    <Authenticated key="authed" fallback={<Loading />}>
-      {/* Render nothing once authenticated — useRedirectIfAuthenticated
-          will navigate away. fallback handles the auth-checking state. */}
+    <Authenticated key="authed" loading={<Loading />}>
+      {/* loading shows <Loading /> while auth check is in-flight.
+          No fallback prop — when auth fails, <Authenticated> falls
+          through to redirect using check() redirectTo (preserves ?to=). */}
       {null}
     </Authenticated>
   );


### PR DESCRIPTION
## Summary

- `<Authenticated fallback={<Loading />}>}` renders the fallback when auth fails, which **prevents** the redirect to `/login` — leaving the user stuck on a spinner
- Changed to `loading={<Loading />}` so:
  - Auth check in-flight: shows `<Loading />`
  - Auth fails: falls through to redirect using `check()` `redirectTo` (preserves `?to=` param)
  - Auth succeeds: renders `null`, `useRedirectIfAuthenticated` navigates to `/dashboard` (or `?to=` target)

---

<!-- kody-pr-summary:start -->
This PR fixes the `AuthedIndex` component in the portal framework auth library by replacing the `fallback` prop with the `loading` prop on the `Authenticated` component. 

Previously, the `fallback` prop was used to display a loading indicator during the auth-checking state. However, this prevented proper fallthrough behavior when authentication failed. By using the `loading` prop instead, the loading indicator is only shown while the auth check is in-flight, and when authentication fails, the component correctly falls through to the redirect logic via `check()`'s `redirectTo`, which preserves the `?to=` query parameter for redirect destination.
<!-- kody-pr-summary:end -->