### PR TITLE
fix(pinner.xyz): fix ENS example domain and revise Pinata comparison copy

### DIFF
--- a/apps/pinner.xyz/src/components/Home/EnsHero.tsx
+++ b/apps/pinner.xyz/src/components/Home/EnsHero.tsx
@@ -28,7 +28,7 @@ const EnsHero = () => {
         trackEvent: "ens_hero_secondary_clicked",
       }}
       trustLine="Contenthash output · IPNS updates · Cancel anytime"
-      visualContent={<HostServerGrid />}
+      visualContent={<HostServerGrid domain="my-site.eth" />}
       showCLIInstall
     />
   );

--- a/apps/pinner.xyz/src/components/Home/HostServerGrid.tsx
+++ b/apps/pinner.xyz/src/components/Home/HostServerGrid.tsx
@@ -1,7 +1,7 @@
 import { Globe, Server, Loader2 } from "lucide-react";
 import { useNodeGrid } from "./useNodeGrid";
 
-export default function HostServerGrid() {
+export default function HostServerGrid({ domain = "my-site.com" }: { domain?: string }) {
   const { nodes, loading: browserLoading, packetPaths, activeCount, totalCount } = useNodeGrid();
 
   return (
@@ -35,7 +35,7 @@ export default function HostServerGrid() {
             )}
           </div>
           <div>
-            <p className="text-white text-sm font-medium">my-site.com</p>
+            <p className="text-white text-sm font-medium">{domain}</p>
             <p className="text-home-text-muted text-xs">
               {activeCount} of {totalCount} providers active
             </p>

--- a/apps/pinner.xyz/src/pages/ens.astro
+++ b/apps/pinner.xyz/src/pages/ens.astro
@@ -46,9 +46,9 @@ import { config, examples } from "@/lib/config";
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-amber-400"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
             </div>
             <div>
-              <h3 class="text-white text-lg font-medium mb-2">Pinata's pricing wall</h3>
+              <h3 class="text-white text-lg font-medium mb-2">Scaling on a centralized pinning service</h3>
               <p class="text-home-text-muted text-base leading-relaxed">
-                Pinata is the biggest IPFS host. Their free tier covers almost nothing. The jump to paid is 20 USD/month minimum. For a static site. That's 240 USD/year for a hobby project.
+                Pinata's free tier handles small projects. When your site grows past 1GB of storage or 10GB of monthly bandwidth, the next plan is 20 USD/month. If you outgrow that, costs scale from there.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

The ENS funnel page showed `my-site.com` in the server grid animation instead of a `.eth` domain. The Pinata comparison section used inaccurate framing about their pricing.

## Changes

- Added `domain` prop to `HostServerGrid` component, defaulting to `my-site.com`
- `EnsHero` passes `my-site.eth` so the ENS page shows the correct domain
- Rewrote the Pinata agitation section on `ens.astro` with factual pricing details (1GB storage, 10GB bandwidth on free tier; $20/month paid tier) instead of the previous framing

---

<!-- kody-pr-summary:start -->
 This PR updates the ENS example domain shown in the pinner.xyz hero and rewrites the Pinata comparison copy on the ENS page.

Changes:
- `EnsHero` now passes `domain="my-site.eth"` to `HostServerGrid`, so the visual grid displays an ENS domain instead of the default `.com` example.
- `HostServerGrid` now accepts an optional `domain` prop (defaulting to `"my-site.com"`) and uses it for the displayed domain label.
- The ENS page's Pinata comparison heading and body copy have been rewritten from a critical framing ("Pinata's pricing wall") to a neutral, scaling-focused explanation of centralized pinning service costs.
<!-- kody-pr-summary:end -->