### PR TITLE
chore: add @lumeweb/lbry-sdk to knope config

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -21,6 +21,10 @@ changelog = "apps/lumeweb.com/CHANGELOG.md"
 versioned_files = ["libs/pinner/package.json"]
 changelog = "libs/pinner/CHANGELOG.md"
 
+[packages."@lumeweb/lbry-sdk"]
+versioned_files = ["libs/lbry-sdk/package.json"]
+changelog = "libs/lbry-sdk/CHANGELOG.md"
+
 [packages."@lumeweb/portal-app-shell"]
 versioned_files = ["apps/portal-app-shell/package.json"]
 changelog = "apps/portal-app-shell/CHANGELOG.md"


### PR DESCRIPTION
Add `@lumeweb/lbry-sdk` package entry to `knope.toml` with `versioned_files` and `changelog` paths so knope can manage releases for the SDK.

---

<!-- kody-pr-summary:start -->
 This PR adds the `@lumeweb/lbry-sdk` package to `knope.toml`, configuring it for automated versioning and changelog management.

- Registers `libs/lbry-sdk/package.json` as the versioned file.
- Registers `libs/lbry-sdk/CHANGELOG.md` as the changelog file.

This enables Knope to track version bumps and generate changelogs for the new `lbry-sdk` library alongside the existing packages.
<!-- kody-pr-summary:end -->