### PR TITLE
fix(lbry-sdk): remove dead wasm-exec export and fix tsdown config loading

### DIFF
--- a/libs/lbry-sdk/package.json
+++ b/libs/lbry-sdk/package.json
@@ -41,14 +41,10 @@
       "types": "./dist/esm/guardrails/index.d.ts",
       "import": "./dist/esm/guardrails/index.js"
     },
-    "./wasm-exec": {
-      "types": "./dist/esm/wasm/wasm-exec.d.ts",
-      "import": "./dist/esm/wasm/wasm-exec.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsdown --config-loader tsx",
+    "build": "tsdown",
     "build:wasm": "cd wasm/go && tinygo build -o ../../src/wasm/lbry-sdk.wasm -target wasm -no-debug .",
     "generate": "cd wasm/go/tools/gencontract && go run . -exports ../../exports -outdir ../../../src/wasm",
     "dev": "tsdown --watch",

--- a/libs/lbry-sdk/tsdown.config.ts
+++ b/libs/lbry-sdk/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsdown";
 import { createLibraryConfig } from "@lumeweb/tsdown-config";
-import { goWasm } from "./src/rollup-plugin-go-wasm";
+import { goWasm } from "./src/rollup-plugin-go-wasm.ts";
 
 export default defineConfig(
   createLibraryConfig(


### PR DESCRIPTION
## Summary

Three fixes to `libs/lbry-sdk` package configuration:

### 1. Remove dead `./wasm-exec` export
The `./wasm-exec` export pointed to `dist/esm/wasm/wasm-exec.js` — a file that never exists. The `rollup-plugin-go-wasm` plugin bundles `wasm_exec.js` inline as a virtual module (no-treeshake), so no separate entry in the exports map is needed. Nothing in the codebase imports `@lumeweb/lbry-sdk/wasm-exec`.

### 2. Remove `--config-loader tsx`
`tsx@4.23.0` has a `node:fs` protocol bug: `ENOENT: no such file or directory, open 'node:fs?tsx-namespace=...'`. The tsdown native loader handles the config without it.

### 3. Add `.ts` extension to config import
`import { goWasm } from "./src/rollup-plugin-go-wasm.ts"` — tsdown's native ESM loader requires explicit extensions for resolution.

### `files[]` stays clean
```json
"files": ["dist", "package.json"]
```
The `.wasm` binary is emitted to `dist/` by Rollup's `emitFile()` in the go-wasm plugin. No `src/` files need to ship.

### Verification
```sh
cd libs/lbry-sdk && pnpm build
# Config loads ✓, build proceeds to TinyGo step (fails only if tinygo not on PATH)
```

---

<!-- kody-pr-summary:start -->
 This PR fixes module resolution in the `libs/lbry-sdk` tsdown configuration.

## Changes
- Updated the import in `tsdown.config.ts` to include the `.ts` extension for the local `rollup-plugin-go-wasm` module.

## Impact
- Ensures tsdown can correctly resolve and load the custom Go WASM rollup plugin, resolving configuration-loading issues caused by the missing explicit file extension.
<!-- kody-pr-summary:end -->