### PR TITLE
chore: add abort-error to pnpm catalog

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -103,6 +103,7 @@ catalog:
   p-queue: ^9.3.1
   zod: ^4.4.3
   zustand: ^5.0.14
+  abort-error: ^1.0.2
 
 catalogs:
   framework:


### PR DESCRIPTION
## Problem

`pnpm -r publish --provenance` fails with:
```
ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC: No catalog entry 'abort-error' was found for catalog 'default'.
``

## Root Cause

`abort-error` was referenced as `"catalog:"` in `libs/pinner/package.json` (added in PR #1096), but the catalog entry was missing from the `catalog:` section in `pnpm-workspace.yaml`. It was only present in the `overrides:` section.

When `pnpm publish` resolves `catalog:` protocol specifiers, it looks in the `catalog:` section — not `overrides:`. Since there was no matching entry, it errored.

## Fix

Add `abort-error: ^1.0.2` to the `catalog:` section in `pnpm-workspace.yaml`.

Verified with `pnpm -r publish --dry-run` — no errors.

---

<!-- kody-pr-summary:start -->
This pull request adds the `abort-error` package (version `^1.0.2`) to the pnpm catalog in the workspace configuration. This centralizes the dependency version management for `abort-error` across the monorepo, allowing workspace packages to reference it via the catalog rather than specifying versions individually.
<!-- kody-pr-summary:end -->