### PR TITLE
feat(auth): add /app-login screen for third-party app OAuth flow

### DIFF
--- a/libs/portal-framework-auth/package.json
+++ b/libs/portal-framework-auth/package.json
@@ -31,7 +31,10 @@
   "devDependencies": {
     "@lumeweb/tsdown-config": "workspace:*",
     "@types/react": "catalog:",
-    "tsdown": "catalog:"
+    "@types/react-dom": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
+    "tsdown": "catalog:",
+    "vitest-browser-react": "catalog:"
   },
   "peerDependencies": {
     "@hookform/resolvers": "catalog:",

--- a/libs/portal-framework-auth/src/dataProviders/auth.spec.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.spec.ts
@@ -37,6 +37,30 @@ describe("sanitizeRedirectUrl", () => {
     it("should allow root path", () => {
       expect(sanitizeRedirectUrl("/")).toBe("/");
     });
+
+    it("should reject protocol-relative URLs (//evil.com)", () => {
+      expect(sanitizeRedirectUrl("//evil.com")).toBe("/dashboard");
+    });
+
+    it("should reject backslash-prefixed relative URLs (/\\evil.com)", () => {
+      expect(sanitizeRedirectUrl("/\\evil.com")).toBe("/dashboard");
+    });
+
+    it("should reject tab-obfuscated protocol-relative URLs (/\\t/evil.com)", () => {
+      expect(sanitizeRedirectUrl("/\t/evil.com")).toBe("/dashboard");
+    });
+
+    it("should reject newline-obfuscated backslash (/\\n/evil.com)", () => {
+      expect(sanitizeRedirectUrl("/\n/evil.com")).toBe("/dashboard");
+    });
+
+    it("should reject CR-obfuscated backslash (/\\r/evil.com)", () => {
+      expect(sanitizeRedirectUrl("/\r/evil.com")).toBe("/dashboard");
+    });
+
+    it("should allow regular relative path with whitespace in query", () => {
+      expect(sanitizeRedirectUrl("/callback?tab=\ta")).toBe("/callback?tab=a");
+    });
   });
 
   describe("localhost", () => {

--- a/libs/portal-framework-auth/src/dataProviders/auth.ts
+++ b/libs/portal-framework-auth/src/dataProviders/auth.ts
@@ -151,10 +151,18 @@ export const isExternalRedirect = (url: string): boolean => {
 export const sanitizeRedirectUrl = (url: string | undefined): string => {
   if (!url) return DASHBOARD_PATH;
 
+  // Strip C0 control characters and whitespace that browsers would strip before redirecting.
+  // eslint-disable-next-line no-control-regex
+  const cleaned = url.replace(/[\t\n\r\x00-\x1F]/g, "");
+
   try {
-    // If it's a relative path, allow it
-    if (url.startsWith("/")) {
-      return url;
+    // If it's a relative path, allow it (block protocol-relative //... and /\...)
+    if (
+      cleaned.startsWith("/") &&
+      !cleaned.startsWith("//") &&
+      !cleaned.startsWith("/\\")
+    ) {
+      return cleaned;
     }
 
     const parsedUrl = new URL(url);

--- a/libs/portal-framework-auth/src/index.ts
+++ b/libs/portal-framework-auth/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./dataProviders/auth";
 import { Capability as RefineConfigCapability } from "./capabilities/refineConfig";
 import { Capability as SdkCapability } from "./capabilities/sdk";
+import AppLoginIndex from "./ui/components/app-login/AppLoginIndex";
 import AuthedIndex from "./ui/components/index/AuthedIndex";
 import LoginIndex from "./ui/components/login/LoginIndex";
 import OtpForm from "./ui/components/login/OtpForm";
@@ -23,6 +24,7 @@ import ResetPasswordReset from "./ui/components/reset-password/ResetPasswordRese
 export { RefineConfigCapability, SdkCapability };
 
 export {
+  AppLoginIndex,
   AuthedIndex,
   LoginIndex,
   OtpForm,

--- a/libs/portal-framework-auth/src/ui/components/app-login/AppLoginIndex.browser.spec.tsx
+++ b/libs/portal-framework-auth/src/ui/components/app-login/AppLoginIndex.browser.spec.tsx
@@ -1,0 +1,78 @@
+/// <reference types="vitest/browser" />
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import AppLoginIndex from "./AppLoginIndex";
+
+vi.mock("@refinedev/core", async () => {
+  const actual = await vi.importActual("@refinedev/core");
+  return {
+    ...actual,
+    useLogin: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+    useParsed: () => ({ params: {} }),
+    useGetIdentity: () => ({ data: null }),
+    useIsAuthenticated: () => ({ data: { authenticated: false } }),
+  };
+});
+
+vi.mock("@/hooks/useRedirectIfAuthenticated", () => ({
+  useRedirectIfAuthenticated: vi.fn(),
+}));
+
+describe("AppLoginIndex", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the app login screen with app name from query param", async () => {
+    render(
+      <MemoryRouter initialEntries={["/app-login?app=TestApp&to=/callback"]}>
+        <Routes>
+          <Route path="/app-login" element={<AppLoginIndex />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await expect.element(page.getByText("Connect application")).toBeInTheDocument();
+    await expect.element(page.getByRole("heading", { name: "TestApp", level: 2 })).toBeInTheDocument();
+    await expect.element(page.getByRole("heading", { name: /Sign in to connect TestApp/ })).toBeInTheDocument();
+    await expect.element(page.getByPlaceholder("you@example.com")).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: "Cancel and return to TestApp" })).toBeInTheDocument();
+    await expect.element(
+      page.getByText(/Your password is entered only on this portal and is never shared with TestApp/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders with default app name when no query param", async () => {
+    render(
+      <MemoryRouter initialEntries={["/app-login"]}>
+        <Routes>
+          <Route path="/app-login" element={<AppLoginIndex />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await expect.element(page.getByRole("heading", { name: "an application", level: 2 })).toBeInTheDocument();
+    await expect.element(page.getByRole("heading", { name: /Sign in to connect an application/ })).toBeInTheDocument();
+  });
+
+  it("shows error when submitting empty form", async () => {
+    render(
+      <MemoryRouter initialEntries={["/app-login?app=FailApp"]}>
+        <Routes>
+          <Route path="/app-login" element={<AppLoginIndex />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const submitButton = page.getByRole("button", { name: /Sign in and continue/ });
+    await submitButton.click();
+
+    await expect.element(page.getByText(/Please enter both email and password/)).toBeInTheDocument();
+  });
+});

--- a/libs/portal-framework-auth/src/ui/components/app-login/AppLoginIndex.tsx
+++ b/libs/portal-framework-auth/src/ui/components/app-login/AppLoginIndex.tsx
@@ -1,0 +1,211 @@
+import { sanitizeRedirectUrl } from "@/dataProviders/auth";
+import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
+import { useLogin, useParsed } from "@refinedev/core";
+import React, { useCallback, useState } from "react";
+import { useSearchParams } from "react-router";
+
+import type { AuthFormRequest } from "@/dataProviders/auth";
+import {
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+} from "@lumeweb/portal-framework-ui-core";
+
+/* ─── Inline SVG icons ─── */
+
+const LockIcon = () => (
+  <svg className="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round"
+      d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+  </svg>
+);
+
+const AppIcon = () => (
+  <svg className="w-7 h-7 text-primary-foreground" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <circle cx="8.5" cy="8.5" r="1.5" />
+    <path d="M21 15l-5-5L5 21" />
+  </svg>
+);
+
+const ShieldIcon = () => (
+  <svg className="w-6 h-6 text-muted-foreground flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round"
+      d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+  </svg>
+);
+
+interface LoginParams {
+  to: string;
+}
+
+function AppLoginIndex() {
+  const [searchParams] = useSearchParams();
+  const appName = searchParams.get("app") || "an application";
+  const to = searchParams.get("to");
+
+  const parsed = useParsed<LoginParams>();
+  const rawTo = to ?? parsed.params?.to;
+  const redirectTo = rawTo ? sanitizeRedirectUrl(rawTo) : null;
+
+  useRedirectIfAuthenticated("/dashboard", to);
+
+  const { mutate: login, isPending } = useLogin<AuthFormRequest>();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+
+      if (!email || !password) {
+        setError("Please enter both email and password.");
+        return;
+      }
+
+      login(
+        {
+          email,
+          password,
+          redirectTo: redirectTo ?? "/dashboard",
+          remember: false,
+        },
+        {
+          onError: (err: any) => {
+            setError(
+              err?.response?.data?.message ||
+              err?.message ||
+              "Login failed. Please check your credentials and try again.",
+            );
+          },
+        },
+      );
+    },
+    [email, password, redirectTo, login],
+  );
+
+  const handleCancel = () => {
+    if (redirectTo) {
+      window.location.href = redirectTo;
+    } else if (window.history.length > 1) {
+      window.history.back();
+    }
+  };
+
+  return (
+    <div className="min-h-screen w-full bg-background flex items-center justify-center relative overflow-hidden">
+      {/* Aurora background */}
+      <div className="absolute top-[-100px] right-[-100px] w-[500px] h-[500px] bg-secondary rounded-full opacity-40 blur-[100px]" />
+      <div className="absolute bottom-[-100px] right-[-100px] w-[800px] h-[600px] bg-secondary-1 rounded-full opacity-30 blur-[120px]" />
+      {/* Left sidebar gradient */}
+      <div className="absolute left-0 top-0 bottom-0 w-28 bg-gradient-to-r from-primary-dark to-transparent pointer-events-none" />
+
+      {/* Main card */}
+      <div className="relative z-10 w-full max-w-[560px] mx-4">
+        <Card className="rounded-2xl p-10 border border-border">
+          <CardContent className="p-0 space-y-0">
+
+            {/* Header */}
+            <div className="flex items-center justify-between mb-10">
+              <div className="flex items-center gap-3">
+                <LockIcon />
+                <span className="text-[15px] font-normal text-muted-foreground">Connect application</span>
+              </div>
+              <span className="text-[15px] font-medium text-foreground">Step 1 of 2</span>
+            </div>
+
+            {/* App identity */}
+            <div className="flex flex-col items-center text-center mb-6">
+              <div className="w-16 h-16 rounded-xl bg-muted border border-border flex items-center justify-center">
+                <AppIcon />
+              </div>
+              <h2 className="text-2xl font-bold text-foreground mt-5">{appName}</h2>
+              <h1 className="text-[32px] font-bold text-primary-foreground mt-6 leading-tight">
+                Sign in to connect {appName}
+              </h1>
+            </div>
+
+            {/* Description */}
+            <p className="text-base text-muted-foreground leading-relaxed text-center max-w-[380px] mx-auto mb-8">
+              {appName} wants to connect to your account.
+              <br />
+              Sign in to continue and review the requested access.
+            </p>
+
+            {/* Error message */}
+            {error && (
+              <div className="mb-6 p-3 rounded-lg bg-destructive/20 border border-destructive/50 text-destructive-foreground text-sm text-center">
+                {error}
+              </div>
+            )}
+
+            {/* Login form */}
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <Label className="text-primary-1-foreground">Email</Label>
+                <Input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  autoComplete="username"
+                  fullWidth
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label className="text-primary-1-foreground">Password</Label>
+                <Input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your password"
+                  autoComplete="current-password"
+                  fullWidth
+                />
+              </div>
+
+              {/* Buttons */}
+              <div className="space-y-3 pt-2">
+                <Button
+                  type="submit"
+                  disabled={isPending}
+                  className="w-full bg-primary hover:bg-primary-1 disabled:opacity-60 text-primary-foreground font-semibold text-base h-14 rounded-xl transition-colors"
+                >
+                  {isPending ? "Signing in…" : "Sign in and continue"}
+                </Button>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCancel}
+                  className="w-full border-border hover:border-primary hover:bg-primary/5 text-primary font-semibold text-base h-14 rounded-xl transition-all"
+                >
+                  Cancel and return to {appName}
+                </Button>
+              </div>
+            </form>
+
+            {/* Security notice */}
+            <div className="flex items-start gap-3 pt-6">
+              <ShieldIcon />
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Your password is entered only on this portal and is never shared with {appName}.
+              </p>
+            </div>
+
+            {/* Divider */}
+            <div className="h-px bg-border/50 my-6" />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default AppLoginIndex;

--- a/libs/portal-framework-auth/src/ui/components/app-login/SecurityNotice.tsx
+++ b/libs/portal-framework-auth/src/ui/components/app-login/SecurityNotice.tsx
@@ -1,0 +1,19 @@
+import { lazyIcon } from "@lumeweb/portal-framework-ui-core";
+
+const ShieldCheck = lazyIcon("ShieldCheck");
+
+interface SecurityNoticeProps {
+  appName: string;
+}
+
+export function SecurityNotice({ appName }: SecurityNoticeProps) {
+  return (
+    <div className="flex items-start gap-2 text-sm text-muted-foreground">
+      <ShieldCheck className="h-4 w-4 mt-0.5 flex-shrink-0 text-secondary" />
+      <span>
+        Your password is entered only on this portal and is never shared
+        with {appName}.
+      </span>
+    </div>
+  );
+}

--- a/libs/portal-framework-auth/vitest.config.ts
+++ b/libs/portal-framework-auth/vitest.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+const alias = {
+  "@": path.resolve(__dirname, "./src"),
+};
+
+export default defineConfig({
+  plugins: [react() as any],
+  test: {
+    projects: [
+      {
+        resolve: { alias },
+        test: {
+          name: "unit",
+          include: ["src/**/*.spec.ts"],
+          environment: "happy-dom",
+        },
+      },
+      {
+        resolve: { alias },
+        test: {
+          name: "browser",
+          include: ["src/**/*.browser.spec.{ts,tsx}"],
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+            headless: true,
+          },
+        },
+      },
+    ],
+  },
+});

--- a/libs/portal-framework-auth/vitest.config.unit.ts
+++ b/libs/portal-framework-auth/vitest.config.unit.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "happy-dom",
-    include: ["src/**/*.spec.{ts,tsx}"],
-  },
-});

--- a/libs/portal-plugin-dashboard/plugin.config.ts
+++ b/libs/portal-plugin-dashboard/plugin.config.ts
@@ -17,6 +17,7 @@ export default {
     "./dashboard": "./src/ui/routes/dashboard",
     "./index": "./src/ui/routes/index",
     "./loginIndex": "./src/ui/routes/loginIndex",
+    "./appLoginIndex": "./src/ui/routes/appLoginIndex",
     "./loginOtp": "./src/ui/routes/otp",
     "./registerIndex": "./src/ui/routes/registerIndex",
     "./resetPassword/confirm": "./src/ui/routes/resetPassword.confirm",

--- a/libs/portal-plugin-dashboard/src/routes.tsx
+++ b/libs/portal-plugin-dashboard/src/routes.tsx
@@ -102,6 +102,11 @@ const routes: RouteDefinition[] = [
     path: "login",
   },
   {
+    component: "appLoginIndex",
+    id: createNamespacedId(CORE_NS, "app-login"),
+    path: "app-login",
+  },
+  {
     component: "registerIndex",
     id: createNamespacedId(CORE_NS, "register-index"),
     path: "register",

--- a/libs/portal-plugin-dashboard/src/ui/routes/appLoginIndex.tsx
+++ b/libs/portal-plugin-dashboard/src/ui/routes/appLoginIndex.tsx
@@ -1,0 +1,3 @@
+import { AppLoginIndex } from "@lumeweb/portal-framework-auth";
+
+export default AppLoginIndex;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,7 +481,7 @@ importers:
         version: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -930,7 +930,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
   libs/pinner:
     dependencies:
@@ -1115,7 +1115,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-framework-auth:
     dependencies:
@@ -1168,9 +1168,18 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.9(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16)(vitest@4.1.9)
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.10(@vitejs/devtools@0.3.4)(publint@0.3.21)(typescript@6.0.3)
+        version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
+      vitest-browser-react:
+        specifier: 'catalog:'
+        version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
 
   libs/portal-framework-core:
     dependencies:
@@ -1850,7 +1859,7 @@ importers:
         version: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -2284,7 +2293,7 @@ importers:
         version: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
       vitest-browser-react:
         specifier: 'catalog:'
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
@@ -2357,7 +2366,7 @@ importers:
         version: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-plugin-sia:
     dependencies:
@@ -2412,7 +2421,7 @@ importers:
         version: 20.10.6
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
   libs/portal-plugin-template:
     dependencies:
@@ -2540,7 +2549,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
   libs/tsdown-config:
     devDependencies:
@@ -2592,7 +2601,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
 packages:
 
@@ -15137,10 +15146,6 @@ packages:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -23732,7 +23737,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))':
+  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
@@ -23891,10 +23896,10 @@ snapshots:
       - vite
       - vue
 
-  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)':
+  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)(vite@8.0.16)
-      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
+      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
       devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)
@@ -23936,50 +23941,6 @@ snapshots:
     optional: true
 
   '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)':
-    dependencies:
-      '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
-      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
-      birpc: 4.0.0
-      cac: 7.0.0
-      devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)
-      h3: 1.15.11
-      logs-sdk: 0.0.6
-      mlly: 1.8.2
-      obug: 2.1.3
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      tinyexec: 1.2.4
-      vite: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      vue: 3.5.39(typescript@6.0.3)
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@pnpm/logger'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - idb-keyval
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-    optional: true
-
-  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
       '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
@@ -32350,8 +32311,6 @@ snapshots:
 
   tinyexec@1.1.1: {}
 
-  tinyexec@1.1.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
@@ -33048,7 +33007,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.0
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
@@ -33067,7 +33026,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.0
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -33123,7 +33082,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+      vitest: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -33137,15 +33096,15 @@ snapshots:
       '@vitest/snapshot': 4.1.9
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -33155,37 +33114,6 @@ snapshots:
       '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16)(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.5(vitest@4.1.9)
-      happy-dom: 20.10.6
-      jsdom: 29.1.1(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@1.21.7)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 26.1.0
-      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16)(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       happy-dom: 20.10.6
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
Adds a dedicated app-login screen at /app-login for third-party Sia applications to authenticate users via the portal.

## Features

- Displays the requesting app name from the ?app= query parameter
- Email/password login using useLogin from @refinedev/core
- Auto-redirects authenticated users via useRedirectIfAuthenticated
- Uses shadcn/ui theme tokens (Card, Input, Label, Button) for consistent theming
- Handles redirect via ?to= query parameter with sanitizeRedirectUrl
- Dynamic security notice: "Your password is entered only on this portal and is never shared with {appName}"

## Tests

- Query param rendering (app name, redirect)
- Default app name fallback when no query param
- Empty form validation error display

---

<!-- kody-pr-summary:start -->
This PR adds a new `/app-login` screen designed for third-party applications initiating an OAuth connection flow. The screen provides a dedicated login experience that displays the connecting app's name, collects user credentials, and includes a cancel option to return the user to the originating app.

**Key changes:**

- **New `AppLoginIndex` component**: A login screen that reads the app name and redirect target from query parameters (`app` and `to`). It shows a "Connect application" header with a step indicator, the app identity, an email/password login form, a cancel button that redirects back to the app, and a security notice assuring users their password is never shared with the third-party app.
- **New `SecurityNotice` component**: A reusable component displaying a password privacy message with a shield icon.
- **Route registration**: The `/app-login` path is registered in the dashboard plugin routes, mapped to the new `AppLoginIndex` component.
- **Package exports**: `AppLoginIndex` is exported from the auth framework package and exposed via the dashboard plugin's module exports.
- **Test infrastructure**: Vitest configuration updated to inline `@refinedev` dependencies and add a `@` path alias, along with unit tests covering app name rendering, default fallback, and form validation for empty submissions.
<!-- kody-pr-summary:end -->