### PR TITLE
fix(pinner.xyz): re-enable newsletter and contact pathways across all pages

### DIFF
--- a/apps/pinner.xyz/src/components/Home/BottomCTA.tsx
+++ b/apps/pinner.xyz/src/components/Home/BottomCTA.tsx
@@ -35,6 +35,24 @@ const BottomCTA = ({ className }: BottomCTAProps) => {
               trackEvent="bottom_cta_pin_clicked"
             />
           </div>
+
+          <p className="text-home-text-muted/60 text-sm mt-8">
+            Building on Sia? Need volume storage?{" "}
+            <a
+              href="/partners"
+              className="text-home-accent underline hover:opacity-80"
+            >
+              See our partnerships
+            </a>{" "}
+            or{" "}
+            <a
+              href="/contact"
+              className="text-home-accent underline hover:opacity-80"
+            >
+              get in touch
+            </a>
+            .
+          </p>
         </div>
       </div>
     </section>

--- a/apps/pinner.xyz/src/pages/ens.astro
+++ b/apps/pinner.xyz/src/pages/ens.astro
@@ -13,7 +13,6 @@ import { config, examples } from "@/lib/config";
   description="Point your ENS name at content hosted on the Sia network. Two commands: upload and point. The CLI gives you the exact contenthash."
   variant="home"
   ogImage="/images/og/ens.png"
-  showNewsletterFooter={false}
 >
   {/* Section 1: Hero */}
   <EnsHero client:load />

--- a/apps/pinner.xyz/src/pages/host.astro
+++ b/apps/pinner.xyz/src/pages/host.astro
@@ -14,7 +14,6 @@ import { config, examples } from "@/lib/config";
   description="Host static sites on distributed storage. Your files copied across independent providers, not one company's servers. Harder to take down."
   variant="home"
   ogImage="/images/og/host.png"
-  showNewsletterFooter={false}
 >
   {/* Section 1: Hero */}
   <HostHero client:load />

--- a/apps/pinner.xyz/src/pages/index.astro
+++ b/apps/pinner.xyz/src/pages/index.astro
@@ -11,7 +11,6 @@ import logos from "@/data/brand-logos";
   title="Storage and Hosting Where You're in Control | Pinner"
   description="Your data. Your rules. Decentralized hosting and storage that doesn't depend on one company."
   variant="home"
-  showNewsletterFooter={false}
 >
   <Hero client:load />
   <BrandLogos

--- a/apps/pinner.xyz/src/pages/pin.astro
+++ b/apps/pinner.xyz/src/pages/pin.astro
@@ -14,7 +14,6 @@ import { config, examples } from "@/lib/config";
   description="IPFS pinning backed by verifiable storage on the Sia network. Upload a file, get a CID. Hosts prove they're holding your data or they don't get paid."
   variant="home"
   ogImage="/images/og/pin.png"
-  showNewsletterFooter={false}
 >
   {/* Section 1: Hero */}
   <PinHero client:load />


### PR DESCRIPTION
## Summary

Newsletter signup, contact, and partnership pathways were disabled
during the funnel page refactor. This restores them.

## Changes

- Re-enabled newsletter footer on homepage, /host, /pin, and /ens
  (removed `showNewsletterFooter={false}`)
- Added contact and partnership links to the homepage BottomCTA so
  visitors have a clear pathway to /partners and /contact without
  relying on the footer alone
- Contact and partners pages were verified intact: HeyForm embeds,
  Discord/GitHub sections, and AboutSection components all render
  correctly

## Files changed

- `BottomCTA.tsx` — added /partners and /contact links below CTA buttons
- `index.astro` — re-enabled newsletter footer
- `host.astro` — re-enabled newsletter footer
- `pin.astro` — re-enabled newsletter footer
- `ens.astro` — re-enabled newsletter footer

---

<!-- kody-pr-summary:start -->
 This PR re-enables the newsletter signup footer across all main pinner.xyz pages and restores contact/partnership pathways for users interested in volume storage or Sia-based solutions.

**Changes:**
- Re-enables the newsletter footer on the Home, Pin, Host, and ENS pages by removing the `showNewsletterFooter={false}` override.
- Adds a new call-to-action in the BottomCTA section that directs users building on Sia or needing volume storage to the partnerships page or contact page.
<!-- kody-pr-summary:end -->