### PR TITLE
feat(advanced-rest): support canonical ErrorResponse shape

### DIFF
--- a/libs/advanced-rest/src/utils/kyInstance.ts
+++ b/libs/advanced-rest/src/utils/kyInstance.ts
@@ -16,6 +16,8 @@ export const httpClient = (apiBase?: string) =>
               .catch(() => ({}));
             const error: HttpError = {
               message:
+                errorBody.error?.reason ||
+                errorBody.error?.details ||
                 errorBody.message ||
                 "An error occurred while processing the request",
               statusCode: response.status,


### PR DESCRIPTION
## Summary
- Updates the ky error hook to read `errorBody.error?.reason` and `errorBody.error?.details` from the canonical `{error:{reason,details}}` response shape before falling back to `errorBody.message`.

---

<!-- kody-pr-summary:start -->
This PR enhances the error handling in the advanced-rest HTTP client to support a canonical `ErrorResponse` shape. When processing HTTP error responses, the client now checks for `error.reason` and `error.details` fields within the error body before falling back to the existing `message` field. This allows the client to surface more specific error information from APIs that return errors in the canonical `ErrorResponse` format.
<!-- kody-pr-summary:end -->