### PR TITLE
fix(ci): add Go, TinyGo setup to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           echo "TINYGOROOT=$(dirname $(dirname $(which tinygo)))" >> "$GITHUB_ENV"
           echo "TINYGOPATH=$(which tinygo)" >> "$GITHUB_ENV"
+          echo "$(dirname $(which tinygo))" >> "$GITHUB_PATH"
       - name: Generate contract types
         run: pnpm --filter=@lumeweb/lbry-sdk generate
       - name: Install pinner-cli


### PR DESCRIPTION
## Summary

The Release workflow (`release.yml`) runs `pnpm build` which triggers `build:wasm` via turbo, but was missing:
- Go setup (`actions/setup-go`)
- TinyGo setup (`acifani/setup-tinygo`)
- TinyGo env vars (`TINYGOROOT`, `TINYGOPATH`)
- Contract type generation (`pnpm --filter=@lumeweb/lbry-sdk generate`)

These steps exist in `build.yml` but were never copied to `release.yml`, causing `sh: 1: tinygo: not found` during release builds.

### Changes
Added the same Go + TinyGo + generate steps from `build.yml` to `release.yml` before the `pnpm build` step.