### PR TITLE
fix(lbry-sdk): flatten wasm asset path — no nested wasm/wasm/

### DIFF
--- a/libs/lbry-sdk/src/wasm/loader.ts
+++ b/libs/lbry-sdk/src/wasm/loader.ts
@@ -37,7 +37,7 @@ export interface WasmLoaderOptions {
 
 const DEFAULT_WASM_BASE =
   typeof import.meta !== "undefined" && import.meta.url
-    ? new URL("./wasm/", import.meta.url).href
+    ? new URL("./", import.meta.url).href
     : "/lbry-sdk/wasm/";
 
 const DEFAULT_WASM_URL = new URL("lbry-sdk.wasm", DEFAULT_WASM_BASE).href;

--- a/libs/lbry-sdk/tsdown.config.ts
+++ b/libs/lbry-sdk/tsdown.config.ts
@@ -32,8 +32,8 @@ export default defineConfig(
       // Copy WASM binary and wasm_exec.js to dist so the runtime loader
       // can fetch them relative to import.meta.url (dist/esm/wasm/).
       copy: [
-        { from: "src/wasm/lbry-sdk.wasm", to: "dist/esm/wasm/wasm" },
-        { from: "src/wasm/wasm_exec.js", to: "dist/esm/wasm/wasm" },
+        { from: "src/wasm/lbry-sdk.wasm", to: "dist/esm/wasm" },
+        { from: "src/wasm/wasm_exec.js", to: "dist/esm/wasm" },
       ],
     }
   )


### PR DESCRIPTION
## Summary

PR #1133 introduced a nested `wasm/wasm/` directory in dist because `WasmLoader` resolved assets via `new URL("./wasm/", import.meta.url)` from `dist/esm/wasm/loader.js`, producing `dist/esm/wasm/wasm/`.

This PR flattens it:

**`src/wasm/loader.ts`** — Changed `DEFAULT_WASM_BASE` from `new URL("./wasm/", import.meta.url)` to `new URL("./", import.meta.url)`, so assets resolve from the same directory as `loader.js`.

**`tsdown.config.ts`** — Changed copy destination from `dist/esm/wasm/wasm` to `dist/esm/wasm`.

### Result
```
dist/esm/wasm/
├── loader.js
├── index.js
├── lbry-sdk.wasm      ← was in wasm/wasm/
├── wasm_exec.js       ← was in wasm/wasm/
└── ...
```

---

<!-- kody-pr-summary:start -->
 **Fix WASM asset path resolution so the loader and build output point to the same directory.**

This change removes the redundant `wasm/wasm` nesting for the LBRY SDK WebAssembly assets.

- **Build output:** `lbry-sdk.wasm` and `wasm_exec.js` are now copied to `dist/esm/wasm/` instead of `dist/esm/wasm/wasm/`.
- **Runtime resolution:** `DEFAULT_WASM_BASE` now resolves assets relative to the current module directory (`./`) rather than a nested `./wasm/` directory.

As a result, the WASM loader locates `lbry-sdk.wasm` and `wasm_exec.js` in the same `wasm/` folder they are emitted to, preventing broken asset loading caused by the extra `/wasm` path segment. The fallback base path `/lbry-sdk/wasm/` remains unchanged and now aligns with the flattened output layout.
<!-- kody-pr-summary:end -->