### PR TITLE
feat(portal-plugin-billing): show quota summary and plan feature details

### DIFF
--- a/libs/portal-plugin-billing/package.json
+++ b/libs/portal-plugin-billing/package.json
@@ -30,6 +30,7 @@
     "@lumeweb/portal-framework-ui": "workspace:*",
     "@lumeweb/portal-framework-ui-core": "workspace:*",
     "@lumeweb/portal-plugin-dashboard": "workspace:*",
+    "@lumeweb/portal-plugin-quota": "workspace:*",
     "@lumeweb/portal-sdk": "workspace:*",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@refinedev/core": "catalog:",

--- a/libs/portal-plugin-billing/src/ui/components/PlanChange/PlanList.tsx
+++ b/libs/portal-plugin-billing/src/ui/components/PlanChange/PlanList.tsx
@@ -1,5 +1,16 @@
 import type { PublicPricingPlanPeriodDTO, PublicPricingPlanResponse } from "@/types/subscription";
-import { cn, Skeleton, Spinner } from "@lumeweb/portal-framework-ui-core";
+import {
+  cn,
+  lazyIcon,
+  Skeleton,
+  Spinner,
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@lumeweb/portal-framework-ui-core";
+import { FeaturesList } from "../PricingTable/FeaturesList";
+
+const ChevronDown = lazyIcon("ChevronDown");
 
 interface PlanListProps {
   currentPeriodId?: number;
@@ -62,6 +73,19 @@ export function PlanList({ currentPeriodId, isLoading, onSelectPeriod, plans, se
               </button>
             ))}
           </div>
+          {plan.features && plan.features.length > 0 && (
+            <Collapsible>
+              <CollapsibleTrigger className="text-primary flex items-center gap-1 text-xs font-medium hover:underline">
+                <ChevronDown className="h-3 w-3" />
+                View details
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="mt-2">
+                  <FeaturesList features={plan.features} />
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
         </div>
       ))}
     </div>

--- a/libs/portal-plugin-billing/src/ui/components/SubscriptionStatusCard.tsx
+++ b/libs/portal-plugin-billing/src/ui/components/SubscriptionStatusCard.tsx
@@ -3,6 +3,7 @@ import { useManagementCapabilities } from "@/hooks/useManagementCapabilities";
 import { cn } from "@lumeweb/portal-framework-ui-core";
 import { StatusHeader } from "./SubscriptionStatusCard/StatusHeader";
 import { PlanDetails } from "./SubscriptionStatusCard/PlanDetails";
+import { QuotaSummary } from "./SubscriptionStatusCard/QuotaSummary";
 import { PausedStatus } from "./SubscriptionStatusCard/PausedStatus";
 import { CancellationStatus } from "./SubscriptionStatusCard/CancellationStatus";
 
@@ -45,6 +46,8 @@ export function SubscriptionStatusCard({ className }: SubscriptionStatusCardProp
       />
 
       <PlanDetails planInfo={currentPlan} />
+
+      <QuotaSummary />
 
       {subscriptionData.paused_at && (
         <PausedStatus pausedAt={subscriptionData.paused_at} />

--- a/libs/portal-plugin-billing/src/ui/components/SubscriptionStatusCard/QuotaSummary.tsx
+++ b/libs/portal-plugin-billing/src/ui/components/SubscriptionStatusCard/QuotaSummary.tsx
@@ -1,0 +1,81 @@
+import { useQuota } from "@lumeweb/portal-plugin-quota";
+import { Progress, Skeleton } from "@lumeweb/portal-framework-ui-core";
+import type { QuotaTypeStatus } from "@lumeweb/portal-sdk";
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+function getBarColor(percentage: number): string {
+  if (percentage > 90) return "bg-destructive";
+  if (percentage >= 70) return "bg-yellow-500";
+  return "bg-foreground";
+}
+
+interface QuotaRowProps {
+  label: string;
+  quota: QuotaTypeStatus;
+}
+
+function QuotaRow({ label, quota }: QuotaRowProps) {
+  const isUnlimited = quota.limit === undefined;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">{label}</span>
+        {isUnlimited ? (
+          <span className="text-muted-foreground">
+            {formatBytes(quota.used)} used
+          </span>
+        ) : (
+          <span className="font-medium">
+            {formatBytes(quota.used)} / {formatBytes(quota.limit ?? 0)}
+          </span>
+        )}
+      </div>
+      {!isUnlimited && (
+        <Progress
+          className="h-1.5"
+          indicatorClassName={getBarColor(quota.percentage)}
+          max={quota.limit ?? 0}
+          value={quota.used}
+        />
+      )}
+    </div>
+  );
+}
+
+export function QuotaSummary() {
+  const { data, isReady, isBusy, hasError } = useQuota();
+
+  if (isBusy) {
+    return (
+      <div className="mt-4 space-y-3">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-1.5 w-full" />
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-1.5 w-full" />
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-1.5 w-full" />
+      </div>
+    );
+  }
+
+  if (hasError || !isReady || !data) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 space-y-3 border-t border-border/30 pt-4">
+      <span className="text-muted-foreground text-sm font-medium">Quota Usage</span>
+      <QuotaRow label="Storage" quota={data.storage} />
+      <QuotaRow label="Upload" quota={data.upload} />
+      <QuotaRow label="Download" quota={data.download} />
+    </div>
+  );
+}

--- a/libs/portal-plugin-quota/src/index.ts
+++ b/libs/portal-plugin-quota/src/index.ts
@@ -9,6 +9,9 @@ import { Capability as RefineConfigCapability } from "./capabilities/refineConfi
 import routes from "./routes";
 import widgets from "./widgetRegistrations";
 
+export { useQuota, QUOTA_QUERY_KEY } from "./hooks/useQuota";
+export type { UseQuotaConfig, UseQuotaReturn } from "./hooks/useQuota";
+
 export default function (): Plugin {
   return {
     capabilities: [new RefineConfigCapability()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1729,6 +1729,9 @@ importers:
       '@lumeweb/portal-plugin-dashboard':
         specifier: workspace:*
         version: link:../portal-plugin-dashboard
+      '@lumeweb/portal-plugin-quota':
+        specifier: workspace:*
+        version: link:../portal-plugin-quota
       '@lumeweb/portal-sdk':
         specifier: workspace:*
         version: link:../portal-sdk


### PR DESCRIPTION
## Summary
- Add QuotaSummary component showing storage/upload/download usage with progress bars
- Render QuotaSummary in SubscriptionStatusCard
- Add collapsible 'View details' section in PlanList with FeaturesList
- Add @lumeweb/portal-plugin-quota as billing dependency
- Sync portal-plugin-quota source exports with built dist

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR enhances the billing plugin's UI by adding two new features to the subscription experience:

### 1. Quota Usage Summary
A new `QuotaSummary` component has been added to the subscription status card, displaying real-time usage for **Storage**, **Upload**, and **Download** quotas. Each quota is shown with a progress bar that is color-coded based on usage level:
- **Red** when usage exceeds 90%
- **Yellow** when usage is between 70–90%
- **Default** color otherwise

The component handles unlimited quotas (showing only used amounts), loading states with skeletons, and error states gracefully. To enable this, the `useQuota` hook and its types were exported from the `portal-plugin-quota` package, which was also added as a dependency to the billing plugin.

### 2. Plan Feature Details in Plan Change View
Each plan in the plan change/selection list now includes a collapsible **"View details"** section. When expanded, it displays the full list of features included in that plan using the existing `FeaturesList` component, giving users better visibility into what each plan offers before making a selection.
<!-- kody-pr-summary:end -->