### PR TITLE
fix(lbry-sdk): remove duplicate wasm files from npm package

### DIFF
--- a/libs/lbry-sdk/package.json
+++ b/libs/lbry-sdk/package.json
@@ -2,12 +2,7 @@
   "name": "@lumeweb/lbry-sdk",
   "version": "0.0.1",
   "type": "module",
-  "files": [
-    "dist",
-    "src/wasm/lbry-sdk.wasm",
-    "src/wasm/wasm_exec.js",
-    "package.json"
-  ],
+  "files": ["dist", "package.json"],
   "main": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Problem

`package.json` `files[]` included `src/wasm/lbry-sdk.wasm` and `src/wasm/wasm_exec.js` separately. But tsdown's `copy` option already places them in `dist/esm/wasm/`. This caused the WASM binary and `wasm_exec.js` to be published twice — once in `src/wasm/` and once in `dist/esm/wasm/`.

## Fix

Remove the individual `src/wasm/` entries from `files[]`, keeping only `["dist", "package.json"]`. The WASM assets are already in `dist/` via the tsdown `copy` config.