### PR TITLE
fix(ci): add Go, TinyGo setup to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,24 @@ jobs:
       - name: Setup JS
         uses: LumeWeb/workflows/.github/actions/setup-js@develop
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Setup TinyGo
+        uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: "0.36.0"
+
+      - name: Set TinyGo env
+        run: |
+          echo "TINYGOROOT=$(dirname $(dirname $(which tinygo)))" >> "$GITHUB_ENV"
+          echo "TINYGOPATH=$(which tinygo)" >> "$GITHUB_ENV"
+
+      - name: Generate contract types
+        run: pnpm --filter=@lumeweb/lbry-sdk generate
+
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
The Release workflow (`release.yml`) runs `pnpm build` which triggers `build:wasm` via turbo, but was missing Go/TinyGo setup and contract type generation. These steps exist in `build.yml` but were never copied to `release.yml`, causing `sh: 1: tinygo: not found` during release builds.

Added:
- `actions/setup-go@v5` (Go 1.24)
- `acifani/setup-tinygo@v2` (TinyGo 0.36.0)
- TinyGo env vars (`TINYGOROOT`, `TINYGOPATH`)
- Contract type generation (`pnpm --filter=@lumeweb/lbry-sdk generate`)

---

<!-- kody-pr-summary:start -->
 **What changed**
Updated the release workflow (`.github/workflows/release.yml`) so the release job can build the parts of the project that depend on Go/TinyGo:

- Added a step to install **Go 1.24**.
- Added a step to install **TinyGo 0.36.0**.
- Added environment variables for `TINYGOROOT` and `TINYGOPATH`.
- Added a step to generate contract types with `pnpm --filter=@lumeweb/lbry-sdk generate` **before** the main build step.

**Why**
The release build requires TinyGo-based generation to run, but the workflow was missing the Go/TinyGo toolchain setup. This change ensures the release job can fully build and publish the project.
<!-- kody-pr-summary:end -->