### PR TITLE
fix(portal-plugin-billing): fix test mocks for lazyIcon and createNamespacedId exports

### DIFF
--- a/libs/portal-plugin-billing/src/__tests__/components/CheckoutFlow.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/CheckoutFlow.test.tsx
@@ -104,11 +104,13 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   Skeleton: ({ ...props }: any) => <div data-testid="skeleton" {...props} />,
   Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
   Spinner: () => <div data-testid="spinner">Loading...</div>,
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 // Mock framework capability
 vi.mock("@lumeweb/portal-framework-core", () => ({
   useCapability: () => ({ data: { getApiUrl: () => "https://api.example.com" } }),
+  createNamespacedId: (id: string) => id,
 }));
 
 function TestPhaseControl() {

--- a/libs/portal-plugin-billing/src/__tests__/components/CheckoutForm.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/CheckoutForm.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   CardTitle: ({ children, ...props }: any) => (
     <div data-testid="card-title" {...props}>{children}</div>
   ),
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 // Mock FragmentRenderer

--- a/libs/portal-plugin-billing/src/__tests__/components/CheckoutSuccess.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/CheckoutSuccess.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   cn: (...args: (string | undefined)[]) => args.filter(Boolean).join(" "),
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 vi.mock("lucide-react", () => ({
@@ -67,6 +68,6 @@ describe("CheckoutSuccess", () => {
     );
 
     await expect.element(screen.getByText("Subscription Activated!")).toBeInTheDocument();
-    await expect.element(screen.getByTestId("check-icon")).toBeInTheDocument();
+    await expect.element(screen.getByTestId("check-circle")).toBeInTheDocument();
   });
 });

--- a/libs/portal-plugin-billing/src/__tests__/components/GatewaySelector.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/GatewaySelector.test.tsx
@@ -11,10 +11,12 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   ),
   Skeleton: () => <div data-testid="skeleton">Loading...</div>,
   cn: (...args: (string | undefined)[]) => args.filter(Boolean).join(" "),
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 vi.mock("@lumeweb/portal-framework-core", () => ({
   useCapability: () => ({ data: { getApiUrl: () => "https://api.example.com" } }),
+  createNamespacedId: (id: string) => id,
 }));
 
 describe("GatewaySelector", () => {

--- a/libs/portal-plugin-billing/src/__tests__/components/PlanChange/PortalView.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/PlanChange/PortalView.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
     asChild ? children : <button>{children}</button>
   ),
   Skeleton: () => <span>Loading...</span>,
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 vi.mock("lucide-react", () => ({

--- a/libs/portal-plugin-billing/src/__tests__/components/PlanChange/RedirectView.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/PlanChange/RedirectView.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   Button: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) => (
     asChild ? children : <button>{children}</button>
   ),
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 vi.mock("lucide-react", () => ({

--- a/libs/portal-plugin-billing/src/__tests__/components/PlanChangeDialog.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/PlanChangeDialog.test.tsx
@@ -37,6 +37,10 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
   ),
   Skeleton: ({ ...props }: any) => <div data-testid="skeleton" {...props} />,
   Spinner: ({ ...props }: any) => <div data-testid="spinner" {...props} />,
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
 const mockPlans: PublicPricingPlanResponse[] = [

--- a/libs/portal-plugin-billing/src/__tests__/components/PlanChangeDialogContainer.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/PlanChangeDialogContainer.test.tsx
@@ -84,6 +84,7 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
     <button onClick={onClick}>{children}</button>
   ),
   cn: (...args: (string | undefined)[]) => args.filter(Boolean).join(" "),
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 // Mock child components

--- a/libs/portal-plugin-billing/src/__tests__/components/PricingTable.test.tsx
+++ b/libs/portal-plugin-billing/src/__tests__/components/PricingTable.test.tsx
@@ -101,6 +101,7 @@ vi.mock("@lumeweb/portal-framework-ui-core", () => ({
     <input type="checkbox" role="switch" checked={checked} onChange={(e: any) => onCheckedChange?.(e.target.checked)} />
   ),
   Skeleton: ({ className }: any) => <div data-testid="skeleton" className={className} />,
+  lazyIcon: (name: string) => () => <span data-testid={name.charAt(0).toLowerCase() + name.slice(1).replace(/([A-Z])/g, (c: string) => "-" + c.toLowerCase())} />,
 }));
 
 vi.mock("@/ui/components/FragmentRenderer", () => ({

--- a/libs/portal-plugin-billing/src/__tests__/hooks/useSubscriptionEventFeed.test.ts
+++ b/libs/portal-plugin-billing/src/__tests__/hooks/useSubscriptionEventFeed.test.ts
@@ -13,6 +13,7 @@ let mockAuthToken = "test-auth-token";
 
 vi.mock("@lumeweb/portal-framework-core", () => ({
   getApiBaseUrl: vi.fn(() => "https://api.example.com"),
+  createNamespacedId: (id: string) => id,
   useCapability: vi.fn(() => ({
     data: {
       getAuthToken: () => mockAuthToken,

--- a/libs/portal-plugin-billing/vitest.config.ts
+++ b/libs/portal-plugin-billing/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     ],
   },
   optimizeDeps: {
-    include: ["react", "react-dom", "papaparse"],
+    include: ["react", "react-dom", "papaparse", "@lumeweb/portal-framework-ui-core"],
   },
   test: {
     projects: [
@@ -59,6 +59,8 @@ export default defineConfig({
             { find: "@lib", replacement: path.resolve(__dirname, "./src-lib") },
             { find: "@lumeweb/portal-framework-auth", replacement: path.resolve(__dirname, "../portal-framework-auth/dist/esm/index.js") },
             { find: "@lumeweb/analytics", replacement: path.resolve(__dirname, "../analytics/dist/esm/index.js") },
+            { find: "@lumeweb/portal-framework-ui-core", replacement: path.resolve(__dirname, "../portal-framework-ui-core/dist/esm/index.js") },
+            { find: "@lumeweb/portal-framework-core", replacement: path.resolve(__dirname, "../portal-framework-core/dist/esm/index.js") },
             {
               find: "papaparse",
               replacement: papaparsePath,


### PR DESCRIPTION
## Summary
- Add lazyIcon mock to all test files that mock portal-framework-ui-core
- Add createNamespacedId mock to portal-framework-core test mocks
- Add resolve aliases to vitest.config.ts to fix Vite ESM barrel re-export issues in browser test mode
- Fixes 10 test files that were failing due to missing named exports from large barrel files

---

<!-- kody-pr-summary:start -->
This PR fixes test mocks in the portal-plugin-billing test suite by adding missing mock implementations for `lazyIcon` (from `@lumeweb/portal-framework-ui-core`) and `createNamespacedId` (from `@lumeweb/portal-framework-core`) across multiple component and hook test files. These exports were being used by components but not mocked, causing tests to fail.

Additionally, the vitest configuration is updated to include `@lumeweb/portal-framework-ui-core` in optimized dependencies and add path aliases for both `@lumeweb/portal-framework-ui-core` and `@lumeweb/portal-framework-core` packages. A test assertion in `CheckoutSuccess.test.tsx` is also corrected to look for the `check-circle` test ID instead of the outdated `check-icon`.
<!-- kody-pr-summary:end -->