### PR TITLE
feat(pinner): update swagger and client for canonical ErrorResponse shape

### DIFF
--- a/libs/pinner/src/__tests__/msw/website-handlers.ts
+++ b/libs/pinner/src/__tests__/msw/website-handlers.ts
@@ -53,7 +53,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
 
       if (!key) {
         return HttpResponse.json(
-          { error: "IPNS key not found" },
+          { error: { reason: "IPNS key not found" } },
           { status: 404 },
         );
       }
@@ -73,7 +73,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
 
       if (!key) {
         return HttpResponse.json(
-          { error: "IPNS key not found" },
+          { error: { reason: "IPNS key not found" } },
           { status: 404 },
         );
       }
@@ -95,7 +95,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
       const key = ipnsStore.findById(body.key_id);
       if (!key) {
         return HttpResponse.json(
-          { error: "IPNS key not found" },
+          { error: { reason: "IPNS key not found" } },
           { status: 404 },
         );
       }
@@ -218,7 +218,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
 
       if (!website) {
         return HttpResponse.json(
-          { error: "Website not found" },
+          { error: { reason: "Website not found" } },
           { status: 404 },
         );
       }
@@ -244,7 +244,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
       const website = websiteStore.findById(id);
       if (!website) {
         return HttpResponse.json(
-          { error: "Website not found" },
+          { error: { reason: "Website not found" } },
           { status: 404 },
         );
       }
@@ -271,7 +271,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
 
       if (!website) {
         return HttpResponse.json(
-          { error: "Website not found" },
+          { error: { reason: "Website not found" } },
           { status: 404 },
         );
       }
@@ -293,7 +293,7 @@ export function createWebsiteHandlers(websiteStore: WebsiteStore, ipnsStore: IPN
 
       if (!website) {
         return HttpResponse.json(
-          { error: "Website not found" },
+          { error: { reason: "Website not found" } },
           { status: 404 },
         );
       }

--- a/libs/pinner/src/api/client.ts
+++ b/libs/pinner/src/api/client.ts
@@ -55,7 +55,11 @@ export abstract class ApiClient {
     if (error instanceof HTTPError) {
       const status = error.response.status;
       const body = await error.response.json().catch(() => ({}));
-      const message = (body as any).error || (body as any).message;
+      const message =
+        (body as any).error?.reason ||
+        (body as any).error?.details ||
+        (body as any).error ||
+        (body as any).message;
 
       if (status === 401 || status === 403) {
         return new AuthenticationError(message || "Authentication failed");

--- a/libs/pinner/src/api/swagger.yaml
+++ b/libs/pinner/src/api/swagger.yaml
@@ -67,11 +67,21 @@ components:
     Component:
       additionalProperties: false
       type: object
+    ErrorDetail:
+      additionalProperties: false
+      properties:
+        details:
+          type: string
+        reason:
+          type: string
+      required:
+      - reason
+      type: object
     ErrorResponse:
       additionalProperties: false
       properties:
         error:
-          type: string
+          $ref: '#/components/schemas/ErrorDetail'
       required:
       - error
       type: object
@@ -393,6 +403,14 @@ components:
       - pin
       - delegates
       type: object
+    PingResponse:
+      additionalProperties: false
+      properties:
+        status:
+          type: string
+      required:
+      - status
+      type: object
     PostUploadResponse:
       additionalProperties: false
       properties:
@@ -518,6 +536,12 @@ components:
         error:
           type: string
         status:
+          enum:
+          - pending
+          - processing
+          - completed
+          - failed
+          - duplicate
           type: string
       required:
       - status
@@ -3222,7 +3246,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
+          description: Invalid request body or validation error
         "401":
           content:
             application/json:
@@ -3241,12 +3265,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Not found
+        "410":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Website target content is broken
         "500":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
+          description: Internal server error occurred
       summary: Create website
       tags:
       - Websites
@@ -3388,7 +3418,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
+          description: Invalid website ID format
         "401":
           content:
             application/json:
@@ -3406,13 +3436,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
+          description: Website not found
+        "410":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebsiteResponse'
+          description: Website is broken or deleted
         "500":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
+          description: Internal server error occurred
       summary: Get website
       tags:
       - Websites
@@ -3582,28 +3618,17 @@ paths:
       summary: Get website hosting configuration
       tags:
       - Websites
-  /internal/websites/{domain}:
+  /internal/ping:
     get:
-      description: |-
-        Gets website configuration for gateway content serving.
-
-        Internal endpoint used by the gateway to retrieve website configuration. Requires X-Gateway-Secret header for authentication.
-
-        See also:.*
-      parameters:
-      - description: 'Domain name for the website. Example: example.com'
-        in: path
-        name: domain
-        required: true
-        schema:
-          type: string
+      description: Returns service liveness status. Requires X-Gateway-Secret header
+        for authentication.
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GatewayWebsiteResponse'
-          description: Website configuration
+                $ref: '#/components/schemas/PingResponse'
+          description: Service is alive
         "400":
           content:
             application/json:
@@ -3634,6 +3659,67 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
+      summary: Health check
+      tags:
+      - Gateway
+  /internal/websites/{domain}:
+    get:
+      description: |-
+        Gets website configuration for gateway content serving.
+
+        Internal endpoint used by the gateway to retrieve website configuration. Requires X-Gateway-Secret header for authentication.
+
+        See also:.*
+      parameters:
+      - description: 'Domain name for the website. Example: example.com'
+        in: path
+        name: domain
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayWebsiteResponse'
+          description: Website configuration
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Invalid domain format
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Website not found
+        "410":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayWebsiteResponse'
+          description: Website is broken or deleted
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error occurred
       summary: Get website configuration for gateway
       tags:
       - Gateway
@@ -3732,7 +3818,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Bad request
+          description: Invalid domain format
         "401":
           content:
             application/json:
@@ -3750,13 +3836,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
+          description: Website not found
+        "410":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GatewayWebsiteStatusResponse'
+          description: Website is broken or deleted
         "500":
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Internal server error
+          description: Internal server error occurred
       summary: Get website status for gateway
       tags:
       - Gateway
@@ -4027,6 +4119,53 @@ paths:
       summary: List pinned content
       tags:
       - Pinning
+    options:
+      description: |-
+        CORS preflight handler for pins endpoints.
+
+        Handles OPTIONS requests for pins endpoints. Most CORS preflight requests are handled by middleware, this serves as a fallback.
+
+        See also:.*
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Pins OPTIONS
+      tags:
+      - Pinning
     post:
       description: |-
         Pins content to IPFS with optional metadata.
@@ -4198,6 +4337,60 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get pin details
+      tags:
+      - Pinning
+    options:
+      description: |-
+        CORS preflight handler for pin detail endpoints.
+
+        Handles OPTIONS requests for pin detail endpoints. Most CORS preflight requests are handled by middleware, this serves as a fallback.
+
+        See also:.*
+      parameters:
+      - description: 'Unique identifier for the pin operation. Example: bafkreiexample'
+        in: path
+        name: requestid
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Pin detail OPTIONS
       tags:
       - Pinning
     post:

--- a/libs/pinner/src/upload/base-upload.ts
+++ b/libs/pinner/src/upload/base-upload.ts
@@ -134,7 +134,11 @@ export abstract class BaseUploadHandler {
           typeof errorObj.xhr.response === "string"
             ? JSON.parse(errorObj.xhr.response)
             : errorObj.xhr.response;
-        if (response.error) {
+        if (response.error?.reason) {
+          errorMessage = response.error.reason;
+        } else if (response.error?.details) {
+          errorMessage = response.error.details;
+        } else if (response.error) {
           errorMessage = response.error;
         } else if (response.message) {
           errorMessage = response.message;


### PR DESCRIPTION
## Summary
- Regenerates the pinner API client from the latest deployed swagger spec.
- Updates error extraction in `ApiClient.mapError` for the canonical `{error:{reason,details}}` shape.
- Updates `base-upload` error message extraction to read `error.reason` from response bodies.
- Updates MSW test handlers to return the new `ErrorResponse` structure.

---

<!-- kody-pr-summary:start -->
This PR updates the pinner library to adopt a canonical `ErrorResponse` shape across the API specification, client, and handlers. The `error` field is now an object containing a `reason` (and optional `details`) instead of a plain string.

Key changes:
- **Swagger spec**: Introduces an `ErrorDetail` schema (`reason` required, `details` optional) and updates `ErrorResponse.error` to reference it. Adds `PingResponse`, status enums for pin status, `410` (broken/deleted website) responses, and OPTIONS (CORS preflight) endpoints for pinning routes. Improves error response descriptions for website and gateway endpoints.
- **API client**: Updates error parsing to extract messages from the new `error.reason` / `error.details` structure, with fallbacks for legacy string-based errors.
- **Base upload handler**: Adjusts error extraction to handle the new nested error shape.
- **MSW test handlers**: Updates mocked error responses to use the new `{ error: { reason: ... } }` shape.
<!-- kody-pr-summary:end -->