### PR TITLE
fix(pinner.xyz): clarify comparison table copy on homepage

### DIFF
--- a/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
+++ b/apps/pinner.xyz/src/components/DifferentiatorsSection.tsx
@@ -7,57 +7,57 @@ interface DifferentiatorsSectionProps {
 
 const columns = [
   { label: "Traditional Cloud" },
-  { label: "Cloud Storage", highlight: true },
-  { label: "Public (IPFS)", highlight: true },
+  { label: "Pinner: Cloud Storage", highlight: true },
+  { label: "Pinner: Public (IPFS)", highlight: true },
 ];
 
 const rows = [
   {
-    factor: "Can your data be read?",
+    factor: "Can the provider read your data?",
     values: [
-      "Yes",
-      "No. Encrypted on your device. No one holds the keys",
-      "Yes, but it's public",
+      "Yes. They hold the keys.",
+      "No. Encrypted on your device.",
+      "Not applicable. Public by design.",
     ],
   },
   {
     factor: "Pricing",
     values: [
       "Complex tiers, hidden fees",
-      "Simple plans, bundled storage",
-      "Simple plans, bundled storage",
+      "Upfront. No surprise line items.",
+      "Upfront. No surprise line items.",
     ],
   },
   {
-    factor: "Ownership",
+    factor: "Can they delete your account?",
     values: [
-      "They can delete your data",
-      "Your data, your rules",
-      "Your data, your rules",
+      "Yes. Terms of service violations, policy changes.",
+      "No. Your keys, your data.",
+      "No. Your keys, your data.",
     ],
   },
   {
-    factor: "Lock-in",
+    factor: "Leaving",
     values: [
       "Export fees, proprietary formats",
-      "Open standards, leave anytime",
-      "Open standards, leave anytime",
+      "Open standards. Leave anytime.",
+      "Open standards. Leave anytime.",
     ],
   },
   {
     factor: "Infrastructure",
     values: [
       "Centralized data centers",
-      "Peer-to-peer storage",
-      "Peer-to-peer storage",
+      "Distributed peer-to-peer network",
+      "Distributed peer-to-peer network",
     ],
   },
   {
-    factor: "Payment options",
+    factor: "Payment",
     values: [
-      "Credit card only, ID required",
-    "Crypto or card. No ID for crypto",
-    "Crypto or card. No ID for crypto",
+      "Credit card and ID required",
+      "Card or crypto. No ID for crypto.",
+      "Card or crypto. No ID for crypto.",
     ],
   },
 ];


### PR DESCRIPTION
## Changes

- **Row labels**: unambiguous questions instead of vague factor names
  - 'Can your data be read?' -> 'Can the provider read your data?'
  - 'Ownership' -> 'Can they delete your account?'
  - 'Lock-in' -> 'Leaving'
- **Traditional column**: answers now specify the mechanism
  - 'Yes' -> 'Yes. They hold the keys.'
  - 'They can delete your data' -> 'Yes. Terms of service violations, policy changes.'
- **IPFS column**: 'Yes, but it\'s public' -> 'Not applicable. Public by design.'
- **Column headers**: clearer 'Pinner: Cloud Storage', 'Pinner: Public (IPFS)'
- **Values tightened** for specificity and consistency across all rows

---

<!-- kody-pr-summary:start -->
This pull request updates the comparison table on the pinner.xyz homepage to clarify and improve the copy. The column headers for the Pinner offerings are now explicitly labeled, and the comparison factors and their corresponding values have been rewritten to be more precise, direct, and consistent across the table. Key changes include rephrasing factors such as "Ownership" to "Can they delete your account?" and "Lock-in" to "Leaving," as well as refining the value descriptions for each provider type to better communicate the differences in data privacy, pricing, account control, portability, infrastructure, and payment options.
<!-- kody-pr-summary:end -->