### PR TITLE
chore(lbry-sdk): lower version to 0.0.0 for initial release

### DIFF
--- a/libs/lbry-sdk/package.json
+++ b/libs/lbry-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumeweb/lbry-sdk",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
Lower `@lumeweb/lbry-sdk` version from `0.1.0` to `0.0.0` so the first release publishes correctly.