### PR TITLE
fix(lbry-sdk): remove tsx config-loader, add .ts extension to import

### DIFF
--- a/libs/lbry-sdk/package.json
+++ b/libs/lbry-sdk/package.json
@@ -48,7 +48,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsdown --config-loader tsx",
+    "build": "tsdown",
     "build:wasm": "cd wasm/go && tinygo build -o ../../src/wasm/lbry-sdk.wasm -target wasm -no-debug .",
     "generate": "cd wasm/go/tools/gencontract && go run . -exports ../../exports -outdir ../../../src/wasm",
     "dev": "tsdown --watch",

--- a/libs/lbry-sdk/tsdown.config.ts
+++ b/libs/lbry-sdk/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsdown";
 import { createLibraryConfig } from "@lumeweb/tsdown-config";
-import { goWasm } from "./src/rollup-plugin-go-wasm";
+import { goWasm } from "./src/rollup-plugin-go-wasm.ts";
 
 export default defineConfig(
   createLibraryConfig(


### PR DESCRIPTION
## Summary

Fixes the `pnpm build` failure in `libs/lbry-sdk` caused by `tsx@4.23.0` `node:fs` protocol bug.

### Changes
- Removed `--config-loader tsx` from the build script — `tsdown` 0.22.3's native loader handles the config without it
- Added `.ts` extension to the `rollup-plugin-go-wasm` import in `tsdown.config.ts` so the native loader can resolve it

### Root Cause
`tsx@4.23.0` has a bug: `ENOENT: no such file or directory, open 'node:fs?tsx-namespace=...'`. The `--config-loader tsx` flag was only needed because the import path lacked an explicit `.ts` extension, which tsdown's native ESM loader requires.

### Verification
```sh
cd libs/lbry-sdk && pnpm build
```
Config loads successfully; build proceeds to the TinyGo WASM step (fails only if TinyGo is not on PATH, which is expected on machines without it installed).