### PR TITLE
fix(pinner.xyz): remove incorrect usage-based pricing claim from comparison table

### DIFF
--- a/apps/pinner.xyz/src/pages/host.astro
+++ b/apps/pinner.xyz/src/pages/host.astro
@@ -358,13 +358,6 @@ import { config, examples } from "@/lib/config";
                 <td class="text-center py-4 px-4">No</td>
                 <td class="text-center py-4 px-4">Annual only</td>
               </tr>
-              <tr>
-                <td class="py-4 px-4">Usage-based, no tiers</td>
-                <td class="text-center py-4 px-4 text-orange-400 font-medium">Yes</td>
-                <td class="text-center py-4 px-4">No</td>
-                <td class="text-center py-4 px-4">No</td>
-                <td class="text-center py-4 px-4">No</td>
-              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary

The host page comparison table included a row claiming "Usage-based, no tiers" with Pinner marked as Yes. This was inaccurate. Pinner is subscription-based by default.

## Changes

- Removed the "Usage-based, no tiers" row from the host page comparison table in `host.astro`