### PR TITLE
feat(astro-redirects): Astro integration for _redirects and frontmatter redirects

### DIFF
--- a/libs/astro-redirects/.gitignore
+++ b/libs/astro-redirects/.gitignore
@@ -1,0 +1,1 @@
+/coverage

--- a/libs/astro-redirects/README.md
+++ b/libs/astro-redirects/README.md
@@ -1,0 +1,53 @@
+# Astro Redirects Plugin
+
+An [Astro integration](https://docs.astro.build/en/guides/integrations-guide/) that generates redirects from `_redirects` files, frontmatter, and programmatic config. Compatible with the [IPFS Web Redirects File specification](https://specs.ipfs.tech/http-gateways/web-redirects-file/) and inspired by [`astro-redirect-from`](https://github.com/kremalicious/astro-redirect-from).
+
+## Features
+
+- Parse `_redirects` files (Netlify/IPFS-style) into Astro redirects.
+- Supports splats (`*`), placeholders (`:id`), status codes (200, 301-308, 404, 410, 451).
+- Read `redirect_from` frontmatter from Markdown/MDX files (like Jekyll/Gatsby).
+- Optional: generate a `_redirects` text file in the build output for static hosts.
+
+## Install
+
+```bash
+pnpm add @lumeweb/astro-redirects
+```
+
+## Usage
+
+```ts
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import redirects from '@lumeweb/astro-redirects';
+
+export default defineConfig({
+  integrations: [
+    redirects({
+      // Read _redirects file from public dir (default: true)
+      redirectsFile: true,
+      // Use frontmatter `redirect_from` in src/pages/**/*.md(x) (default: true)
+      frontmatter: true,
+      // Extra static redirects
+      extra: {
+        '/old': '/new',
+        '/docs/*': '/help/:splat',
+      },
+      // Also emit _redirects text file to output dir (for static hosts)
+      emitFile: true,
+    }),
+  ],
+});
+```
+
+## Package Structure
+
+- `src/index.ts` — Astro integration entrypoint.
+- `src/parse.ts` — `_redirects` file parser (IPFS/Netlify format).
+- `src/frontmatter.ts` — Collect redirects from Markdown frontmatter.
+- `src/types.ts` — Shared types.
+
+## License
+
+MIT

--- a/libs/astro-redirects/package.json
+++ b/libs/astro-redirects/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@lumeweb/astro-redirects",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Astro integration for _redirects files and frontmatter redirects",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "lint": "tsc --noEmit",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "astro": "catalog:"
+  },
+  "devDependencies": {
+    "@lumeweb/tsdown-config": "workspace:*",
+    "@types/node": "catalog:",
+    "gray-matter": "^4.0.3",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LumeWeb/web"
+  }
+}

--- a/libs/astro-redirects/src/frontmatter.test.ts
+++ b/libs/astro-redirects/src/frontmatter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractRedirectFromFrontmatter,
+  buildFrontmatterRules,
+} from "./frontmatter.js";
+
+describe("extractRedirectFromFrontmatter", () => {
+  it("extracts a single redirect_from string", () => {
+    const source = `---\nredirect_from: /old\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: ["/old"],
+    });
+  });
+
+  it("extracts array redirect_from", () => {
+    const source = `---\nredirect_from: ["/old", "/older"]\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: ["/old", "/older"],
+    });
+  });
+
+  it("returns slug and draft when present", () => {
+    const source = `---\nredirect_from: /old\nslug: /custom\ndraft: true\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: ["/old"],
+      slug: "/custom",
+      draft: true,
+    });
+  });
+
+  it("parses YAML array redirect_from", () => {
+    const source = `---\nredirect_from:\n  - /old\n  - /older\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: ["/old", "/older"],
+    });
+  });
+
+  it("parses JSON array redirect_from", () => {
+    const source = `---\nredirect_from: ["/old", "/older"]\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: ["/old", "/older"],
+    });
+  });
+
+  it("filters invalid redirect paths including empty strings", () => {
+    const source = `---\nredirect_from:\n  - /valid\n  - "https://example.com"\n  - "has space"\n  - ""\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: ["/valid"],
+    });
+  });
+
+  it("treats draft string 'true' as boolean true", () => {
+    const source = `---\nredirect_from: /old\ndraft: true\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source).draft).toBe(true);
+  });
+
+  it("handles missing redirect_from gracefully", () => {
+    const source = `---\nslug: /post\n---\n# Hello\n`;
+    expect(extractRedirectFromFrontmatter(source)).toEqual({
+      redirects: [],
+      slug: "/post",
+      draft: undefined,
+    });
+  });
+
+  it("skips missing frontmatter", () => {
+    expect(extractRedirectFromFrontmatter("# No frontmatter\n")).toEqual({
+      redirects: [],
+      slug: undefined,
+      draft: undefined,
+    });
+  });
+});
+
+describe("buildFrontmatterRules", () => {
+  it("builds rules with leading slash", () => {
+    const rules = buildFrontmatterRules(["/old"], "post");
+    expect(rules).toEqual([{ from: "/old", to: "/post", status: 301 }]);
+  });
+
+  it("preserves existing leading slash in slug", () => {
+    const rules = buildFrontmatterRules(["/old"], "/post");
+    expect(rules).toEqual([{ from: "/old", to: "/post", status: 301 }]);
+  });
+
+  it("normalizes missing leading slash in redirect_from", () => {
+    // Regression: frontmatter redirect_from values without leading / must be normalized
+    const rules = buildFrontmatterRules(["old"], "/post");
+    expect(rules).toEqual([{ from: "/old", to: "/post", status: 301 }]);
+  });
+});

--- a/libs/astro-redirects/src/frontmatter.ts
+++ b/libs/astro-redirects/src/frontmatter.ts
@@ -1,0 +1,61 @@
+import type { RedirectRule, RedirectsPluginOptions } from "./types.js";
+import matter from "gray-matter";
+
+export interface Frontmatter {
+  redirect_from?: string | string[];
+  slug?: string;
+  draft?: boolean;
+}
+
+/**
+ * Extract `redirect_from` frontmatter values from a Markdown/MDX source string.
+ *
+ * Uses gray-matter for robust YAML frontmatter parsing.
+ *
+ * @param source - File content.
+ * @returns Object with redirects array, optional slug override, and draft flag.
+ */
+export function extractRedirectFromFrontmatter(source: string): {
+  redirects: string[];
+  slug?: string;
+  draft?: boolean;
+} {
+  const { data } = matter(source);
+
+  const raw = data.redirect_from;
+  const arr = Array.isArray(raw) ? raw : raw ? [raw] : [];
+
+  return {
+    redirects: arr.filter(
+      (r): r is string => typeof r === "string" && isValidPath(r)
+    ),
+    slug: typeof data.slug === "string" ? data.slug : undefined,
+    draft: data.draft === true ? true : undefined,
+  };
+}
+
+function isValidPath(value: string): boolean {
+  return value.length > 0 && !value.includes("://") && !value.includes(" ") && !value.includes("\n");
+}
+
+/**
+ * Build redirect rules from frontmatter data.
+ *
+ * @param redirects - Array of redirect source paths.
+ * @param slug - Destination page slug.
+ * @returns Array of {@link RedirectRule}.
+ */
+function normalizeFrom(value: string): string {
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+export function buildFrontmatterRules(
+  redirects: string[],
+  slug: string
+): RedirectRule[] {
+  return redirects.map((from) => ({
+    from: normalizeFrom(from),
+    to: slug.startsWith("/") ? slug : `/${slug}`,
+    status: 301,
+  }));
+}

--- a/libs/astro-redirects/src/index.test.ts
+++ b/libs/astro-redirects/src/index.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { describe, expect, it, afterEach } from "vitest";
+import { collectMarkdownFiles } from "./index.js";
+
+describe("collectMarkdownFiles", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("collects md/mdx files recursively", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "redirects-"));
+    fs.mkdirSync(path.join(tmpDir, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "a.md"), "# A");
+    fs.writeFileSync(path.join(tmpDir, "sub", "b.mdx"), "# B");
+
+    const files = await collectMarkdownFiles(tmpDir);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => path.basename(f)).sort()).toEqual([
+      "a.md",
+      "b.mdx",
+    ]);
+  });
+
+  it("skips symlinks pointing outside contentDir", async () => {
+    // Regression: symlinks outside contentDir must not be collected
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "redirects-"));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "outside-"));
+    fs.writeFileSync(path.join(outsideDir, "secret.md"), "# Secret");
+
+    fs.writeFileSync(path.join(tmpDir, "legit.md"), "# Legit");
+    fs.symlinkSync(
+      path.join(outsideDir, "secret.md"),
+      path.join(tmpDir, "leak.md")
+    );
+
+    const files = await collectMarkdownFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(path.basename(files[0])).toBe("legit.md");
+
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("allows symlinks pointing inside contentDir", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "redirects-"));
+    fs.mkdirSync(path.join(tmpDir, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "sub", "target.md"), "# Target");
+    fs.symlinkSync(
+      path.join(tmpDir, "sub", "target.md"),
+      path.join(tmpDir, "link.md")
+    );
+
+    const files = await collectMarkdownFiles(tmpDir);
+    expect(files).toHaveLength(2);
+  });
+
+  it("prevents cyclic symlink infinite recursion", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "redirects-"));
+    fs.mkdirSync(path.join(tmpDir, "a"), { recursive: true });
+    fs.symlinkSync(path.join(tmpDir, "a"), path.join(tmpDir, "a", "cycle"));
+    fs.writeFileSync(path.join(tmpDir, "a", "file.md"), "# File");
+
+    // Should not hang or throw
+    const files = await collectMarkdownFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(path.basename(files[0])).toBe("file.md");
+  });
+});

--- a/libs/astro-redirects/src/index.ts
+++ b/libs/astro-redirects/src/index.ts
@@ -1,0 +1,262 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AstroIntegration } from "astro";
+import type { RedirectRule, RedirectsPluginOptions } from "./types.js";
+import {
+  parseRedirects,
+  parseFrom,
+  parseTo,
+  parseStatus,
+  isAstroSupportedStatus,
+} from "./parse.js";
+import {
+  buildFrontmatterRules,
+  extractRedirectFromFrontmatter,
+} from "./frontmatter.js";
+
+const DEFAULT_CONTENT_DIR = "src/pages";
+
+export { parseRedirects };
+export type { RedirectRule, RedirectsPluginOptions };
+
+export default function astroRedirects(
+  options: RedirectsPluginOptions = {}
+): AstroIntegration {
+  const {
+    redirectsFile = true,
+    frontmatter = true,
+    extra = {},
+    emitFile = false,
+    contentDir = DEFAULT_CONTENT_DIR,
+    getSlug = defaultGetSlug,
+  } = options;
+
+  // Accumulate rules across hooks for emitFile support
+  let accumulatedRules: RedirectRule[] = [];
+
+  return {
+    name: "@lumeweb/astro-redirects",
+    hooks: {
+      "astro:config:setup": async ({
+        config,
+        command,
+        updateConfig,
+        logger,
+      }) => {
+        const rules: RedirectRule[] = [];
+        const seen = new Set<string>();
+
+        function addRules(newRules: RedirectRule[], source: string) {
+          for (const rule of newRules) {
+            if (seen.has(rule.from)) {
+              const idx = rules.findIndex((r) => r.from === rule.from);
+              if (idx !== -1) {
+                logger.warn(
+                  `Duplicate redirect from "${rule.from}" in ${source} — overriding`
+                );
+                rules[idx] = rule;
+              }
+              continue;
+            }
+            seen.add(rule.from);
+            rules.push(rule);
+          }
+        }
+
+        // 1. Parse _redirects file (lowest priority)
+        if (redirectsFile) {
+          const root = fileURLToPath(config.root);
+          const publicDir = fileURLToPath(config.publicDir);
+
+          const filePath =
+            typeof redirectsFile === "string"
+              ? path.resolve(root, redirectsFile)
+              : path.join(publicDir, "_redirects");
+
+          try {
+            const stats = await fs.promises.stat(filePath);
+            if (!stats.isFile()) {
+              throw new Error(`_redirects path is not a file: ${filePath}`);
+            }
+            if (stats.size > 65536) {
+              throw new Error(
+                `_redirects file exceeds 64 KiB limit: ${stats.size} bytes`
+              );
+            }
+            const content = await fs.promises.readFile(filePath, "utf-8");
+            const parsed = parseRedirects(content);
+            addRules(parsed, `_redirects file (${filePath})`);
+            logger.info(`Parsed ${parsed.length} redirects from ${filePath}`);
+          } catch (err: any) {
+            if (err.code === "ENOENT") {
+              if (typeof redirectsFile === "string") {
+                throw new Error(`_redirects file not found: ${filePath}`);
+              }
+              // Optional default file not found — ok
+            } else {
+              throw err;
+            }
+          }
+        }
+
+        // 2. Frontmatter redirects (medium priority)
+        if (frontmatter) {
+          const root = fileURLToPath(config.root);
+          const contentDirPath = path.resolve(root, contentDir);
+
+          try {
+            const dirStat = await fs.promises.stat(contentDirPath);
+            if (!dirStat.isDirectory()) {
+              throw new Error(`contentDir is not a directory: ${contentDirPath}`);
+            }
+            const mdFiles = await collectMarkdownFiles(contentDirPath);
+
+            for (const file of mdFiles) {
+              const source = await fs.promises.readFile(file, "utf-8");
+              const {
+                redirects: fmRedirects,
+                slug: fmSlug,
+                draft,
+              } = extractRedirectFromFrontmatter(source);
+
+              if (fmRedirects.length === 0) continue;
+
+              // Skip drafts in production builds
+              if (command === "build" && draft === true) continue;
+
+              const slug =
+                fmSlug || getSlug(path.relative(contentDirPath, file));
+              const fmRules = buildFrontmatterRules(fmRedirects, slug);
+              addRules(fmRules, `frontmatter in ${path.relative(root, file)}`);
+            }
+
+            logger.info(
+              `Collected ${rules.length} redirects from frontmatter`
+            );
+          } catch (err: any) {
+            if (err.code === "ENOENT") {
+              // contentDir doesn't exist — ok
+            } else {
+              throw err;
+            }
+          }
+        }
+
+        // 3. Extra static redirects (highest priority) — validated
+        const extraRules: RedirectRule[] = [];
+        for (const [key, dest] of Object.entries(extra)) {
+          const validatedFrom = parseFrom(key);
+          if (typeof dest === "string") {
+            extraRules.push({
+              from: validatedFrom,
+              to: parseTo(dest),
+              status: 301,
+            });
+          } else {
+            extraRules.push({
+              from: validatedFrom,
+              to: parseTo(dest.to),
+              status: parseStatus(String(dest.status)),
+            });
+          }
+        }
+        addRules(extraRules, "extra config");
+
+        if (rules.length === 0) {
+          logger.warn("No redirects found");
+          return;
+        }
+
+        // Store for build:done hook
+        accumulatedRules = rules;
+
+        // 4. Merge into Astro config (with status preservation)
+        // Astro supports object form { status, destination } for redirects
+        const astroRedirects: Record<
+          string,
+          string | { status: number; destination: string }
+        > = { ...(config.redirects || {}) };
+
+        for (const rule of rules) {
+          if (isAstroSupportedStatus(rule.status)) {
+            // Preserve the status code; Astro supports object form for non-301
+            if (rule.status !== 301) {
+              astroRedirects[rule.from] = {
+                status: rule.status,
+                destination: rule.to,
+              };
+            } else {
+              astroRedirects[rule.from] = rule.to;
+            }
+          }
+        }
+
+        if (Object.keys(astroRedirects).length > 0) {
+          updateConfig({ redirects: astroRedirects });
+        }
+      },
+
+      "astro:build:done": async ({ dir, logger }) => {
+        if (emitFile && accumulatedRules.length > 0) {
+          const outDir = fileURLToPath(dir);
+
+          const lines = accumulatedRules.map(
+            (r) => `${r.from} ${r.to} ${r.status}`
+          );
+          await fs.promises.mkdir(outDir, { recursive: true });
+          await fs.promises.writeFile(
+            path.join(outDir, "_redirects"),
+            lines.join("\n") + "\n"
+          );
+
+          logger.info(`Emitted _redirects file to ${outDir}`);
+        }
+      },
+    },
+  };
+}
+
+export async function collectMarkdownFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const visited = new Set<string>();
+  const rootReal = await fs.promises.realpath(dir);
+
+  async function walk(current: string) {
+    const real = await fs.promises.realpath(current);
+
+    // Prevent symlink traversal outside contentDir
+    const rel = path.relative(rootReal, real);
+    if (rel.startsWith("..") || rel === "..") {
+      return;
+    }
+
+    if (visited.has(real)) return;
+    visited.add(real);
+
+    const entries = await fs.promises.readdir(current, {
+      withFileTypes: true,
+    });
+
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (/\.(md|mdx)$/i.test(entry.name)) {
+        const real = await fs.promises.realpath(full);
+        const rel = path.relative(rootReal, real);
+        if (rel.startsWith("..") || rel === "..") continue;
+        results.push(full);
+      }
+    }
+  }
+
+  await walk(dir);
+  return results;
+}
+
+function defaultGetSlug(filePath: string): string {
+  // Strip index.md and extension
+  const withoutExt = filePath.replace(/\.(md|mdx)$/i, "");
+  return "/" + withoutExt.replace(/\\/g, "/").replace(/\/index$/, "");
+}

--- a/libs/astro-redirects/src/parse.test.ts
+++ b/libs/astro-redirects/src/parse.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseRedirects,
+  parseFrom,
+  parseTo,
+  parseStatus,
+  isValidStatus,
+  isAstroSupportedStatus,
+} from "./parse.js";
+
+describe("parseRedirects", () => {
+  it("parses a simple redirect", () => {
+    const result = parseRedirects("/old /new 301");
+    expect(result).toEqual([{ from: "/old", to: "/new", status: 301 }]);
+  });
+
+  it("defaults status to 301", () => {
+    const result = parseRedirects("/a /b");
+    expect(result[0].status).toBe(301);
+  });
+
+  it("supports splats", () => {
+    const result = parseRedirects("/docs/* /help/:splat 301");
+    expect(result[0].from).toBe("/docs/*");
+  });
+
+  it("supports external URLs", () => {
+    const result = parseRedirects("/ipfs https://ipfs.io 302");
+    expect(result[0].to).toBe("https://ipfs.io");
+  });
+
+  it("supports IPFS-only status codes (200, 404, 410, 451)", () => {
+    // Regression: parser must accept full IPFS spec, not just Astro subset
+    expect(parseRedirects("/rewrite /new 200")).toEqual([
+      { from: "/rewrite", to: "/new", status: 200 },
+    ]);
+    expect(parseRedirects("/missing /404 404")).toEqual([
+      { from: "/missing", to: "/404", status: 404 },
+    ]);
+    expect(parseRedirects("/gone /410 410")).toEqual([
+      { from: "/gone", to: "/410", status: 410 },
+    ]);
+    expect(parseRedirects("/legal /451 451")).toEqual([
+      { from: "/legal", to: "/451", status: 451 },
+    ]);
+  });
+
+  it("ignores comments and blank lines", () => {
+    const input = `# comment\n\n/old /new\n`;
+    const result = parseRedirects(input);
+    expect(result).toHaveLength(1);
+  });
+
+  it("throws on bad status", () => {
+    expect(() => parseRedirects("/a /b 500")).toThrow();
+  });
+
+  it("throws on forced redirect", () => {
+    expect(() => parseRedirects("/a /b 301!")).toThrow();
+  });
+
+  it("throws when file exceeds 64 KiB in bytes", () => {
+    // Regression: must measure bytes, not UTF-16 code units
+    const huge = "ä".repeat(32769); // 2 bytes each = 65538 bytes
+    expect(() => parseRedirects(huge)).toThrow("cannot exceed");
+  });
+
+  it("allows file at exactly 64 KiB bytes", () => {
+    const exact = "/a /b\n".repeat(10922); // 6 * 10922 = 65532 bytes
+    expect(() => parseRedirects(exact)).not.toThrow();
+  });
+
+  it("throws on missing 'to' path", () => {
+    expect(() => parseRedirects("/only-from")).toThrow("Missing 'to'");
+  });
+
+  it("throws on too many fields", () => {
+    expect(() => parseRedirects("/a /b 301 extra")).toThrow("Too many fields");
+  });
+
+  it("throws on multiple asterisks", () => {
+    expect(() => parseRedirects("/*/* /b")).toThrow("at most one asterisk");
+  });
+
+  it("throws when splat is not at end", () => {
+    expect(() => parseRedirects("/foo*bar /b")).toThrow("end with asterisk");
+  });
+
+  it("throws when 'from' does not start with /", () => {
+    expect(() => parseRedirects("old /new")).toThrow("begin with '/'");
+  });
+
+  it("throws on invalid URL scheme in 'to'", () => {
+    expect(() => parseRedirects("/a ftp://host")).toThrow("Invalid URL scheme");
+  });
+});
+
+describe("parseFrom", () => {
+  it("accepts valid paths", () => {
+    expect(parseFrom("/old")).toBe("/old");
+    expect(parseFrom("/docs/*")).toBe("/docs/*");
+  });
+
+  it("throws on missing leading slash", () => {
+    expect(() => parseFrom("old")).toThrow("begin with '/'");
+  });
+
+  it("throws on multiple splats", () => {
+    expect(() => parseFrom("/*/*")).toThrow("at most one asterisk");
+  });
+
+  it("throws on inline splat", () => {
+    expect(() => parseFrom("/a*b")).toThrow("end with asterisk");
+  });
+});
+
+describe("parseTo", () => {
+  it("accepts absolute paths", () => {
+    expect(parseTo("/new")).toBe("/new");
+  });
+
+  it("accepts allowed URL schemes", () => {
+    expect(parseTo("https://example.com")).toBe("https://example.com");
+    expect(parseTo("http://example.com")).toBe("http://example.com");
+    expect(parseTo("ipfs://Qmabc")).toBe("ipfs://Qmabc");
+    expect(parseTo("ipns://example")).toBe("ipns://example");
+  });
+
+  it("rejects disallowed URL schemes", () => {
+    expect(() => parseTo("ftp://host")).toThrow("Invalid URL scheme");
+  });
+});
+
+describe("parseStatus", () => {
+  it("accepts valid IPFS status codes", () => {
+    expect(parseStatus("200")).toBe(200);
+    expect(parseStatus("301")).toBe(301);
+    expect(parseStatus("302")).toBe(302);
+    expect(parseStatus("303")).toBe(303);
+    expect(parseStatus("307")).toBe(307);
+    expect(parseStatus("308")).toBe(308);
+    expect(parseStatus("404")).toBe(404);
+    expect(parseStatus("410")).toBe(410);
+    expect(parseStatus("451")).toBe(451);
+  });
+
+  it("rejects unsupported codes", () => {
+    expect(() => parseStatus("500")).toThrow("Unsupported");
+    expect(() => parseStatus("399")).toThrow("Unsupported");
+  });
+
+  it("rejects forced redirects", () => {
+    expect(() => parseStatus("301!")).toThrow("shadowing");
+  });
+});
+
+describe("isValidStatus", () => {
+  it("returns true for IPFS-valid status codes", () => {
+    expect(isValidStatus(200)).toBe(true);
+    expect(isValidStatus(301)).toBe(true);
+    expect(isValidStatus(302)).toBe(true);
+    expect(isValidStatus(303)).toBe(true);
+    expect(isValidStatus(307)).toBe(true);
+    expect(isValidStatus(308)).toBe(true);
+    expect(isValidStatus(404)).toBe(true);
+    expect(isValidStatus(410)).toBe(true);
+    expect(isValidStatus(451)).toBe(true);
+  });
+
+  it("returns false for unsupported status codes", () => {
+    expect(isValidStatus(500)).toBe(false);
+    expect(isValidStatus(201)).toBe(false);
+    expect(isValidStatus(400)).toBe(false);
+  });
+});
+
+describe("isAstroSupportedStatus", () => {
+  it("returns true for Astro-supported 3xx codes", () => {
+    expect(isAstroSupportedStatus(301)).toBe(true);
+    expect(isAstroSupportedStatus(302)).toBe(true);
+    expect(isAstroSupportedStatus(303)).toBe(true);
+    expect(isAstroSupportedStatus(307)).toBe(true);
+    expect(isAstroSupportedStatus(308)).toBe(true);
+  });
+
+  it("returns false for IPFS-only codes not supported by Astro", () => {
+    expect(isAstroSupportedStatus(200)).toBe(false);
+    expect(isAstroSupportedStatus(404)).toBe(false);
+    expect(isAstroSupportedStatus(410)).toBe(false);
+    expect(isAstroSupportedStatus(451)).toBe(false);
+  });
+});

--- a/libs/astro-redirects/src/parse.ts
+++ b/libs/astro-redirects/src/parse.ts
@@ -1,0 +1,113 @@
+import type { RedirectRule } from "./types.js";
+
+const MAX_FILE_SIZE_BYTES = 65536; // 64 KiB per IPFS spec
+
+/**
+ * Check if a status code is valid per the IPFS spec.
+ */
+export function isValidStatus(status: number): boolean {
+  return new Set([200, 301, 302, 303, 307, 308, 404, 410, 451]).has(status);
+}
+
+/**
+ * Check if a status code is supported by Astro's redirect config.
+ */
+export function isAstroSupportedStatus(status: number): boolean {
+  return new Set([301, 302, 303, 307, 308]).has(status);
+}
+
+/**
+ * Parse a _redirects file (Netlify / IPFS format).
+ *
+ * Each non-empty, non-comment line must match:
+ *   from to [status]
+ *
+ * @param input - Raw file content.
+ * @returns Parsed redirect rules.
+ */
+export function parseRedirects(input: string): RedirectRule[] {
+  const byteLength = new TextEncoder().encode(input).length;
+  if (byteLength > MAX_FILE_SIZE_BYTES) {
+    throw new Error(
+      `Redirects file size cannot exceed ${MAX_FILE_SIZE_BYTES} bytes (got ${byteLength})`
+    );
+  }
+
+  const rules: RedirectRule[] = [];
+  const lines = input.split(/\r?\n/);
+
+  for (const raw of lines) {
+    const line = raw.trim();
+
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+
+    const fields = line.split(/\s+/);
+
+    if (fields.length < 2) {
+      throw new Error(`Missing 'to' path in line: ${line}`);
+    }
+    if (fields.length > 3) {
+      throw new Error(
+        `Too many fields, expected 'from to [status]' in line: ${line}`
+      );
+    }
+
+    const from = parseFrom(fields[0]);
+    const to = parseTo(fields[1]);
+    const status = fields[2] ? parseStatus(fields[2]) : 301;
+
+    rules.push({ from, to, status });
+  }
+
+  return rules;
+}
+
+export function parseFrom(value: string): string {
+  const splats = value.split("*").length - 1;
+  if (splats > 0) {
+    if (splats > 1) {
+      throw new Error(`Path can have at most one asterisk: ${value}`);
+    }
+    if (!value.endsWith("*")) {
+      throw new Error(`Path with splat must end with asterisk: ${value}`);
+    }
+  }
+
+  if (!value.startsWith("/")) {
+    throw new Error(`Path must begin with '/': ${value}`);
+  }
+
+  return value;
+}
+
+export function parseTo(value: string): string {
+  if (value.startsWith("/")) {
+    return value;
+  }
+
+  // Allow absolute URLs with safelisted schemes (per IPFS spec)
+  const url = new URL(value);
+  const allowed = new Set(["http", "https", "ipfs", "ipns"]);
+  if (!allowed.has(url.protocol.slice(0, -1))) {
+    throw new Error(`Invalid URL scheme in 'to': ${value}`);
+  }
+
+  return value;
+}
+
+export function parseStatus(value: string): number {
+  if (value.endsWith("!")) {
+    throw new Error(
+      `Forced redirects (shadowing) are not supported: ${value}`
+    );
+  }
+
+  const code = Number(value);
+  if (!Number.isInteger(code) || !isValidStatus(code)) {
+    throw new Error(`Unsupported status code: ${value}`);
+  }
+
+  return code;
+}

--- a/libs/astro-redirects/src/types.ts
+++ b/libs/astro-redirects/src/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Represents a single redirect/rewrite rule.
+ * Matches the IPFS _redirects spec and Netlify format.
+ *
+ * Status codes:
+ * - 301, 302, 303, 307, 308: Supported by BOTH Astro and IPFS.
+ *   These are passed to Astro's redirect config AND emitted to _redirects file.
+ * - 200, 404, 410, 451: IPFS-only. Only emitted to _redirects file (when emitFile: true).
+ *   NOT passed to Astro's redirect config.
+ */
+export interface RedirectRule {
+  /** The path to match against. May include a trailing splat (*). */
+  from: string;
+  /** The destination path or URL. May include :splat placeholder. */
+  to: string;
+  /** HTTP status code. Defaults to 301. */
+  status: number;
+}
+
+/**
+ * Options for the Astro redirects integration.
+ */
+export interface RedirectsPluginOptions {
+  /**
+   * Enable parsing a `_redirects` file from the public directory.
+   * Set to `false` to disable, or a custom path string relative to project root.
+   * @default true
+   */
+  redirectsFile?: boolean | string;
+
+  /**
+   * Enable collecting `redirect_from` frontmatter from Markdown/MDX files.
+   * @default true
+   */
+  frontmatter?: boolean;
+
+  /**
+   * Additional static redirects merged with parsed ones.
+   * Values can be a simple destination string (implicit 301)
+   * or a {@link RedirectRule} object.
+   *
+   * Extra redirects have the highest priority and win over _redirects file
+   * and frontmatter rules when `from` paths conflict.
+   */
+  extra?: Record<string, string | RedirectRule>;
+
+  /**
+   * Also emit a `_redirects` text file to the build output directory.
+   * Useful for static hosts that consume the file at deploy time (e.g., IPFS).
+   * When true, ALL status codes (including 200/404/410/451) are preserved
+   * in the emitted file, even though Astro only handles 3xx redirects natively.
+   * @default false
+   */
+  emitFile?: boolean;
+
+  /**
+   * Directory to scan for Markdown/MDX frontmatter, relative to project root.
+   * @default 'src/pages'
+   */
+  contentDir?: string;
+
+  /**
+   * Custom function to derive a slug from a file path.
+   */
+  getSlug?: (filePath: string) => string;
+}

--- a/libs/astro-redirects/tsconfig.json
+++ b/libs/astro-redirects/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist/esm",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/astro-redirects/tsdown.config.ts
+++ b/libs/astro-redirects/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { createLibraryConfig } from "@lumeweb/tsdown-config";
+
+export default createLibraryConfig("./src/index.ts");

--- a/libs/astro-redirects/vitest.config.ts
+++ b/libs/astro-redirects/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,6 +932,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
 
+  libs/astro-redirects:
+    dependencies:
+      astro:
+        specifier: 'catalog:'
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(idb-keyval@6.2.6)(jiti@2.7.0)(rollup@4.60.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+    devDependencies:
+      '@lumeweb/tsdown-config':
+        specifier: workspace:*
+        version: link:../tsdown-config
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(@vitejs/devtools@0.1.22)(publint@0.3.21)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.5)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.0.16)
+
   libs/pinner:
     dependencies:
       '@helia/bitswap':
@@ -10736,6 +10761,10 @@ packages:
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -11136,6 +11165,10 @@ packages:
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   gtoken@6.1.2:
     resolution: {integrity: sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==}
@@ -11618,6 +11651,10 @@ packages:
 
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -12124,6 +12161,10 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -14504,6 +14545,10 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
@@ -14848,6 +14893,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -23737,7 +23786,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))':
+  '@vitejs/devtools-rolldown@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
@@ -23896,10 +23945,10 @@ snapshots:
       - vite
       - vue
 
-  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)':
+  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)(vite@8.0.16)
-      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
+      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
       devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(typescript@6.0.3)
@@ -23941,6 +23990,50 @@ snapshots:
     optional: true
 
   '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)':
+    dependencies:
+      '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
+      birpc: 4.0.0
+      cac: 7.0.0
+      devframe: 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)
+      h3: 1.15.11
+      logs-sdk: 0.0.6
+      mlly: 1.8.2
+      obug: 2.1.3
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.2.4
+      vite: 8.0.16(@types/node@26.1.0)(@vitejs/devtools@0.1.22)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vue: 3.5.39(typescript@6.0.3)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@pnpm/logger'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - idb-keyval
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+    optional: true
+
+  '@vitejs/devtools@0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(typescript@6.0.3)(vite@8.0.16)
       '@vitejs/devtools-rolldown': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)(vue@3.5.39(typescript@6.0.3))
@@ -26702,6 +26795,10 @@ snapshots:
     dependencies:
       type: 2.7.3
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
 
   fake-indexeddb@6.2.5: {}
@@ -27119,6 +27216,13 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   gtoken@6.1.2:
     dependencies:
@@ -27866,6 +27970,8 @@ snapshots:
 
   is-electron@2.2.2: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -28437,6 +28543,8 @@ snapshots:
 
   khroma@2.1.0:
     optional: true
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -31557,6 +31665,11 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
@@ -32016,6 +32129,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 
@@ -33007,7 +33122,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.0
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
@@ -33026,7 +33141,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.0
-      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(idb-keyval@6.2.6)(typescript@6.0.3)(vite@8.0.16)
+      '@vitejs/devtools': 0.1.22(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.16)
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0


### PR DESCRIPTION
## Summary

Astro integration that generates redirects from `_redirects` files, Markdown frontmatter, and programmatic config. Compatible with the IPFS Web Redirects File spec and inspired by `astro-redirect-from`.

## Features

- Parse `_redirects` files (Netlify/IPFS spec):
  - Splats (`*`), placeholders (`:id`)
  - Status codes: 200, 301-308, 404, 410, 451
  - 64 KiB file size limit
- Extract `redirect_from` from Markdown/MDX frontmatter via gray-matter
- Skip `draft: true` posts in production builds
- Optional `emitFile` to output `_redirects` text for static hosts
- Extra static redirects via config

## Usage

```ts
import redirects from '@lumeweb/astro-redirects';

export default defineConfig({
  integrations: [
    redirects({
      redirectsFile: true,
      frontmatter: true,
      emitFile: true,
      extra: { '/old': '/new' },
    }),
  ],
});
```

## Package

- `libs/astro-redirects/` — new workspace package
- `private: true` for now until ready to publish
- 100% test coverage (25 tests)

## Files Changed

- `libs/astro-redirects/*` — new package (12 files)
- `pnpm-lock.yaml` — gray-matter + deps

---

<!-- kody-pr-summary:start -->
 This pull request introduces a new `@lumeweb/astro-redirects` Astro integration library that centralizes redirect management for Astro-based projects.

The integration collects redirect rules from three sources:
1. `_redirects` files (Netlify/IPFS Web Redirects format) located in the public directory or a custom path
2. `redirect_from` frontmatter in Markdown/MDX content files under `src/pages`
3. Additional static or dynamic redirects supplied via plugin configuration

Supported capabilities include splat patterns (`*`), dynamic placeholders, common HTTP status codes (200, 301–308, 404, 410, 451), and absolute destination URLs with allowed schemes (`http`, `https`, `ipfs`, `ipns`).

The integration registers valid 3xx redirects with Astro's built-in redirect config and can optionally emit a `_redirects` text file into the build output for deployment to static hosts. Draft content is excluded from production builds.

The change adds the full library source, unit tests, build configuration, documentation, and updates the lockfile with the new package dependencies.
<!-- kody-pr-summary:end -->