### PR TITLE
ci(deploy): align envfile secrets with actual repository secret names

### DIFF
--- a/.github/workflows/deploy-pinner.xyz.yml
+++ b/.github/workflows/deploy-pinner.xyz.yml
@@ -28,11 +28,11 @@ jobs:
           directory: apps/pinner.xyz
           env-keys: |
             {
-              "PUBLIC_PORTAL_API_URL": "${{ vars.PINNER_PORTAL_API_URL }}",
-              "PUBLIC_LISTMONK_URL": "${{ vars.PINNER_LISTMONK_URL }}",
-              "PUBLIC_LISTMONK_LIST_UUID": "${{ vars.PINNER_LISTMONK_LIST_UUID }}",
+              "PUBLIC_PORTAL_API_URL": "${{ secrets.PINNER_PORTAL_API_URL }}",
+              "PUBLIC_LISTMONK_URL": "${{ secrets.PUBLIC_LISTMONK_URL }}",
+              "PUBLIC_LISTMONK_LIST_UUID": "${{ secrets.PUBLIC_LISTMONK_LIST_UUID }}",
               "PUBLIC_POSTHOG_PROJECT_TOKEN": "${{ secrets.PINNER_POSTHOG_PROJECT_TOKEN }}",
-              "PUBLIC_POSTHOG_HOST": "${{ vars.PINNER_POSTHOG_HOST }}"
+              "PUBLIC_POSTHOG_HOST": "${{ secrets.PINNER_POSTHOG_HOST }}"
             }
           fail-on-empty: "PUBLIC_POSTHOG_PROJECT_TOKEN,PUBLIC_POSTHOG_HOST"
       - name: Build


### PR DESCRIPTION
- Fix PUBLIC_PORTAL_API_URL to use secrets instead of vars
- Fix PUBLIC_LISTMONK_URL and PUBLIC_LISTMONK_LIST_UUID to match actual secret names (PUBLIC_* prefix)
- Fix PUBLIC_POSTHOG_HOST to use secrets instead of vars

---

<!-- kody-pr-summary:start -->
This PR fixes the deployment workflow for the pinner.xyz application by correcting the environment variable references in the envfile generation step. Specifically, it changes several configuration values from using repository variables (`vars`) to repository secrets (`secrets`) to align with how they are actually stored. Additionally, it corrects the secret names for `PUBLIC_LISTMONK_URL` and `PUBLIC_LISTMONK_LIST_UUID` to match the actual repository secret names (using the `PUBLIC_` prefix instead of `PINNER_`).
<!-- kody-pr-summary:end -->