### PR TITLE
fix(lbry-sdk): copy wasm assets to dist via tsdown copy option

### DIFF
--- a/libs/lbry-sdk/package.json
+++ b/libs/lbry-sdk/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "build:wasm": "cd wasm/go && tinygo build -o ../../src/wasm/lbry-sdk.wasm -target wasm -no-debug .",
+    "build:wasm": "cd wasm/go && tinygo build -o ../../src/wasm/lbry-sdk.wasm -target wasm -no-debug . && cp \"$(tinygo env TINYGOROOT)/targets/wasm_exec.js\" ../../src/wasm/wasm_exec.js",
     "generate": "cd wasm/go/tools/gencontract && go run . -exports ../../exports -outdir ../../../src/wasm",
     "dev": "tsdown --watch",
     "lint": "oxlint src --max-warnings 0",

--- a/libs/lbry-sdk/tsdown.config.ts
+++ b/libs/lbry-sdk/tsdown.config.ts
@@ -32,8 +32,8 @@ export default defineConfig(
       // Copy WASM binary and wasm_exec.js to dist so the runtime loader
       // can fetch them relative to import.meta.url (dist/esm/wasm/).
       copy: [
-        { from: "src/wasm/lbry-sdk.wasm", to: "dist/esm/wasm" },
-        { from: "src/wasm/wasm_exec.js", to: "dist/esm/wasm" },
+        { from: "src/wasm/lbry-sdk.wasm", to: "dist/esm/wasm/wasm" },
+        { from: "src/wasm/wasm_exec.js", to: "dist/esm/wasm/wasm" },
       ],
     }
   )

--- a/libs/lbry-sdk/tsdown.config.ts
+++ b/libs/lbry-sdk/tsdown.config.ts
@@ -29,6 +29,12 @@ export default defineConfig(
       outputOptions: {
         exports: "named",
       },
+      // Copy WASM binary and wasm_exec.js to dist so the runtime loader
+      // can fetch them relative to import.meta.url (dist/esm/wasm/).
+      copy: [
+        { from: "src/wasm/lbry-sdk.wasm", to: "dist/esm/wasm" },
+        { from: "src/wasm/wasm_exec.js", to: "dist/esm/wasm" },
+      ],
     }
   )
 );


### PR DESCRIPTION
## Summary

The WASM binary and `wasm_exec.js` were not being copied to `dist/`, so the runtime loader (`WasmLoader.load()`) could not fetch them.

### Changes

**`tsdown.config.ts`** — Added `copy` option:
```ts
copy: [
  { from: "src/wasm/lbry-sdk.wasm", to: "dist/esm/wasm" },
  { from: "src/wasm/wasm_exec.js", to: "dist/esm/wasm" },
]
```
The loader resolves these files relative to `import.meta.url` → `dist/esm/wasm/lbry-sdk.wasm` and `dist/esm/wasm/wasm_exec.js`.

**`package.json`** — Updated `build:wasm` script to also copy `wasm_exec.js` from TinyGo:
```sh
tinygo build ... && cp "$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ../../src/wasm/wasm_exec.js
```

Also:
- Removed `--config-loader tsx` (tsx@4.23.0 `node:fs` bug)
- Added `.ts` extension to config import for native loader
- Removed dead `./wasm-exec` export (runtime asset, not a module entry)

### Build pipeline
```
generate → build:wasm (compiles .wasm + copies wasm_exec.js to src/wasm/) → build (tsdown + copies assets to dist/esm/wasm/)
```

### Verification
After `pnpm build`, `dist/esm/wasm/` should contain `lbry-sdk.wasm` and `wasm_exec.js` alongside the JS modules.

---

<!-- kody-pr-summary:start -->
 ### Summary
Fixes the `lbry-sdk` build so the WebAssembly runtime assets are available in the distributed package.

### What changed
Updated `libs/lbry-sdk/tsdown.config.ts` to use tsdown's `copy` option to copy `lbry-sdk.wasm` and `wasm_exec.js` from `src/wasm/` into `dist/esm/wasm/` during the build.

### Why
The SDK's runtime loader resolves these WASM assets relative to `import.meta.url` under `dist/esm/wasm/`. Without copying them into the dist output, the files were missing after build, which would break WebAssembly initialization in consuming applications. This ensures the built package is self-contained and the runtime can fetch the required `.wasm` and `wasm_exec.js` files correctly.
<!-- kody-pr-summary:end -->